### PR TITLE
[GH-build] Consider target-files in deps-caching and set build timeout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 40
     steps:
     - uses: actions/checkout@v3
       with:
@@ -27,7 +28,14 @@ jobs:
       with:
         java-version: '17'
         distribution: 'temurin'
-        cache: maven
+    - name: Cache local Maven repository
+      uses: actions/cache@v3
+      with:
+        path: ~/.m2/repository
+        # re-cache on changes in the pom and target files
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml', '**/*.target') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
     - name: Build with Maven
       uses: GabrielBB/xvfb-action@v1
       with:


### PR DESCRIPTION
The dependencies stored in the .m2 folder not only depend on the content of pom.xml files but also on the content of *.target-files. Therefore the latter should be considered when computing cache-hash.

An enhancement of the `setup-java` action to simplify the setup was already requested https://github.com/actions/setup-java/issues/345