### PR TITLE
Add OSGi-service bundles to features 

### DIFF
--- a/features/org.eclipse.equinox.compendium.sdk/forceQualifierUpdate.txt
+++ b/features/org.eclipse.equinox.compendium.sdk/forceQualifierUpdate.txt
@@ -8,3 +8,4 @@ Bug 514338 - Update felix SCR to 2.0.12
 Bug 529719 - Update felix SCR to 2.0.14
 Touch feature for I20180903-0800 failure due to new felix.scr qualifier.
 Bug 544571 - Update felix SCR to 2.0.16
+Update Felix SCR to 2.2.0 - (https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/282)

--- a/features/org.eclipse.equinox.core.feature/feature.xml
+++ b/features/org.eclipse.equinox.core.feature/feature.xml
@@ -142,4 +142,67 @@
          version="0.0.0"
          unpack="false"/>
 
+   <plugin
+         id="org.osgi.service.cm"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.osgi.service.component"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.osgi.service.device"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.osgi.service.event"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.osgi.service.metatype"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.osgi.service.provisioning"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.osgi.service.upnp"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.osgi.service.useradmin"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.osgi.service.wireadmin"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
 </feature>

--- a/features/org.eclipse.equinox.server.core/feature.xml
+++ b/features/org.eclipse.equinox.server.core/feature.xml
@@ -121,4 +121,67 @@
          version="0.0.0"
          unpack="false"/>
 
+   <plugin
+         id="org.osgi.service.cm"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.osgi.service.component"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.osgi.service.device"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.osgi.service.event"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.osgi.service.metatype"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.osgi.service.provisioning"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.osgi.service.upnp"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.osgi.service.useradmin"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.osgi.service.wireadmin"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
 </feature>


### PR DESCRIPTION
_This PR was originally created as https://github.com/eclipse-equinox/equinox.bundles/pull/29 and is now moved to this repository due to the merge of the equinox.framework and equinox.bundles repository._

---

This PR adds the OSGi-bundles that replace the formerly embedded OSGi source-code in `org.eclipse.osgi.service` to those Features that contain the `org.eclipse.osgi.service` plugin.
The motivation to add the OSGi-bundles to the features is mainly to also have their sources included into the p2-repos of the Eclipse-SDK.

This is part of https://github.com/eclipse-equinox/equinox/issues/18 and should be submitted after https://github.com/eclipse-equinox/equinox/pull/30 is merged.