### PR TITLE
Update moditect-maven-plugin to 1.0.0.RC2

### DIFF
--- a/bundles/org.eclipse.osgi/pom.xml
+++ b/bundles/org.eclipse.osgi/pom.xml
@@ -37,7 +37,7 @@
       <plugin>
         <groupId>org.moditect</groupId>
         <artifactId>moditect-maven-plugin</artifactId>
-        <version>1.0.0.RC1</version>
+        <version>1.0.0.RC2</version>
         <executions>
           <execution>
             <id>add-module-infos</id>


### PR DESCRIPTION
Provoked by https://github.com/eclipse-equinox/equinox/issues/27 so
build uses the latest plugin version.