### PR TITLE
Use BND to generate the JPMS info automatically

### DIFF
--- a/bundles/org.eclipse.osgi/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.osgi/META-INF/MANIFEST.MF
@@ -98,14 +98,16 @@ Provide-Capability: osgi.service; objectClass:List<String>="org.osgi.service.log
  osgi.service; objectClass:List<String>="org.eclipse.osgi.service.localization.BundleLocalization"; uses:="org.eclipse.osgi.service.localization",
  osgi.service; objectClass:List<String>="org.eclipse.osgi.service.security.TrustEngine"; uses:="org.eclipse.osgi.service.security",
  osgi.service; objectClass:List<String>="org.eclipse.osgi.signedcontent.SignedContentFactory"; uses:="org.eclipse.osgi.signedcontent",
- osgi.service; objectClass:List<String>="org.osgi.service.condition.Condition"; osgi.condition.id="true"; uses:="org.osgi.service.condition"
+ osgi.service; objectClass:List<String>="org.osgi.service.condition.Condition"; osgi.condition.id="true"; uses:="org.osgi.service.condition",
+ osgi.serviceloader;osgi.serviceloader="org.osgi.framework.connect.ConnectFrameworkFactory";register:="org.eclipse.osgi.launch.EquinoxFactory",
+ osgi.serviceloader;osgi.serviceloader="org.osgi.framework.launch.FrameworkFactory";register:="org.eclipse.osgi.launch.EquinoxFactory"
 Bundle-Name: %systemBundle
 Bundle-SymbolicName: org.eclipse.osgi; singleton:=true
 Bundle-Activator: org.eclipse.osgi.internal.framework.SystemBundleActivator
 Bundle-Description: %systemBundle
 Bundle-Copyright: %copyright
 Bundle-Vendor: %eclipse.org
-Bundle-Version: 3.18.0.qualifier
+Bundle-Version: 3.18.100.qualifier
 Bundle-Localization: systembundle
 Bundle-DocUrl: http://www.eclipse.org
 Eclipse-ExtensibleAPI: true

--- a/bundles/org.eclipse.osgi/bnd.bnd
+++ b/bundles/org.eclipse.osgi/bnd.bnd
@@ -1,0 +1,2 @@
+-jpms-module-info: ${project.artifactId};access='OPEN'
+-jpms-module-info-options: java.management;ignore="true"

--- a/bundles/org.eclipse.osgi/pom.xml
+++ b/bundles/org.eclipse.osgi/pom.xml
@@ -19,7 +19,7 @@
 </parent>
   <groupId>org.eclipse.osgi</groupId>
   <artifactId>org.eclipse.osgi</artifactId>
-  <version>3.18.0-SNAPSHOT</version>
+  <version>3.18.100-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <build>
@@ -35,78 +35,18 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.moditect</groupId>
-        <artifactId>moditect-maven-plugin</artifactId>
-        <version>1.0.0.RC2</version>
+       <!--Unless next tycho release we need to explicitly enable this here, once 2.7.4 or 3.x is out we can switch to full pomless here! -->
+       <groupId>biz.aQute.bnd</groupId>
+        <artifactId>bnd-maven-plugin</artifactId>
         <executions>
           <execution>
-            <id>add-module-infos</id>
-            <phase>package</phase>
+            <id>bnd-process</id>
             <goals>
-                <goal>add-module-info</goal>
+              <goal>bnd-process</goal>
             </goals>
             <configuration>
-                <module>
-                  <moduleInfoSource>
-open module org.eclipse.osgi {
-	requires java.xml;
-	requires static jdk.unsupported;
-
-	exports org.eclipse.equinox.log;
-	exports org.eclipse.osgi.container;
-	exports org.eclipse.osgi.container.builders;
-	exports org.eclipse.osgi.container.namespaces;
-	exports org.eclipse.osgi.framework.console;
-	exports org.eclipse.osgi.framework.eventmgr;
-	exports org.eclipse.osgi.framework.log;
-	exports org.eclipse.osgi.launch;
-	exports org.eclipse.osgi.report.resolution;
-	exports org.eclipse.osgi.service.datalocation;
-	exports org.eclipse.osgi.service.debug;
-	exports org.eclipse.osgi.service.environment;
-	exports org.eclipse.osgi.service.localization;
-	exports org.eclipse.osgi.service.pluginconversion;
-	exports org.eclipse.osgi.service.resolver;
-	exports org.eclipse.osgi.service.runnable;
-	exports org.eclipse.osgi.service.security;
-	exports org.eclipse.osgi.service.urlconversion;
-	exports org.eclipse.osgi.signedcontent;
-	exports org.eclipse.osgi.storagemanager;
-	exports org.eclipse.osgi.util;
-	exports org.osgi.dto;
-	exports org.osgi.framework;
-	exports org.osgi.framework.connect;
-	exports org.osgi.framework.dto;
-	exports org.osgi.framework.hooks.bundle;
-	exports org.osgi.framework.hooks.resolver;
-	exports org.osgi.framework.hooks.service;
-	exports org.osgi.framework.hooks.weaving;
-	exports org.osgi.framework.launch;
-	exports org.osgi.framework.namespace;
-	exports org.osgi.framework.startlevel;
-	exports org.osgi.framework.startlevel.dto;
-	exports org.osgi.framework.wiring;
-	exports org.osgi.framework.wiring.dto;
-	exports org.osgi.resource;
-	exports org.osgi.resource.dto;
-	exports org.osgi.service.condpermadmin;
-	exports org.osgi.service.log;
-	exports org.osgi.service.log.admin;
-	exports org.osgi.service.packageadmin;
-	exports org.osgi.service.permissionadmin;
-	exports org.osgi.service.resolver;
-	exports org.osgi.service.startlevel;
-	exports org.osgi.service.url;
-	exports org.osgi.util.tracker;
-
-	provides org.osgi.framework.launch.FrameworkFactory with org.eclipse.osgi.launch.EquinoxFactory;
-	provides org.osgi.framework.connect.ConnectFrameworkFactory with org.eclipse.osgi.launch.EquinoxFactory;
-
-	uses org.osgi.framework.connect.FrameworkUtilHelper;
-}
-                  </moduleInfoSource>
-                </module>
-                <overwriteExistingFiles>true</overwriteExistingFiles>
+              <packagingTypes>eclipse-plugin</packagingTypes>
+              <manifestPath>${project.build.directory}/BND.MF</manifestPath>
             </configuration>
           </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -161,6 +161,15 @@
         </executions>
       </plugin>
     </plugins>
+    <pluginManagement>
+		<plugins>
+			<plugin>
+				<groupId>biz.aQute.bnd</groupId>
+				<artifactId>bnd-maven-plugin</artifactId>
+				<version>6.3.1</version>
+			</plugin>
+		</plugins>
+	</pluginManagement>
   </build>
 
 </project>


### PR DESCRIPTION
This replaces the manual crafted moditec JPMS info with the automatically generated one by BND.

As the new tycho-extension for bnd is not yet published, we simply use an explicit maven execution in the pom right now.

FYI @stbischof