### PR TITLE
Adding Stale bugs boot to Equinox

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -12,11 +12,9 @@ jobs:
     steps:
       - uses: actions/stale@v4
         with:
-          days-before-issue-stale: 90
-          days-before-issue-close: 180
+          days-before-issue-stale: 180
           stale-issue-label: "stale"
-          stale-issue-message: "This issue is stale because it has been open for 90 days with no activity."
-          close-issue-message: "This issue was closed because it has been inactive for 180 days since being marked as stale."
+          stale-issue-message: "This issue is stale because it has been open for 180 days with no activity."
           days-before-pr-stale: -1
           days-before-pr-close: -1
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -14,7 +14,13 @@ jobs:
         with:
           days-before-issue-stale: 180
           stale-issue-label: "stale"
-          stale-issue-message: "This issue is stale because it has been open for 180 days with no activity."
+          stale-issue-message: "This issue has been inactive for 180 days and is therefore labeled as stale.
+
+If this issue became irrelevant in the meantime please close it as completed.
+If it is still relevant and you think it should be fixed some possibilities are listed below.
+
+Please read https://github.com/eclipse-equinox/.github/blob/main/CONTRIBUTING.md#contributing-to-eclipse-equinox for ways to influence development.
+"
           days-before-pr-stale: -1
           days-before-pr-close: -1
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -1,0 +1,22 @@
+name: Close inactive issues
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v4
+        with:
+          days-before-issue-stale: 90
+          days-before-issue-close: 180
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue is stale because it has been open for 90 days with no activity."
+          close-issue-message: "This issue was closed because it has been inactive for 180 days since being marked as stale."
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Keeping issue open but not reacting to them is a bad practice. With this
action a bot will comment if an issue has been inactive for 180 days to
prompt participants to take action. 
See
https://docs.github.com/en/github-ae@latest/actions/managing-issues-and-pull-requests/closing-inactive-issues

See https://github.com/eclipse/gef-classic/pull/76#issuecomment-1158926496
for approvement