### PR TITLE
URIUtil: Fix UNC-related issues and provide UNC-safe URI-factories

### DIFF
--- a/bundles/org.eclipse.equinox.common.tests/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.common.tests/META-INF/MANIFEST.MF
@@ -8,7 +8,7 @@ Automatic-Module-Name: org.eclipse.equinox.common.tests
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.junit,
- org.eclipse.equinox.common;bundle-version="3.15.100",
+ org.eclipse.equinox.common;bundle-version="3.17.0",
  org.eclipse.core.tests.harness;bundle-version="3.11.400",
  org.eclipse.equinox.registry;bundle-version="3.8.200"
 Import-Package: org.eclipse.osgi.service.localization,

--- a/bundles/org.eclipse.equinox.common.tests/src/org/eclipse/equinox/common/tests/URIUtilTest.java
+++ b/bundles/org.eclipse.equinox.common.tests/src/org/eclipse/equinox/common/tests/URIUtilTest.java
@@ -13,9 +13,18 @@
  *******************************************************************************/
 package org.eclipse.equinox.common.tests;
 
-import java.io.*;
-import java.net.*;
-import org.eclipse.core.runtime.*;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+import org.eclipse.core.runtime.FileLocator;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.URIUtil;
 import org.eclipse.core.tests.harness.CoreTest;
 import org.osgi.framework.FrameworkUtil;
 
@@ -550,6 +559,37 @@ public class URIUtilTest extends CoreTest {
 			URI expected = data[i][2];
 			URI actual = URIUtil.makeRelative(location, root);
 			assertEquals("2." + Integer.toString(i), expected, actual);
+		}
+	}
+
+	/**
+	 * Test UNC-Paths containing a $.
+	 */
+	public void testDollar() throws URISyntaxException {
+		var relative = "SomePath";
+		URI expectedResolved = new URI("file:////WSL$/Ubuntu/SomePath");
+		String[] uris = {
+				// @formatter:off
+				"file:////WSL$/Ubuntu",
+				"file:////WSL$/Ubuntu/",
+				"file://////WSL$/Ubuntu",
+				"file://////WSL$/Ubuntu/"
+				// @formatter:on
+		};
+
+		for (int i = 0; i < uris.length; i++) {
+			URI base = new URI(uris[i]);
+			URI resolved = URIUtil.append(base, relative);
+			assertEquals("1." + Integer.toString(i), expectedResolved, resolved);
+		}
+
+		var relative2 = "SomePath/";
+		URI expectedResolved2 = new URI("file:////WSL$/Ubuntu/SomePath/");
+
+		for (int i = 0; i < uris.length; i++) {
+			URI base = new URI(uris[i]);
+			URI resolved = URIUtil.append(base, relative2);
+			assertEquals("2." + Integer.toString(i), expectedResolved2, resolved);
 		}
 	}
 }

--- a/bundles/org.eclipse.equinox.common/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.common/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.common; singleton:=true
-Bundle-Version: 3.16.300.qualifier
+Bundle-Version: 3.17.0.qualifier
 Bundle-Localization: plugin
 Export-Package: org.eclipse.core.internal.boot;x-friends:="org.eclipse.core.resources,org.eclipse.pde.build",
  org.eclipse.core.internal.runtime;common=split;mandatory:=common;

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/URIUtil.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/URIUtil.java
@@ -71,6 +71,11 @@ public final class URIUtil {
 					result = new URI(toUnencodedString(result));
 				}
 			} else {
+				// Unless the path starts with four slashes, the first element of the path is
+				// interpreted as host ( probably related to Java bug 4723726)
+				if (path.startsWith(UNC_PREFIX)) {
+					path = ensureUNCPath(path);
+				}
 				path = path + '/' + extension;
 				result = new URI(base.getScheme(), base.getUserInfo(), base.getHost(), base.getPort(), path, base.getQuery(), base.getFragment());
 			}


### PR DESCRIPTION
I had some issues with dollar-signs in UNC-Paths (e,.g. `\\WSL$`). There are others, too. [CDT](https://www.eclipse.org/cdt/) already has some special handling of UNC-Paths when creating URIs, but not everywhere. Thus the intention of this PR is to provide UNC-safe factories that can be used as drop-in replacement for `new java.net.URI()`. 

fixes #6 