### PR TITLE
Strip off the qualifier part form the JPMS output

### DIFF
--- a/bundles/org.eclipse.osgi/bnd.bnd
+++ b/bundles/org.eclipse.osgi/bnd.bnd
@@ -1,2 +1,2 @@
--jpms-module-info: ${project.artifactId};access='OPEN'
+-jpms-module-info: ${project.artifactId};access='OPEN';version=${versionmask;===;${version_cleanup;${project.version}}}
 -jpms-module-info-options: java.management;ignore="true"


### PR DESCRIPTION
Fix https://github.com/eclipse-equinox/equinox/issues/42

Local build output is now:
```
//  (version 9 : 53.0, no super bit)
 module org.eclipse.osgi  {
  // Version: 3.18.100

  requires java.base;
  requires java.xml;
  requires jdk.unsupported;
  
  Module packages:
    org.apache.felix.resolver
    org.apache.felix.resolver.reason
    org.apache.felix.resolver.util
    org.eclipse.core.runtime.adaptor
    org.eclipse.core.runtime.internal.adaptor
    org.eclipse.equinox.log
    org.eclipse.osgi.container
    org.eclipse.osgi.container.builders
    org.eclipse.osgi.container.namespaces
    org.eclipse.osgi.framework.console
    org.eclipse.osgi.framework.eventmgr
    org.eclipse.osgi.framework.internal.reliablefile
    org.eclipse.osgi.framework.log
    org.eclipse.osgi.framework.util
    org.eclipse.osgi.internal.cds
    org.eclipse.osgi.internal.connect
    org.eclipse.osgi.internal.container
    org.eclipse.osgi.internal.debug
    org.eclipse.osgi.internal.framework
    org.eclipse.osgi.internal.framework.legacy
    org.eclipse.osgi.internal.hookregistry
    org.eclipse.osgi.internal.hooks
    org.eclipse.osgi.internal.loader
    org.eclipse.osgi.internal.loader.buddy
    org.eclipse.osgi.internal.loader.classpath
    org.eclipse.osgi.internal.loader.sources
    org.eclipse.osgi.internal.location
    org.eclipse.osgi.internal.log
    org.eclipse.osgi.internal.messages
    org.eclipse.osgi.internal.permadmin
    org.eclipse.osgi.internal.provisional.service.security
    org.eclipse.osgi.internal.provisional.verifier
    org.eclipse.osgi.internal.service.security
    org.eclipse.osgi.internal.serviceregistry
    org.eclipse.osgi.internal.signedcontent
    org.eclipse.osgi.internal.url
    org.eclipse.osgi.internal.util
    org.eclipse.osgi.internal.weaving
    org.eclipse.osgi.launch
    org.eclipse.osgi.report.resolution
    org.eclipse.osgi.service.datalocation
    org.eclipse.osgi.service.debug
    org.eclipse.osgi.service.environment
    org.eclipse.osgi.service.localization
    org.eclipse.osgi.service.pluginconversion
    org.eclipse.osgi.service.resolver
    org.eclipse.osgi.service.runnable
    org.eclipse.osgi.service.security
    org.eclipse.osgi.service.urlconversion
    org.eclipse.osgi.signedcontent
    org.eclipse.osgi.storage
    org.eclipse.osgi.storage.bundlefile
    org.eclipse.osgi.storage.url
    org.eclipse.osgi.storage.url.bundleentry
    org.eclipse.osgi.storage.url.bundleresource
    org.eclipse.osgi.storage.url.reference
    org.eclipse.osgi.storagemanager
    org.eclipse.osgi.util
    org.osgi.dto
    org.osgi.framework
    org.osgi.framework.connect
    org.osgi.framework.dto
    org.osgi.framework.hooks.bundle
    org.osgi.framework.hooks.resolver
    org.osgi.framework.hooks.service
    org.osgi.framework.hooks.weaving
    org.osgi.framework.launch
    org.osgi.framework.namespace
    org.osgi.framework.startlevel
    org.osgi.framework.startlevel.dto
    org.osgi.framework.wiring
    org.osgi.framework.wiring.dto
    org.osgi.resource
    org.osgi.resource.dto
    org.osgi.service.condition
    org.osgi.service.condpermadmin
    org.osgi.service.log
    org.osgi.service.log.admin
    org.osgi.service.packageadmin
    org.osgi.service.permissionadmin
    org.osgi.service.resolver
    org.osgi.service.startlevel
    org.osgi.service.url
    org.osgi.util.tracker

}
```

@rotty3000 thanks for your help!