### PR TITLE
Small fixes for native build

### DIFF
--- a/features/org.eclipse.equinox.executable.feature/library/gtk/README.md
+++ b/features/org.eclipse.equinox.executable.feature/library/gtk/README.md
@@ -2,7 +2,7 @@
 
 # Building
 
-    ./bulid.sh
+    ./build.sh
     ./build.sh clean
 
 # Developer notes:

--- a/features/org.eclipse.equinox.executable.feature/library/gtk/make_linux.mak
+++ b/features/org.eclipse.equinox.executable.feature/library/gtk/make_linux.mak
@@ -149,7 +149,9 @@ clean:
 dev_build_install: all
 ifeq "$(origin DEV_ECLIPSE)" "environment"
 	$(info Copying $(EXEC) and $(DLL) into your development eclipse folder:)
+	mkdir -p ${DEV_ECLIPSE}/
 	cp $(EXEC) ${DEV_ECLIPSE}/
+	mkdir -p ${DEV_ECLIPSE}/plugins/org.eclipse.equinox.launcher.gtk.linux.x86_64/
 	cp $(DLL) ${DEV_ECLIPSE}/plugins/org.eclipse.equinox.launcher.gtk.linux.x86_64/
 else
 	$(error $(DEV_INSTALL_ERROR_MSG))


### PR DESCRIPTION
- Fixed typo in the README
- Fixed error in make_linux.mak if the DEV_ECLIPSE directory isn't yet
created