### PR TITLE
 Import org.osgi.service.cm in console.ssh.tests 

### DIFF
--- a/bundles/org.eclipse.equinox.console.ssh.tests/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.console.ssh.tests/META-INF/MANIFEST.MF
@@ -13,6 +13,7 @@ Import-Package: org.apache.sshd.client,
  org.junit;version="4.8.1",
  org.mockito,
  org.mockito.stubbing,
- org.mockito.invocation
+ org.mockito.invocation,
+ org.osgi.service.cm
 Fragment-Host: org.eclipse.equinox.console.ssh, org.eclipse.equinox.console
 Automatic-Module-Name: org.eclipse.equinox.console.ssh.tests


### PR DESCRIPTION
Bundle o.e.equinox.console.ssh has optional import but tests need it
unconditionally.
Fixes https://github.com/eclipse-equinox/equinox/issues/56