### PR TITLE
Apply jdt clean ups

### DIFF
--- a/bundles/org.eclipse.equinox.app/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.app/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.app; singleton:=true
-Bundle-Version: 1.6.100.qualifier
+Bundle-Version: 1.6.200.qualifier
 Bundle-Vendor: %providerName
 Bundle-Activator: org.eclipse.equinox.internal.app.Activator
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.equinox.app/pom.xml
+++ b/bundles/org.eclipse.equinox.app/pom.xml
@@ -19,7 +19,7 @@
 </parent>
   <groupId>org.eclipse.equinox</groupId>
   <artifactId>org.eclipse.equinox.app</artifactId>
-  <version>1.6.100-SNAPSHOT</version>
+  <version>1.6.200-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   <build>
     <plugins>

--- a/bundles/org.eclipse.equinox.app/src/org/eclipse/equinox/internal/app/AppPersistence.java
+++ b/bundles/org.eclipse.equinox.app/src/org/eclipse/equinox/internal/app/AppPersistence.java
@@ -271,9 +271,7 @@ public class AppPersistence implements ServiceTrackerCustomizer {
 				EclipseScheduledApplication schedApp = new EclipseScheduledApplication(context, id, appPid, args, topic, eventFilter, recurring);
 				addScheduledApp(schedApp);
 			}
-		} catch (InvalidSyntaxException e) {
-			throw new IOException(e.getMessage());
-		} catch (NoClassDefFoundError | ClassNotFoundException e) {
+		} catch (InvalidSyntaxException | NoClassDefFoundError | ClassNotFoundException e) {
 			throw new IOException(e.getMessage());
 		}
 	}

--- a/bundles/org.eclipse.equinox.bidi/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.bidi/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.equinox.bidi;singleton:=true
-Bundle-Version: 1.4.100.qualifier
+Bundle-Version: 1.4.200.qualifier
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy

--- a/bundles/org.eclipse.equinox.bidi/src/org/eclipse/equinox/bidi/advanced/StructuredTextExpertFactory.java
+++ b/bundles/org.eclipse.equinox.bidi/src/org/eclipse/equinox/bidi/advanced/StructuredTextExpertFactory.java
@@ -126,7 +126,7 @@ final public class StructuredTextExpertFactory {
 		synchronized (sharedExperts) {
 			Map<StructuredTextEnvironment, IStructuredTextExpert> experts = sharedExperts.get(type);
 			if (experts == null) {
-				experts = new HashMap<StructuredTextEnvironment, IStructuredTextExpert>(); // environment -> expert
+				experts = new HashMap<>(); // environment -> expert
 				sharedExperts.put(type, experts);
 			}
 			expert = experts.get(environment);

--- a/bundles/org.eclipse.equinox.bidi/src/org/eclipse/equinox/bidi/internal/StructuredTextTypesCollector.java
+++ b/bundles/org.eclipse.equinox.bidi/src/org/eclipse/equinox/bidi/internal/StructuredTextTypesCollector.java
@@ -81,7 +81,7 @@ public class StructuredTextTypesCollector implements IRegistryEventListener {
 			types.clear();
 
 		if (factories == null)
-			factories = new HashMap<String, IConfigurationElement>();
+			factories = new HashMap<>();
 		else
 			factories.clear();
 
@@ -141,7 +141,7 @@ public class StructuredTextTypesCollector implements IRegistryEventListener {
 	 *         to structured text type handler (value type: {@link StructuredTextTypeHandler}).
 	 */
 	public static Map<String, StructuredTextTypeHandler> getDefaultTypeHandlers() {
-		Map<String, StructuredTextTypeHandler> types = new LinkedHashMap<String, StructuredTextTypeHandler>();
+		Map<String, StructuredTextTypeHandler> types = new LinkedHashMap<>();
 
 		types.put(StructuredTextTypeHandlerFactory.COMMA_DELIMITED, new StructuredTextComma());
 		types.put(StructuredTextTypeHandlerFactory.EMAIL, new StructuredTextEmail());

--- a/bundles/org.eclipse.equinox.cm.test/src/org/eclipse/equinox/cm/test/ConfigurationAdminTest.java
+++ b/bundles/org.eclipse.equinox.cm.test/src/org/eclipse/equinox/cm/test/ConfigurationAdminTest.java
@@ -231,7 +231,7 @@ public class ConfigurationAdminTest {
 	public void testPersistentConfig() throws Exception {
 		Configuration config = cm.getConfiguration("test");
 		assertNull(config.getProperties());
-		Dictionary<String, Object> props = new Hashtable<String, Object>();
+		Dictionary<String, Object> props = new Hashtable<>();
 		props.put("testkey", "testvalue");
 		config.update(props);
 		assertTrue(config.getPid().equals("test"));
@@ -251,7 +251,7 @@ public class ConfigurationAdminTest {
 	public void testPersistentFactoryConfig() throws Exception {
 		Configuration config = cm.createFactoryConfiguration("test");
 		assertNull(config.getProperties());
-		Dictionary<String, Object> props = new Hashtable<String, Object>();
+		Dictionary<String, Object> props = new Hashtable<>();
 		props.put("testkey", "testvalue");
 		config.update(props);
 		assertTrue(config.getFactoryPid().equals("test"));

--- a/bundles/org.eclipse.equinox.cm.test/src/org/eclipse/equinox/cm/test/ConfigurationDictionaryTest.java
+++ b/bundles/org.eclipse.equinox.cm.test/src/org/eclipse/equinox/cm/test/ConfigurationDictionaryTest.java
@@ -74,8 +74,8 @@ public class ConfigurationDictionaryTest {
 			dict.put("24", new short[] {1});
 			dict.put("25", new char[] {'a'});
 			dict.put("26", new boolean[] {true});
-			dict.put("27", new Vector<Object>());
-			Vector<Object> v = new Vector<Object>();
+			dict.put("27", new Vector<>());
+			Vector<Object> v = new Vector<>();
 			v.add(new String("x"));
 			v.add(Integer.valueOf(1));
 			v.add(Long.valueOf(1));
@@ -86,7 +86,7 @@ public class ConfigurationDictionaryTest {
 			v.add(Character.valueOf('a'));
 			v.add(Boolean.TRUE);
 			dict.put("28", v);
-			Collection<Object> c = new ArrayList<Object>();
+			Collection<Object> c = new ArrayList<>();
 			c.add(new String("x"));
 			c.add(Integer.valueOf(1));
 			c.add(Long.valueOf(1));
@@ -197,7 +197,7 @@ public class ConfigurationDictionaryTest {
 		config.update();
 		Dictionary<String, Object> dict = config.getProperties();
 		try {
-			Vector<Object> v = new Vector<Object>();
+			Vector<Object> v = new Vector<>();
 			v.add(new Object());
 			dict.put("x", v);
 		} catch (IllegalArgumentException e) {
@@ -214,7 +214,7 @@ public class ConfigurationDictionaryTest {
 		config.update();
 		Dictionary<String, Object> dict = config.getProperties();
 		try {
-			Collection<Object> c = new ArrayList<Object>();
+			Collection<Object> c = new ArrayList<>();
 			c.add(new Object());
 			dict.put("x", c);
 		} catch (IllegalArgumentException e) {

--- a/bundles/org.eclipse.equinox.cm.test/src/org/eclipse/equinox/cm/test/ConfigurationEventAdapterTest.java
+++ b/bundles/org.eclipse.equinox.cm.test/src/org/eclipse/equinox/cm/test/ConfigurationEventAdapterTest.java
@@ -51,7 +51,7 @@ public class ConfigurationEventAdapterTest {
 	public void testConfigurationEvent() throws Exception {
 
 		Configuration config = cm.getConfiguration("test");
-		Dictionary<String, Object> props = new Hashtable<String, Object>();
+		Dictionary<String, Object> props = new Hashtable<>();
 		props.put("testkey", "testvalue");
 		config.update(props);
 
@@ -65,7 +65,7 @@ public class ConfigurationEventAdapterTest {
 
 		};
 		String[] topics = new String[] {"org/osgi/service/cm/ConfigurationEvent/*"};
-		Dictionary<String, Object> handlerProps = new Hashtable<String, Object>();
+		Dictionary<String, Object> handlerProps = new Hashtable<>();
 
 		handlerProps.put(EventConstants.EVENT_TOPIC, topics);
 		ServiceRegistration<EventHandler> reg = Activator.getBundleContext().registerService(EventHandler.class, handler, handlerProps);
@@ -91,7 +91,7 @@ public class ConfigurationEventAdapterTest {
 	public void testConfigurationFactoryEvent() throws Exception {
 
 		Configuration config = cm.createFactoryConfiguration("test");
-		Dictionary<String, Object> props = new Hashtable<String, Object>();
+		Dictionary<String, Object> props = new Hashtable<>();
 		props.put("testkey", "testvalue");
 		config.update(props);
 
@@ -105,7 +105,7 @@ public class ConfigurationEventAdapterTest {
 
 		};
 		String[] topics = new String[] {"org/osgi/service/cm/ConfigurationEvent/*"};
-		Dictionary<String, Object> handlerProps = new Hashtable<String, Object>();
+		Dictionary<String, Object> handlerProps = new Hashtable<>();
 		handlerProps.put(EventConstants.EVENT_TOPIC, topics);
 		ServiceRegistration<EventHandler> reg = Activator.getBundleContext().registerService(EventHandler.class, handler, handlerProps);
 

--- a/bundles/org.eclipse.equinox.cm.test/src/org/eclipse/equinox/cm/test/ConfigurationListenerTest.java
+++ b/bundles/org.eclipse.equinox.cm.test/src/org/eclipse/equinox/cm/test/ConfigurationListenerTest.java
@@ -46,7 +46,7 @@ public class ConfigurationListenerTest {
 	public void testListener() throws Exception {
 
 		Configuration config = cm.getConfiguration("test");
-		Dictionary<String, Object> props = new Hashtable<String, Object>();
+		Dictionary<String, Object> props = new Hashtable<>();
 		props.put("testkey", "testvalue");
 		config.update(props);
 

--- a/bundles/org.eclipse.equinox.cm.test/src/org/eclipse/equinox/cm/test/ConfigurationPluginTest.java
+++ b/bundles/org.eclipse.equinox.cm.test/src/org/eclipse/equinox/cm/test/ConfigurationPluginTest.java
@@ -45,7 +45,7 @@ public class ConfigurationPluginTest {
 	public void testPlugin() throws Exception {
 
 		Configuration config = cm.getConfiguration("test");
-		Dictionary<String, Object> props = new Hashtable<String, Object>();
+		Dictionary<String, Object> props = new Hashtable<>();
 		props.put("testkey", "testvalue");
 		config.update(props);
 
@@ -67,7 +67,7 @@ public class ConfigurationPluginTest {
 			}
 		};
 
-		Dictionary<String, Object> dict = new Hashtable<String, Object>();
+		Dictionary<String, Object> dict = new Hashtable<>();
 		dict.put(Constants.SERVICE_PID, "test");
 		ServiceRegistration<ManagedService> reg = null;
 		synchronized (lock) {
@@ -89,7 +89,7 @@ public class ConfigurationPluginTest {
 	public void testPidSpecificPlugin() throws Exception {
 
 		Configuration config = cm.getConfiguration("test");
-		Dictionary<String, Object> props = new Hashtable<String, Object>();
+		Dictionary<String, Object> props = new Hashtable<>();
 		props.put("testkey", "testvalue");
 		config.update(props);
 
@@ -99,7 +99,7 @@ public class ConfigurationPluginTest {
 				properties.put("plugin", "plugin1");
 			}
 		};
-		Dictionary<String, Object> pluginDict = new Hashtable<String, Object>();
+		Dictionary<String, Object> pluginDict = new Hashtable<>();
 		pluginDict.put(ConfigurationPlugin.CM_TARGET, new String[] {"test"});
 		ServiceRegistration<ConfigurationPlugin> pluginReg = Activator.getBundleContext().registerService(ConfigurationPlugin.class, plugin, pluginDict);
 
@@ -113,7 +113,7 @@ public class ConfigurationPluginTest {
 			}
 		};
 
-		Dictionary<String, Object> dict = new Hashtable<String, Object>();
+		Dictionary<String, Object> dict = new Hashtable<>();
 		dict.put(Constants.SERVICE_PID, "test");
 		ServiceRegistration<ManagedService> reg = null;
 		synchronized (lock) {
@@ -135,7 +135,7 @@ public class ConfigurationPluginTest {
 	public void testPidSpecificMissPlugin() throws Exception {
 
 		Configuration config = cm.getConfiguration("test");
-		Dictionary<String, Object> props = new Hashtable<String, Object>();
+		Dictionary<String, Object> props = new Hashtable<>();
 		props.put("testkey", "testvalue");
 		config.update(props);
 
@@ -145,7 +145,7 @@ public class ConfigurationPluginTest {
 				properties.put("plugin", "plugin1");
 			}
 		};
-		Dictionary<String, Object> pluginDict = new Hashtable<String, Object>();
+		Dictionary<String, Object> pluginDict = new Hashtable<>();
 		pluginDict.put(ConfigurationPlugin.CM_TARGET, new String[] {"testXXX"});
 		ServiceRegistration<ConfigurationPlugin> pluginReg = Activator.getBundleContext().registerService(ConfigurationPlugin.class, plugin, pluginDict);
 
@@ -159,7 +159,7 @@ public class ConfigurationPluginTest {
 			}
 		};
 
-		Dictionary<String, Object> dict = new Hashtable<String, Object>();
+		Dictionary<String, Object> dict = new Hashtable<>();
 		dict.put(Constants.SERVICE_PID, "test");
 		ServiceRegistration<ManagedService> reg = null;
 		synchronized (lock) {
@@ -179,7 +179,7 @@ public class ConfigurationPluginTest {
 	public void testRankedPlugin() throws Exception {
 
 		Configuration config = cm.getConfiguration("test");
-		Dictionary<String, Object> props = new Hashtable<String, Object>();
+		Dictionary<String, Object> props = new Hashtable<>();
 		props.put("testkey", "testvalue");
 		config.update(props);
 
@@ -189,7 +189,7 @@ public class ConfigurationPluginTest {
 				properties.put("plugin", "plugin1");
 			}
 		};
-		Dictionary<String, Object> pluginDict = new Hashtable<String, Object>();
+		Dictionary<String, Object> pluginDict = new Hashtable<>();
 		pluginDict.put(ConfigurationPlugin.CM_RANKING, Integer.valueOf(1));
 		ServiceRegistration<ConfigurationPlugin> pluginReg1 = Activator.getBundleContext().registerService(ConfigurationPlugin.class, plugin, pluginDict);
 
@@ -212,7 +212,7 @@ public class ConfigurationPluginTest {
 			}
 		};
 
-		Dictionary<String, Object> dict = new Hashtable<String, Object>();
+		Dictionary<String, Object> dict = new Hashtable<>();
 		dict.put(Constants.SERVICE_PID, "test");
 		ServiceRegistration<ManagedService> reg = null;
 		synchronized (lock) {
@@ -235,12 +235,12 @@ public class ConfigurationPluginTest {
 	public void testSameRankedPlugin() throws Exception {
 
 		Configuration config = cm.getConfiguration("test");
-		Dictionary<String, Object> props = new Hashtable<String, Object>();
+		Dictionary<String, Object> props = new Hashtable<>();
 		props.put("testkey", "testvalue");
 		config.update(props);
-		final List<String> pluginsCalled = new ArrayList<String>();
+		final List<String> pluginsCalled = new ArrayList<>();
 
-		Hashtable<String, Object> pluginProps = new Hashtable<String, Object>();
+		Hashtable<String, Object> pluginProps = new Hashtable<>();
 		pluginProps.put(Constants.SERVICE_RANKING, Integer.valueOf(1));
 		ConfigurationPlugin plugin1 = new ConfigurationPlugin() {
 			public void modifyConfiguration(ServiceReference<?> serviceReference, Dictionary<String, Object> properties) {
@@ -276,7 +276,7 @@ public class ConfigurationPluginTest {
 			}
 		};
 
-		Dictionary<String, Object> dict = new Hashtable<String, Object>();
+		Dictionary<String, Object> dict = new Hashtable<>();
 		dict.put(Constants.SERVICE_PID, "test");
 		ServiceRegistration<ManagedService> reg = null;
 		synchronized (lock) {

--- a/bundles/org.eclipse.equinox.cm.test/src/org/eclipse/equinox/cm/test/ManagedServiceFactoryTest.java
+++ b/bundles/org.eclipse.equinox.cm.test/src/org/eclipse/equinox/cm/test/ManagedServiceFactoryTest.java
@@ -47,7 +47,7 @@ public class ManagedServiceFactoryTest {
 	public void testSamePidManagedServiceFactory() throws Exception {
 
 		Configuration config = cm.createFactoryConfiguration("test");
-		Dictionary<String, Object> props = new Hashtable<String, Object>();
+		Dictionary<String, Object> props = new Hashtable<>();
 		props.put("testkey", "testvalue");
 		config.update(props);
 
@@ -75,7 +75,7 @@ public class ManagedServiceFactoryTest {
 			}
 		};
 
-		Dictionary<String, Object> dict = new Hashtable<String, Object>();
+		Dictionary<String, Object> dict = new Hashtable<>();
 		dict.put(Constants.SERVICE_PID, "test");
 		ServiceRegistration<ManagedServiceFactory> reg = null;
 		synchronized (lock) {
@@ -127,7 +127,7 @@ public class ManagedServiceFactoryTest {
 			}
 		};
 
-		Dictionary<String, Object> dict = new Hashtable<String, Object>();
+		Dictionary<String, Object> dict = new Hashtable<>();
 		dict.put(Constants.SERVICE_PID, "test");
 
 		ServiceRegistration<ManagedServiceFactory> reg = null;
@@ -142,7 +142,7 @@ public class ManagedServiceFactoryTest {
 
 		Configuration config = cm.createFactoryConfiguration("test");
 		assertNull(config.getProperties());
-		Dictionary<String, Object> props = new Hashtable<String, Object>();
+		Dictionary<String, Object> props = new Hashtable<>();
 		props.put("testkey", "testvalue");
 
 		synchronized (lock) {

--- a/bundles/org.eclipse.equinox.cm.test/src/org/eclipse/equinox/cm/test/ManagedServiceTest.java
+++ b/bundles/org.eclipse.equinox.cm.test/src/org/eclipse/equinox/cm/test/ManagedServiceTest.java
@@ -49,7 +49,7 @@ public class ManagedServiceTest {
 	public void testSamePidManagedService() throws Exception {
 
 		Configuration config = cm.getConfiguration("test");
-		Dictionary<String, Object> props = new Hashtable<String, Object>();
+		Dictionary<String, Object> props = new Hashtable<>();
 		props.put("testkey", "testvalue");
 		config.update(props);
 
@@ -66,7 +66,7 @@ public class ManagedServiceTest {
 			}
 		};
 
-		Dictionary<String, Object> dict = new Hashtable<String, Object>();
+		Dictionary<String, Object> dict = new Hashtable<>();
 		dict.put(Constants.SERVICE_PID, "test");
 		ServiceRegistration<ManagedService> reg = null;
 		synchronized (lock) {
@@ -119,7 +119,7 @@ public class ManagedServiceTest {
 				return logLevel == LogService.LOG_ERROR;
 			}
 		});
-		Dictionary<String, Object> dict = new Hashtable<String, Object>();
+		Dictionary<String, Object> dict = new Hashtable<>();
 		dict.put(Constants.SERVICE_PID, "test");
 		ServiceRegistration<ManagedService> reg1 = Activator.getBundleContext().registerService(ManagedService.class, ms, dict);
 		ServiceRegistration<ManagedService> reg2 = Activator.getBundleContext().registerService(ManagedService.class, ms, dict);
@@ -149,7 +149,7 @@ public class ManagedServiceTest {
 			}
 		};
 
-		Dictionary<String, Object> dict = new Hashtable<String, Object>();
+		Dictionary<String, Object> dict = new Hashtable<>();
 		dict.put(Constants.SERVICE_PID, "test");
 
 		ServiceRegistration<ManagedService> reg = null;
@@ -164,7 +164,7 @@ public class ManagedServiceTest {
 
 		Configuration config = cm.getConfiguration("test");
 		assertNull(config.getProperties());
-		Dictionary<String, Object> props = new Hashtable<String, Object>();
+		Dictionary<String, Object> props = new Hashtable<>();
 		props.put("testkey", "testvalue");
 
 		synchronized (lock) {

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/internal/runtime/DevClassPathHelper.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/internal/runtime/DevClassPathHelper.java
@@ -86,13 +86,8 @@ public class DevClassPathHelper {
 	private static Properties load(URL url) {
 		Properties props = new Properties();
 		try {
-			InputStream is = null;
-			try {
-				is = url.openStream();
+			try (InputStream is = url.openStream()) {
 				props.load(is);
-			} finally {
-				if (is != null)
-					is.close();
 			}
 		} catch (IOException e) {
 			// TODO consider logging here

--- a/bundles/org.eclipse.equinox.coordinator/src/org/eclipse/equinox/coordinator/Activator.java
+++ b/bundles/org.eclipse.equinox.coordinator/src/org/eclipse/equinox/coordinator/Activator.java
@@ -27,7 +27,7 @@ public class Activator implements BundleActivator {
 
 	public void start(BundleContext bundleContext) throws Exception {
 		factory = new CoordinatorServiceFactory(bundleContext);
-		Dictionary<String, Object> properties = new Hashtable<String, Object>();
+		Dictionary<String, Object> properties = new Hashtable<>();
 		@SuppressWarnings({"unchecked"})
 		// Use local variable to avoid suppressing unchecked warnings at method level.
 		ServiceRegistration<Coordinator> reg = (ServiceRegistration<Coordinator>) bundleContext.registerService(Coordinator.class.getName(), factory, properties);

--- a/bundles/org.eclipse.equinox.coordinator/src/org/eclipse/equinox/coordinator/CoordinationImpl.java
+++ b/bundles/org.eclipse.equinox.coordinator/src/org/eclipse/equinox/coordinator/CoordinationImpl.java
@@ -61,7 +61,7 @@ public class CoordinationImpl {
 		totalTimeout = timeout;
 		this.coordinator = coordinator;
 		participants = Collections.synchronizedList(new ArrayList<Participant>());
-		variables = new HashMap<Class<?>, Object>();
+		variables = new HashMap<>();
 		// Not an escaping 'this' reference. It will not escape the thread calling the constructor.
 		referent = new CoordinationReferent(this);
 	}
@@ -182,7 +182,7 @@ public class CoordinationImpl {
 		Participant exceptionParticipant = null;
 		// No additional synchronization is needed here because the participant
 		// list will not be modified post termination.
-		List<Participant> participantsToNotify = new ArrayList<Participant>(this.participants);
+		List<Participant> participantsToNotify = new ArrayList<>(this.participants);
 		Collections.reverse(participantsToNotify);
 		for (Participant participant : participantsToNotify) {
 			try {
@@ -291,7 +291,7 @@ public class CoordinationImpl {
 		// Notify participants this coordination has failed.
 		// No additional synchronization is needed here because the participant
 		// list will not be modified post termination.
-		List<Participant> participantsToNotify = new ArrayList<Participant>(this.participants);
+		List<Participant> participantsToNotify = new ArrayList<>(this.participants);
 		Collections.reverse(participantsToNotify);
 		for (Participant participant : participantsToNotify) {
 			try {
@@ -338,7 +338,7 @@ public class CoordinationImpl {
 		coordinator.checkPermission(CoordinationPermission.INITIATE, name);
 		// Return a mutable snapshot.
 		synchronized (participants) {
-			return new ArrayList<Participant>(participants);
+			return new ArrayList<>(participants);
 		}
 	}
 

--- a/bundles/org.eclipse.equinox.coordinator/src/org/eclipse/equinox/coordinator/CoordinationWeakReference.java
+++ b/bundles/org.eclipse.equinox.coordinator/src/org/eclipse/equinox/coordinator/CoordinationWeakReference.java
@@ -22,7 +22,7 @@ import org.osgi.service.coordinator.CoordinationException;
 import org.osgi.service.log.LogService;
 
 public class CoordinationWeakReference extends WeakReference<CoordinationReferent> {
-	private static final ReferenceQueue<CoordinationReferent> referenceQueue = new ReferenceQueue<CoordinationReferent>();
+	private static final ReferenceQueue<CoordinationReferent> referenceQueue = new ReferenceQueue<>();
 	
 	public static void processOrphanedCoordinations() {
 		CoordinationWeakReference r;

--- a/bundles/org.eclipse.equinox.coordinator/src/org/eclipse/equinox/coordinator/CoordinatorImpl.java
+++ b/bundles/org.eclipse.equinox.coordinator/src/org/eclipse/equinox/coordinator/CoordinatorImpl.java
@@ -47,7 +47,7 @@ public class CoordinatorImpl implements Coordinator {
 	}
 
 	// Coordination IDs must be unique across all using bundles.
-	private static final Map<Long, CoordinationImpl> idToCoordination = new HashMap<Long, CoordinationImpl>();
+	private static final Map<Long, CoordinationImpl> idToCoordination = new HashMap<>();
 	// Coordination participation must be tracked across all using bundles.
 	private static final Map<Participant, CoordinationImpl> participantToCoordination = Collections.synchronizedMap(new IdentityHashMap<Participant, CoordinationImpl>());
 
@@ -59,7 +59,7 @@ public class CoordinatorImpl implements Coordinator {
 	};
 
 	private static class WeakCoordinationStack {
-		private final LinkedList<CoordinationImpl> coordinations = new LinkedList<CoordinationImpl>();
+		private final LinkedList<CoordinationImpl> coordinations = new LinkedList<>();
 
 		public WeakCoordinationStack() {
 		}
@@ -103,7 +103,7 @@ public class CoordinatorImpl implements Coordinator {
 		this.bundle = bundle;
 		this.logTracker = logService;
 		this.timer = timer;
-		coordinations = new ArrayList<CoordinationImpl>();
+		coordinations = new ArrayList<>();
 		if (maxTimeout < 0)
 			throw new IllegalArgumentException(NLS.bind(Messages.InvalidTimeInterval, maxTimeout));
 		this.maxTimeout = maxTimeout;
@@ -193,7 +193,7 @@ public class CoordinatorImpl implements Coordinator {
 		CoordinationWeakReference.processOrphanedCoordinations();
 		ArrayList<Coordination> result;
 		synchronized (CoordinatorImpl.class) {
-			result = new ArrayList<Coordination>(idToCoordination.size());
+			result = new ArrayList<>(idToCoordination.size());
 			for (CoordinationImpl coordination : idToCoordination.values()) {
 				// Ideally, we're only interested in coordinations that have not terminated.
 				// It's okay, however, if the coordination terminates from this point forward.
@@ -285,7 +285,7 @@ public class CoordinatorImpl implements Coordinator {
 			shutdown = true;
 			// Make a copy so the removal of the coordination from the list during
 			// termination does not interfere with the iteration.
-			coords = new ArrayList<CoordinationImpl>(this.coordinations);
+			coords = new ArrayList<>(this.coordinations);
 		}
 		for (CoordinationImpl coordination : coords) {
 			coordination.fail(Coordination.RELEASED);

--- a/bundles/org.eclipse.equinox.ds.tests/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.ds.tests/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Declarative Services Tests
 Bundle-Vendor: Eclipse.org - Equinox
 Bundle-Category: test
 Bundle-SymbolicName: org.eclipse.equinox.ds.tests
-Bundle-Version: 1.6.200.qualifier
+Bundle-Version: 1.6.300.qualifier
 Bundle-Activator: org.eclipse.equinox.ds.tests.DSTestsActivator
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.junit

--- a/bundles/org.eclipse.equinox.ds.tests/bundles_src/tb16/org/eclipse/equinox/ds/tests/tb16/TargetProperties.java
+++ b/bundles/org.eclipse.equinox.ds.tests/bundles_src/tb16/org/eclipse/equinox/ds/tests/tb16/TargetProperties.java
@@ -34,7 +34,7 @@ public class TargetProperties implements PropertiesProvider, ComponentContextPro
 
     Object prop = properties.get("serial.num");
     if (prop != null) {
-      Dictionary<String, Object> serviceProps = new Hashtable<String, Object>();
+      Dictionary<String, Object> serviceProps = new Hashtable<>();
       serviceProps.put("serial.num", prop);
       sr = ctxt.getBundleContext().registerService(getClass().getName(), this, serviceProps);
     }

--- a/bundles/org.eclipse.equinox.ds.tests/bundles_src/tb17/org/eclipse/equinox/ds/tests/tb17/Worker.java
+++ b/bundles/org.eclipse.equinox.ds.tests/bundles_src/tb17/org/eclipse/equinox/ds/tests/tb17/Worker.java
@@ -35,7 +35,7 @@ public class Worker implements PropertiesProvider, ComponentContextProvider {
 
     Object prop = properties.get(ComponentConstants.COMPONENT_NAME);
     if (prop != null) {
-      Dictionary<String, Object> serviceProps = new Hashtable<String, Object>();
+      Dictionary<String, Object> serviceProps = new Hashtable<>();
       serviceProps.put(ComponentConstants.COMPONENT_NAME, prop);
       sr = ctxt.getBundleContext().registerService(PropertiesProvider.class.getName(), this, serviceProps);
     }

--- a/bundles/org.eclipse.equinox.ds.tests/bundles_src/tb26/org/eclipse/equinox/ds/tests/tb26/Component.java
+++ b/bundles/org.eclipse.equinox.ds.tests/bundles_src/tb26/org/eclipse/equinox/ds/tests/tb26/Component.java
@@ -42,7 +42,7 @@ public abstract class Component {
 		this.context = context;
 		BundleContext bc = context.getBundleContext();
 		Filter f = bc.createFilter("(&(objectClass=" + URLConverter.class.getName() + ")(protocol=bundleentry))");
-		tracker = new ServiceTracker<URLConverter, URLConverter>(bc, f, null);
+		tracker = new ServiceTracker<>(bc, f, null);
 		tracker.open();
 	}
 	

--- a/bundles/org.eclipse.equinox.ds.tests/pom.xml
+++ b/bundles/org.eclipse.equinox.ds.tests/pom.xml
@@ -19,7 +19,7 @@
   </parent>
   <groupId>org.eclipse.equinox</groupId>
   <artifactId>org.eclipse.equinox.ds.tests</artifactId>
-  <version>1.6.200-SNAPSHOT</version>
+  <version>1.6.300-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
   <properties>
     <testClass>org.eclipse.equinox.ds.tests.AllTests</testClass>

--- a/bundles/org.eclipse.equinox.ds.tests/src/org/eclipse/equinox/ds/tests/tbc/DSTest.java
+++ b/bundles/org.eclipse.equinox.ds.tests/src/org/eclipse/equinox/ds/tests/tbc/DSTest.java
@@ -3031,8 +3031,7 @@ public class DSTest {
 	  // The bundle is a JAR file and needs to be extracted and copied as a
 	  // directory to the data storage area of the test harness bundle.
 	  File file = context.getBundle().getDataFile(bundle);
-	  ZipInputStream in = new ZipInputStream(new URL(location).openStream());
-	  try {
+	  try (ZipInputStream in = new ZipInputStream(new URL(location).openStream())) {
 		  for (ZipEntry ze = in.getNextEntry(); ze != null; ze = in.getNextEntry()) {
 			  String name = ze.getName();
 			  // Is the entry a directory?
@@ -3057,19 +3056,12 @@ public class DSTest {
 			  // Now copy the contents of the file entry to the destination.
 			  byte[] bytes = new byte[1024];
 			  int read;
-			  FileOutputStream out = new FileOutputStream(destination);
-			  try {
+			  try (FileOutputStream out = new FileOutputStream(destination)) {
 				  while ((read = in.read(bytes)) != -1)
 					  out.write(bytes, 0, read);
 			  }
-			  finally {
-				  out.close();
-			  }
 			  in.closeEntry();
 		  }
-	  }
-	  finally {
-		  in.close();
 	  }
 	  // Add the "reference" protocol back when running from a server so the
 	  // framework sees the modified component.xml in the bundle data storage.

--- a/bundles/org.eclipse.equinox.ds.tests/src/org/eclipse/equinox/ds/tests/tbc/DSTest.java
+++ b/bundles/org.eclipse.equinox.ds.tests/src/org/eclipse/equinox/ds/tests/tbc/DSTest.java
@@ -708,7 +708,7 @@ public class DSTest {
     newProps.put(ComponentConstants.COMPONENT_ID, Long.valueOf(-1));
     newProps.put("name", "test");
 
-    List<ComponentInstance> cis = new ArrayList<ComponentInstance>();
+    List<ComponentInstance> cis = new ArrayList<>();
     ComponentInstance ci = factory.newInstance(newProps);
     assertNotNull("newInstance() method shouldn't return null", ci);
     cis.add(ci);

--- a/bundles/org.eclipse.equinox.http.registry/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.http.registry/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-SymbolicName: org.eclipse.equinox.http.registry;singleton:=true
-Bundle-Version: 1.3.100.qualifier
+Bundle-Version: 1.3.200.qualifier
 Bundle-Activator: org.eclipse.equinox.http.registry.internal.Activator
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.equinox.common,

--- a/bundles/org.eclipse.equinox.http.registry/src/org/eclipse/equinox/http/registry/internal/HttpRegistryManager.java
+++ b/bundles/org.eclipse.equinox.http.registry/src/org/eclipse/equinox/http/registry/internal/HttpRegistryManager.java
@@ -17,7 +17,6 @@ import java.lang.reflect.Method;
 import java.util.*;
 import javax.servlet.Filter;
 import javax.servlet.Servlet;
-import javax.servlet.ServletException;
 import org.eclipse.core.runtime.IContributor;
 import org.eclipse.core.runtime.IExtensionRegistry;
 import org.osgi.framework.*;
@@ -248,9 +247,6 @@ public class HttpRegistryManager {
 		try {
 			httpService.registerResources(contribution.alias, contribution.baseName, context);
 			registered.add(contribution.alias);
-		} catch (NamespaceException e) {
-			// TODO: should log this
-			e.printStackTrace();
 		} catch (Throwable t) {
 			// TODO: should log this
 			t.printStackTrace();
@@ -264,12 +260,6 @@ public class HttpRegistryManager {
 		try {
 			httpService.registerServlet(contribution.alias, contribution.servlet, contribution.initparams, context);
 			registered.add(contribution.alias);
-		} catch (NamespaceException e) {
-			// TODO: should log this
-			e.printStackTrace();
-		} catch (ServletException e) {
-			// TODO: should log this
-			e.printStackTrace();
 		} catch (Throwable t) {
 			// TODO: should log this
 			t.printStackTrace();

--- a/bundles/org.eclipse.equinox.http.servlet.tests/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.http.servlet.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: org.eclipse.equinox.http.servlet.tests
 Bundle-Vendor: Eclipse.org - Equinox
 Bundle-SymbolicName: org.eclipse.equinox.http.servlet.tests
-Bundle-Version: 1.8.400.qualifier
+Bundle-Version: 1.8.500.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Eclipse-BundleShape: dir
 Require-Bundle: org.junit;bundle-version="4.0"

--- a/bundles/org.eclipse.equinox.http.servlet.tests/bundles_src/tb1/org/eclipse/equinox/http/servlet/tests/tb/AbstractTestServlet.java
+++ b/bundles/org.eclipse.equinox.http.servlet.tests/bundles_src/tb1/org/eclipse/equinox/http/servlet/tests/tb/AbstractTestServlet.java
@@ -66,11 +66,8 @@ public abstract class AbstractTestServlet extends HttpServlet {
 
 	@Override
 	protected final void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-		PrintWriter writer = response.getWriter();
-		try {
+		try (PrintWriter writer = response.getWriter()) {
 			handleDoGet(request, writer);
-		} finally {
-			writer.close();
 		}
 	}
 

--- a/bundles/org.eclipse.equinox.http.servlet.tests/bundles_src/tb1/org/eclipse/equinox/http/servlet/tests/tb/AbstractWhiteboardTestServlet.java
+++ b/bundles/org.eclipse.equinox.http.servlet.tests/bundles_src/tb1/org/eclipse/equinox/http/servlet/tests/tb/AbstractWhiteboardTestServlet.java
@@ -30,13 +30,8 @@ public class AbstractWhiteboardTestServlet extends HttpServlet {
 
 	@Override
 	protected void service(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-		PrintWriter writer = response.getWriter();
-
-		try {
+		try (PrintWriter writer = response.getWriter()) {
 			handleDoGet(request, writer);
-		}
-		finally {
-			writer.close();
 		}
 	}
 

--- a/bundles/org.eclipse.equinox.http.servlet.tests/bundles_src/tb1/org/eclipse/equinox/http/servlet/tests/tb1/TestServlet10.java
+++ b/bundles/org.eclipse.equinox.http.servlet.tests/bundles_src/tb1/org/eclipse/equinox/http/servlet/tests/tb1/TestServlet10.java
@@ -37,21 +37,15 @@ public class TestServlet10 extends AbstractTestServlet {
 
 		ServletContext servletContext = getServletContext();
 
-		InputStream in = servletContext.getResourceAsStream(
+		try (InputStream in = servletContext.getResourceAsStream(
 			"/org/eclipse/equinox/http/servlet/tests/tb1/resource1.txt");
-		OutputStream out = response.getOutputStream();
-
-		try {
+				OutputStream out = response.getOutputStream()) {
 			byte[] buffer = new byte[2048];
 			int bytesRead;
 
 			while ((bytesRead = in.read(buffer)) != -1) {
 				out.write(buffer, 0, bytesRead);
 			}
-		}
-		finally {
-			out.close();
-			in.close();
 		}
 	}
 

--- a/bundles/org.eclipse.equinox.http.servlet.tests/bundles_src/tb1/org/eclipse/equinox/http/servlet/tests/tb1/TestServlet11.java
+++ b/bundles/org.eclipse.equinox.http.servlet.tests/bundles_src/tb1/org/eclipse/equinox/http/servlet/tests/tb1/TestServlet11.java
@@ -39,21 +39,15 @@ public class TestServlet11 extends AbstractTestServlet {
 
 		ClassLoader classLoader = servletContext.getClassLoader();
 
-		InputStream in = classLoader.getResourceAsStream(
+		try (InputStream in = classLoader.getResourceAsStream(
 			"/org/eclipse/equinox/http/servlet/tests/tb1/resource1.txt");
-		OutputStream out = response.getOutputStream();
-
-		try {
+				OutputStream out = response.getOutputStream()) {
 			byte[] buffer = new byte[2048];
 			int bytesRead;
 
 			while ((bytesRead = in.read(buffer)) != -1) {
 				out.write(buffer, 0, bytesRead);
 			}
-		}
-		finally {
-			out.close();
-			in.close();
 		}
 	}
 

--- a/bundles/org.eclipse.equinox.http.servlet.tests/pom.xml
+++ b/bundles/org.eclipse.equinox.http.servlet.tests/pom.xml
@@ -19,7 +19,7 @@
   </parent>
   <groupId>org.eclipse.equinox</groupId>
   <artifactId>org.eclipse.equinox.http.servlet.tests</artifactId>
-  <version>1.8.400-SNAPSHOT</version>
+  <version>1.8.500-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <build>

--- a/bundles/org.eclipse.equinox.http.servlet.tests/src/org/eclipse/equinox/http/servlet/tests/util/BaseAsyncServlet.java
+++ b/bundles/org.eclipse.equinox.http.servlet.tests/src/org/eclipse/equinox/http/servlet/tests/util/BaseAsyncServlet.java
@@ -58,11 +58,7 @@ public class BaseAsyncServlet extends BaseServlet {
 
 		@Override
 		public void run() {
-			PrintWriter writer = null;
-
-			try {
-				writer = asyncContext.getResponse().getWriter();
-
+			try (PrintWriter writer = asyncContext.getResponse().getWriter()) {
 				writer.print(Thread.currentThread().getName());
 				writer.print(" - ");
 				writer.print(content);
@@ -71,10 +67,6 @@ public class BaseAsyncServlet extends BaseServlet {
 				ioe.printStackTrace();
 			}
 			finally {
-				if (writer != null) {
-					writer.close();
-				}
-
 				asyncContext.complete();
 			}
 		}

--- a/bundles/org.eclipse.equinox.http.servlet.tests/src/org/eclipse/equinox/http/servlet/tests/util/ServletRequestAdvisor.java
+++ b/bundles/org.eclipse.equinox.http.servlet.tests/src/org/eclipse/equinox/http/servlet/tests/util/ServletRequestAdvisor.java
@@ -154,11 +154,8 @@ public class ServletRequestAdvisor extends Object {
 		httpsConn.connect();
 
 		assertEquals("Request to the url " + spec + " was not successful", 200 , httpsConn.getResponseCode());
-		InputStream stream = httpsConn.getInputStream();
-		try {
+		try (InputStream stream = httpsConn.getInputStream()) {
 			return drain(stream);
-		} finally {
-			stream.close();
 		}
 	}
 

--- a/bundles/org.eclipse.equinox.http.servlet.tests/src/org/eclipse/equinox/http/servlet/tests/util/TestWBServlet.java
+++ b/bundles/org.eclipse.equinox.http.servlet.tests/src/org/eclipse/equinox/http/servlet/tests/util/TestWBServlet.java
@@ -36,11 +36,8 @@ public class TestWBServlet extends HttpServlet {
 
 	@Override
 	protected final void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-		PrintWriter writer = response.getWriter();
-		try {
+		try (PrintWriter writer = response.getWriter()) {
 			handleDoGet(request, writer);
-		} finally {
-			writer.close();
 		}
 	}
 

--- a/bundles/org.eclipse.equinox.http.servlet/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.http.servlet/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.equinox.http.servlet
-Bundle-Version: 1.7.200.qualifier
+Bundle-Version: 1.7.300.qualifier
 Bundle-Activator: org.eclipse.equinox.http.servlet.internal.Activator
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/Activator.java
+++ b/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/Activator.java
@@ -49,7 +49,7 @@ public class Activator
 
 	private static volatile BundleContext context;
 	private static ConcurrentMap<ProxyServlet, Object> registrations =
-		new ConcurrentHashMap<ProxyServlet, Object>();
+		new ConcurrentHashMap<>();
 
 	private ServiceTracker<HttpServlet, HttpTuple> serviceTracker;
 
@@ -89,7 +89,7 @@ public class Activator
 
 		processRegistrations();
 
-		serviceTracker = new ServiceTracker<HttpServlet, HttpTuple>(
+		serviceTracker = new ServiceTracker<>(
 			bundleContext, HttpServlet.class, this);
 
 		serviceTracker.open();
@@ -122,7 +122,7 @@ public class Activator
 			ServletContext servletContext = servletConfig.getServletContext();
 
 			Dictionary<String, Object> serviceProperties =
-				new Hashtable<String, Object>(3);
+				new Hashtable<>(3);
 
 			Enumeration<String> initparameterNames =
 				servletConfig.getInitParameterNames();
@@ -155,7 +155,7 @@ public class Activator
 					httpServiceEndpoints);
 			}
 			else {
-				List<String> httpServiceEndpoints = new ArrayList<String>();
+				List<String> httpServiceEndpoints = new ArrayList<>();
 
 				String contextPath = servletContext.getContextPath();
 
@@ -232,7 +232,7 @@ public class Activator
 	private String[] getHttpServiceEndpoints(
 		Dictionary<String, Object> serviceProperties, ServletContext servletContext, String servletName) {
 
-		List<String> httpServiceEndpoints = new ArrayList<String>();
+		List<String> httpServiceEndpoints = new ArrayList<>();
 
 		String contextPath = (String)serviceProperties.get(Const.CONTEXT_PATH);
 

--- a/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/HttpServiceImpl.java
+++ b/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/HttpServiceImpl.java
@@ -185,7 +185,7 @@ public class HttpServiceImpl implements HttpService, ExtendedHttpService {
 
 		if (httpContextHolder == null) {
 			String legacyId= httpContext.getClass().getName().replaceAll("[^a-zA-Z_0-9\\-]", "_") + "-" + generateLegacyId(); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-			Dictionary<String, Object> props = new Hashtable<String, Object>();
+			Dictionary<String, Object> props = new Hashtable<>();
 			props.put(HTTP_WHITEBOARD_CONTEXT_NAME, legacyId);
 			props.put(HTTP_WHITEBOARD_CONTEXT_PATH, "/"); //$NON-NLS-1$
 			props.put(HTTP_WHITEBOARD_TARGET, httpServiceRuntime.getTargetFilter());

--- a/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/HttpServiceRuntimeImpl.java
+++ b/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/HttpServiceRuntimeImpl.java
@@ -74,7 +74,7 @@ public class HttpServiceRuntimeImpl
 		this.listenerServiceFilter = createListenerFilter(consumingContext, parentServletContext);
 
 		this.parentServletContext = parentServletContext;
-		this.attributes = new UMDictionaryMap<String, Object>(attributes);
+		this.attributes = new UMDictionaryMap<>(attributes);
 		this.targetFilter = "(" + Activator.UNIQUE_SERVICE_ID + "=" + this.attributes.get(Activator.UNIQUE_SERVICE_ID) + ")";  //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 		this.httpSessionTracker = new HttpSessionTracker(this);
 		this.invalidatorReg = trackingContext.registerService(HttpSessionInvalidator.class, this.httpSessionTracker, attributes);
@@ -96,18 +96,18 @@ public class HttpServiceRuntimeImpl
 		loggerFactoryTracker.open();
 
 		contextServiceTracker =
-			new ServiceTracker<ServletContextHelper, AtomicReference<ContextController>>(
+			new ServiceTracker<>(
 				trackingContext, ServletContextHelper.class, this);
 
 		preprocessorServiceTracker =
-			new ServiceTracker<Preprocessor, AtomicReference<PreprocessorRegistration>>(
+			new ServiceTracker<>(
 				trackingContext, Preprocessor.class, new PreprocessorCustomizer(this));
 
 		contextPathCustomizerHolder = new ContextPathCustomizerHolder(consumingContext, contextServiceTracker);
-		contextPathAdaptorTracker = new ServiceTracker<ContextPathCustomizer, ContextPathCustomizer>(
+		contextPathAdaptorTracker = new ServiceTracker<>(
 			consumingContext, ContextPathCustomizer.class, contextPathCustomizerHolder);
 
-		Hashtable<String, Object> defaultContextProps = new Hashtable<String, Object>();
+		Hashtable<String, Object> defaultContextProps = new Hashtable<>();
 		defaultContextProps.put(HTTP_WHITEBOARD_CONTEXT_NAME, HTTP_WHITEBOARD_DEFAULT_CONTEXT_NAME);
 		defaultContextProps.put(Constants.SERVICE_RANKING, Integer.MIN_VALUE);
 		defaultContextProps.put(HTTP_WHITEBOARD_CONTEXT_PATH, Const.SLASH);
@@ -127,7 +127,7 @@ public class HttpServiceRuntimeImpl
 	public synchronized AtomicReference<ContextController> addingService(
 		ServiceReference<ServletContextHelper> serviceReference) {
 
-		AtomicReference<ContextController> result = new AtomicReference<ContextController>();
+		AtomicReference<ContextController> result = new AtomicReference<>();
 		if (!matches(serviceReference)) {
 			return result;
 		}
@@ -343,7 +343,7 @@ public class HttpServiceRuntimeImpl
 	private FailedErrorPageDTO[] getFailedErrorPageDTOs() {
 		Collection<FailedErrorPageDTO> fepDTOs = failedErrorPageDTOs.values();
 
-		List<FailedErrorPageDTO> copies = new ArrayList<FailedErrorPageDTO>();
+		List<FailedErrorPageDTO> copies = new ArrayList<>();
 
 		for (FailedErrorPageDTO failedErrorPageDTO : fepDTOs) {
 			copies.add(DTOUtil.clone(failedErrorPageDTO));
@@ -466,7 +466,7 @@ public class HttpServiceRuntimeImpl
 		int pos = requestURI.lastIndexOf('/');
 
 		do {
-			List<ContextController> contextControllers = new ArrayList<ContextController>();
+			List<ContextController> contextControllers = new ArrayList<>();
 
 			for (ContextController contextController : controllerMap.values()) {
 				if (contextController.getContextPath().equals(requestURI)) {
@@ -557,7 +557,7 @@ public class HttpServiceRuntimeImpl
 	private FailedFilterDTO[] getFailedFilterDTOs() {
 		Collection<FailedFilterDTO> ffDTOs = failedFilterDTOs.values();
 
-		List<FailedFilterDTO> copies = new ArrayList<FailedFilterDTO>();
+		List<FailedFilterDTO> copies = new ArrayList<>();
 
 		for (FailedFilterDTO failedFilterDTO : ffDTOs) {
 			copies.add(DTOUtil.clone(failedFilterDTO));
@@ -569,7 +569,7 @@ public class HttpServiceRuntimeImpl
 	private FailedListenerDTO[] getFailedListenerDTOs() {
 		Collection<FailedListenerDTO> flDTOs = failedListenerDTOs.values();
 
-		List<FailedListenerDTO> copies = new ArrayList<FailedListenerDTO>();
+		List<FailedListenerDTO> copies = new ArrayList<>();
 
 		for (FailedListenerDTO failedListenerDTO : flDTOs) {
 			copies.add(DTOUtil.clone(failedListenerDTO));
@@ -581,7 +581,7 @@ public class HttpServiceRuntimeImpl
 	private FailedResourceDTO[] getFailedResourceDTOs() {
 		Collection<FailedResourceDTO> frDTOs = failedResourceDTOs.values();
 
-		List<FailedResourceDTO> copies = new ArrayList<FailedResourceDTO>();
+		List<FailedResourceDTO> copies = new ArrayList<>();
 
 		for (FailedResourceDTO failedResourceDTO : frDTOs) {
 			copies.add(DTOUtil.clone(failedResourceDTO));
@@ -593,7 +593,7 @@ public class HttpServiceRuntimeImpl
 	private FailedServletContextDTO[] getFailedServletContextDTO() {
 		Collection<ExtendedFailedServletContextDTO> fscDTOs = failedServletContextDTOs.values();
 
-		List<FailedServletContextDTO> copies = new ArrayList<FailedServletContextDTO>();
+		List<FailedServletContextDTO> copies = new ArrayList<>();
 
 		for (FailedServletContextDTO failedServletContextDTO : fscDTOs) {
 			copies.add(DTOUtil.clone(failedServletContextDTO));
@@ -605,7 +605,7 @@ public class HttpServiceRuntimeImpl
 	private FailedServletDTO[] getFailedServletDTOs() {
 		Collection<FailedServletDTO> fsDTOs = failedServletDTOs.values();
 
-		List<FailedServletDTO> copies = new ArrayList<FailedServletDTO>();
+		List<FailedServletDTO> copies = new ArrayList<>();
 
 		for (FailedServletDTO failedServletDTO : fsDTOs) {
 			copies.add(DTOUtil.clone(failedServletDTO));
@@ -617,7 +617,7 @@ public class HttpServiceRuntimeImpl
 	private FailedPreprocessorDTO[] getFailedPreprocessorDTOs() {
 		Collection<FailedPreprocessorDTO> fpDTOs = failedPreprocessorDTOs.values();
 
-		List<FailedPreprocessorDTO> copies = new ArrayList<FailedPreprocessorDTO>();
+		List<FailedPreprocessorDTO> copies = new ArrayList<>();
 
 		for (FailedPreprocessorDTO failedPreprocessorDTO : fpDTOs) {
 			copies.add(DTOUtil.clone(failedPreprocessorDTO));
@@ -627,7 +627,7 @@ public class HttpServiceRuntimeImpl
 	}
 
 	public ServletContextDTO[] getServletContextDTOs() {
-		List<ServletContextDTO> servletContextDTOs = new ArrayList<ServletContextDTO>();
+		List<ServletContextDTO> servletContextDTOs = new ArrayList<>();
 
 		for (ContextController contextController : controllerMap.values()) {
 			servletContextDTOs.add(contextController.getServletContextDTO());
@@ -637,7 +637,7 @@ public class HttpServiceRuntimeImpl
 	}
 
 	public PreprocessorDTO[] getPreprocessorDTOs() {
-		List<PreprocessorDTO> pDTOs = new ArrayList<PreprocessorDTO>();
+		List<PreprocessorDTO> pDTOs = new ArrayList<>();
 
 		for (PreprocessorRegistration registration : preprocessorMap.values()) {
 			pDTOs.add(registration.getD());
@@ -687,7 +687,7 @@ public class HttpServiceRuntimeImpl
 			HttpServiceObjectRegistration objectRegistration = null;
 			ServiceRegistration<Filter> registration = null;
 			try {
-				Dictionary<String, Object> props = new Hashtable<String, Object>();
+				Dictionary<String, Object> props = new Hashtable<>();
 				props.put(HTTP_WHITEBOARD_TARGET, targetFilter);
 				props.put(HTTP_WHITEBOARD_FILTER_PATTERN, alias);
 				props.put(HTTP_WHITEBOARD_FILTER_NAME, filterName);
@@ -707,7 +707,7 @@ public class HttpServiceRuntimeImpl
 				objectRegistration = new HttpServiceObjectRegistration(filter, registration, httpContextHolder, bundle);
 				Set<HttpServiceObjectRegistration> objectRegistrations = bundleRegistrations.get(bundle);
 				if (objectRegistrations == null) {
-					objectRegistrations = new HashSet<HttpServiceObjectRegistration>();
+					objectRegistrations = new HashSet<>();
 					bundleRegistrations.put(bundle, objectRegistrations);
 				}
 				objectRegistrations.add(objectRegistration);
@@ -796,7 +796,7 @@ public class HttpServiceRuntimeImpl
 				if (existing != null) {
 					throw new PatternInUseException(alias);
 				}
-				Dictionary<String, Object> props = new Hashtable<String, Object>();
+				Dictionary<String, Object> props = new Hashtable<>();
 				props.put(HTTP_WHITEBOARD_TARGET, targetFilter);
 				props.put(HTTP_WHITEBOARD_RESOURCE_PATTERN, pattern);
 				props.put(HTTP_WHITEBOARD_RESOURCE_PREFIX, name);
@@ -809,14 +809,14 @@ public class HttpServiceRuntimeImpl
 
 				Set<HttpServiceObjectRegistration> objectRegistrations = bundleRegistrations.get(bundle);
 				if (objectRegistrations == null) {
-					objectRegistrations = new HashSet<HttpServiceObjectRegistration>();
+					objectRegistrations = new HashSet<>();
 					bundleRegistrations.put(bundle, objectRegistrations);
 				}
 				objectRegistrations.add(objectRegistration);
 
 				Map<String, String> aliasCustomizations = bundleAliasCustomizations.get(bundle);
 				if (aliasCustomizations == null) {
-					aliasCustomizations = new HashMap<String, String>();
+					aliasCustomizations = new HashMap<>();
 					bundleAliasCustomizations.put(bundle, aliasCustomizations);
 				}
 				aliasCustomizations.put(alias, fullAlias);
@@ -879,7 +879,7 @@ public class HttpServiceRuntimeImpl
 					servletName = String.valueOf(initparams.get(Const.SERVLET_NAME));
 				}
 
-				Dictionary<String, Object> props = new Hashtable<String, Object>();
+				Dictionary<String, Object> props = new Hashtable<>();
 				props.put(HTTP_WHITEBOARD_TARGET, targetFilter);
 				props.put(HTTP_WHITEBOARD_SERVLET_PATTERN, pattern);
 				props.put(HTTP_WHITEBOARD_SERVLET_NAME, servletName);
@@ -897,14 +897,14 @@ public class HttpServiceRuntimeImpl
 
 				Set<HttpServiceObjectRegistration> objectRegistrations = bundleRegistrations.get(bundle);
 				if (objectRegistrations == null) {
-					objectRegistrations = new HashSet<HttpServiceObjectRegistration>();
+					objectRegistrations = new HashSet<>();
 					bundleRegistrations.put(bundle, objectRegistrations);
 				}
 				objectRegistrations.add(objectRegistration);
 
 				Map<String, String> aliasCustomizations = bundleAliasCustomizations.get(bundle);
 				if (aliasCustomizations == null) {
-					aliasCustomizations = new HashMap<String, String>();
+					aliasCustomizations = new HashMap<>();
 					bundleAliasCustomizations.put(bundle, aliasCustomizations);
 				}
 				aliasCustomizations.put(alias, fullAlias);
@@ -1305,33 +1305,33 @@ public class HttpServiceRuntimeImpl
 
 	// BEGIN of old HttpService support
 	final ConcurrentMap<HttpContext, HttpContextHolder> legacyContextMap =
-		new ConcurrentHashMap<HttpContext, HttpContextHolder>();
+		new ConcurrentHashMap<>();
 	private final Map<Object, HttpServiceObjectRegistration> legacyMappings =
 		Collections.synchronizedMap(new HashMap<Object, HttpServiceObjectRegistration>());
 	private final Map<Bundle, Set<HttpServiceObjectRegistration>> bundleRegistrations =
-		new HashMap<Bundle, Set<HttpServiceObjectRegistration>>();
-	private final Map<Bundle, Map<String, String>> bundleAliasCustomizations = new HashMap<Bundle, Map<String,String>>();
+		new HashMap<>();
+	private final Map<Bundle, Map<String, String>> bundleAliasCustomizations = new HashMap<>();
 	// END of old HttpService support
 
 	private final ConcurrentMap<ServiceReference<ServletContextHelper>, ContextController> controllerMap =
-		new ConcurrentSkipListMap<ServiceReference<ServletContextHelper>, ContextController>(Collections.reverseOrder());
+		new ConcurrentSkipListMap<>(Collections.reverseOrder());
 	private final ConcurrentMap<ServiceReference<Preprocessor>, PreprocessorRegistration> preprocessorMap =
-		new ConcurrentSkipListMap<ServiceReference<Preprocessor>, PreprocessorRegistration>(Collections.reverseOrder());
+		new ConcurrentSkipListMap<>(Collections.reverseOrder());
 
 	final ConcurrentMap<ServiceReference<?>, FailedErrorPageDTO> failedErrorPageDTOs =
-		new ConcurrentHashMap<ServiceReference<?>, FailedErrorPageDTO>();
+		new ConcurrentHashMap<>();
 	final ConcurrentMap<ServiceReference<Filter>, FailedFilterDTO> failedFilterDTOs =
-		new ConcurrentHashMap<ServiceReference<Filter>, FailedFilterDTO>();
+		new ConcurrentHashMap<>();
 	final ConcurrentMap<ServiceReference<EventListener>, FailedListenerDTO> failedListenerDTOs =
-		new ConcurrentHashMap<ServiceReference<EventListener>, FailedListenerDTO>();
+		new ConcurrentHashMap<>();
 	final ConcurrentMap<ServiceReference<?>, FailedResourceDTO> failedResourceDTOs =
-		new ConcurrentHashMap<ServiceReference<?>, FailedResourceDTO>();
+		new ConcurrentHashMap<>();
 	final ConcurrentMap<ServiceReference<ServletContextHelper>, ExtendedFailedServletContextDTO> failedServletContextDTOs =
-		new ConcurrentHashMap<ServiceReference<ServletContextHelper>, ExtendedFailedServletContextDTO>();
+		new ConcurrentHashMap<>();
 	final ConcurrentMap<ServiceReference<?>, FailedServletDTO> failedServletDTOs =
-		new ConcurrentHashMap<ServiceReference<?>, FailedServletDTO>();
+		new ConcurrentHashMap<>();
 	final ConcurrentMap<ServiceReference<?>, FailedPreprocessorDTO> failedPreprocessorDTOs =
-		new ConcurrentHashMap<ServiceReference<?>, FailedPreprocessorDTO>();
+		new ConcurrentHashMap<>();
 
 	private final Set<Object> registeredObjects = Collections.newSetFromMap(new ConcurrentHashMap<Object, Boolean>());
 	private final ServiceTracker<LoggerFactory, Logger> loggerFactoryTracker;
@@ -1363,7 +1363,7 @@ public class HttpServiceRuntimeImpl
 	}
 
 	static class LegacyServiceObject {
-		final AtomicReference<Exception> error = new AtomicReference<Exception>(new ServletException("The init() method was never called.")); //$NON-NLS-1$
+		final AtomicReference<Exception> error = new AtomicReference<>(new ServletException("The init() method was never called.")); //$NON-NLS-1$
 		public void checkForError() {
 			Exception result = error.get();
 			if (result != null) {
@@ -1485,7 +1485,7 @@ public class HttpServiceRuntimeImpl
 		private final BundleContext context;
 		private final ServiceTracker<ServletContextHelper, AtomicReference<ContextController>> contextServiceTracker;
 		private final NavigableMap<ServiceReference<ContextPathCustomizer>, ContextPathCustomizer> pathCustomizers =
-			new TreeMap<ServiceReference<ContextPathCustomizer>, ContextPathCustomizer>(Collections.reverseOrder());
+			new TreeMap<>(Collections.reverseOrder());
 
 		public ContextPathCustomizerHolder(
 			BundleContext context,

--- a/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/PreprocessorCustomizer.java
+++ b/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/PreprocessorCustomizer.java
@@ -45,7 +45,7 @@ public class PreprocessorCustomizer
 	public AtomicReference<PreprocessorRegistration> addingService(
 		ServiceReference<Preprocessor> serviceReference) {
 
-		AtomicReference<PreprocessorRegistration> result = new AtomicReference<PreprocessorRegistration>();
+		AtomicReference<PreprocessorRegistration> result = new AtomicReference<>();
 		if (!httpServiceRuntime.matches(serviceReference)) {
 			return result;
 		}
@@ -117,7 +117,7 @@ public class PreprocessorCustomizer
 	private PreprocessorRegistration addPreprocessorRegistration(
 		ServiceReference<Preprocessor> preprocessorRef) throws ServletException {
 
-		ServiceHolder<Preprocessor> preprocessorHolder = new ServiceHolder<Preprocessor>(httpServiceRuntime.getConsumingContext().getServiceObjects(preprocessorRef));
+		ServiceHolder<Preprocessor> preprocessorHolder = new ServiceHolder<>(httpServiceRuntime.getConsumingContext().getServiceObjects(preprocessorRef));
 		Preprocessor preprocessor = preprocessorHolder.get();
 		PreprocessorRegistration registration = null;
 		boolean addedRegisteredObject = false;

--- a/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/context/ContextController.java
+++ b/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/context/ContextController.java
@@ -65,35 +65,35 @@ public class ContextController {
 		this.initParams = ServiceProperties.parseInitParams(
 			serviceReference, HTTP_WHITEBOARD_CONTEXT_INIT_PARAM_PREFIX, parentServletContext);
 
-		listenerServiceTracker = new ServiceTracker<EventListener, AtomicReference<ListenerRegistration>>(
+		listenerServiceTracker = new ServiceTracker<>(
 			trackingContext, httpServiceRuntime.getListenerFilter(),
 			new ContextListenerTrackerCustomizer(
 				trackingContext, httpServiceRuntime, this));
 
 		listenerServiceTracker.open();
 
-		filterServiceTracker = new ServiceTracker<Filter, AtomicReference<FilterRegistration>>(
+		filterServiceTracker = new ServiceTracker<>(
 			trackingContext, httpServiceRuntime.getFilterFilter(),
 			new ContextFilterTrackerCustomizer(
 				trackingContext, httpServiceRuntime, this));
 
 		filterServiceTracker.open();
 
-		errorPageServiceTracker =  new ServiceTracker<Servlet, AtomicReference<ErrorPageRegistration>>(
+		errorPageServiceTracker =  new ServiceTracker<>(
 			trackingContext, httpServiceRuntime.getErrorPageFilter(),
 			new ContextErrorPageTrackerCustomizer(
 				trackingContext, httpServiceRuntime, this));
 
 		errorPageServiceTracker.open();
 
-		servletServiceTracker =  new ServiceTracker<Servlet, AtomicReference<ServletRegistration>>(
+		servletServiceTracker =  new ServiceTracker<>(
 			trackingContext, httpServiceRuntime.getServletFilter(),
 			new ContextServletTrackerCustomizer(
 				trackingContext, httpServiceRuntime, this));
 
 		servletServiceTracker.open();
 
-		resourceServiceTracker = new ServiceTracker<Object, AtomicReference<ResourceRegistration>>(
+		resourceServiceTracker = new ServiceTracker<>(
 			trackingContext, httpServiceRuntime.getResourceFilter(),
 			new ContextResourceTrackerCustomizer(
 				trackingContext, httpServiceRuntime, this));
@@ -102,7 +102,7 @@ public class ContextController {
 	}
 
 	public ErrorPageRegistration addErrorPageRegistration(ServiceReference<Servlet> servletRef) {
-		ServiceHolder<Servlet> servletHolder = new ServiceHolder<Servlet>(consumingContext.getServiceObjects(servletRef));
+		ServiceHolder<Servlet> servletHolder = new ServiceHolder<>(consumingContext.getServiceObjects(servletRef));
 		Servlet servlet = servletHolder.get();
 		ErrorPageRegistration registration = null;
 		//boolean addedRegisteredObject = false;
@@ -172,7 +172,7 @@ public class ContextController {
 	}
 
 	public FilterRegistration addFilterRegistration(ServiceReference<Filter> filterRef) throws ServletException {
-		ServiceHolder<Filter> filterHolder = new ServiceHolder<Filter>(consumingContext.getServiceObjects(filterRef));
+		ServiceHolder<Filter> filterHolder = new ServiceHolder<>(consumingContext.getServiceObjects(filterRef));
 		Filter filter = filterHolder.get();
 		FilterRegistration registration = null;
 		boolean addedRegisteredObject = false;
@@ -284,7 +284,7 @@ public class ContextController {
 	}
 
 	public ListenerRegistration addListenerRegistration(ServiceReference<EventListener> listenerRef) throws ServletException {
-		ServiceHolder<EventListener> listenerHolder = new ServiceHolder<EventListener>(consumingContext.getServiceObjects(listenerRef));
+		ServiceHolder<EventListener> listenerHolder = new ServiceHolder<>(consumingContext.getServiceObjects(listenerRef));
 		EventListener listener = listenerHolder.get();
 		ListenerRegistration registration = null;
 		try {
@@ -397,7 +397,7 @@ public class ContextController {
 		ServletContext servletContext = createServletContext(
 			bundle, curServletContextHelper);
 		ResourceRegistration resourceRegistration = new ResourceRegistration(
-			resourceRef, new ServiceHolder<Servlet>(servlet, bundle, serviceId, serviceRanking, legacyTCCL),
+			resourceRef, new ServiceHolder<>(servlet, bundle, serviceId, serviceRanking, legacyTCCL),
 			resourceDTO, curServletContextHelper, this);
 		ServletConfig servletConfig = new ServletConfigImpl(
 			resourceRegistration.getName(), new HashMap<String, String>(),
@@ -420,7 +420,7 @@ public class ContextController {
 	}
 
 	public ServletRegistration addServletRegistration(ServiceReference<Servlet> servletRef) {
-		ServiceHolder<Servlet> servletHolder = new ServiceHolder<Servlet>(consumingContext.getServiceObjects(servletRef));
+		ServiceHolder<Servlet> servletHolder = new ServiceHolder<>(consumingContext.getServiceObjects(servletRef));
 		Servlet servlet = servletHolder.get();
 		ServletRegistration registration = null;
 		boolean addedRegisteredObject = false;
@@ -498,7 +498,7 @@ public class ContextController {
 	}
 
 	private void recordEndpointShadowing(EndpointRegistration<?> newRegistration) {
-		Set<EndpointRegistration<?>> shadowedRegs = new HashSet<EndpointRegistration<?>>();
+		Set<EndpointRegistration<?>> shadowedRegs = new HashSet<>();
 		for (EndpointRegistration<?> existingRegistration : endpointRegistrations) {
 			for (String newPattern : newRegistration.getPatterns()) {
 				for (String existingPattern : existingRegistration.getPatterns()) {
@@ -527,7 +527,7 @@ public class ContextController {
 	}
 
 	private void recordErrorPageShadowing(ErrorPageRegistration newRegistration) {
-		Set<ErrorPageRegistration> shadowedEPs = new HashSet<ErrorPageRegistration>();
+		Set<ErrorPageRegistration> shadowedEPs = new HashSet<>();
 		for (EndpointRegistration<?> existingRegistration : endpointRegistrations) {
 			if (!(existingRegistration instanceof ErrorPageRegistration)) {
 				continue;
@@ -748,7 +748,7 @@ public class ContextController {
 		}
 
 		List<FilterRegistration> matchingFilterRegistrations =
-			new ArrayList<FilterRegistration>();
+			new ArrayList<>();
 
 		collectFilters(
 			matchingFilterRegistrations, endpointRegistration.getName(), requestURI,
@@ -850,7 +850,7 @@ public class ContextController {
 
 		servletContextDTO.attributes = getDTOAttributes(servletContext);
 		servletContextDTO.contextPath = getContextPath();
-		servletContextDTO.initParams = new HashMap<String, String>(initParams);
+		servletContextDTO.initParams = new HashMap<>(initParams);
 		servletContextDTO.name = getContextName();
 		servletContextDTO.serviceId = getServiceId();
 
@@ -967,7 +967,7 @@ public class ContextController {
 			return;
 		}
 
-		List<FilterDTO> filterDTOs = new ArrayList<FilterDTO>();
+		List<FilterDTO> filterDTOs = new ArrayList<>();
 
 		for (FilterRegistration filterRegistration : matchedFilterRegistrations) {
 			if (Arrays.binarySearch(filterRegistration.getD().dispatcher, DispatcherType.REQUEST.toString()) > -1) {
@@ -1094,9 +1094,9 @@ public class ContextController {
 	private void collectEndpointDTOs(
 		ServletContextDTO servletContextDTO) {
 
-		List<ErrorPageDTO> errorPageDTOs = new ArrayList<ErrorPageDTO>();
-		List<ResourceDTO> resourceDTOs = new ArrayList<ResourceDTO>();
-		List<ServletDTO> servletDTOs = new ArrayList<ServletDTO>();
+		List<ErrorPageDTO> errorPageDTOs = new ArrayList<>();
+		List<ResourceDTO> resourceDTOs = new ArrayList<>();
+		List<ServletDTO> servletDTOs = new ArrayList<>();
 
 		for (EndpointRegistration<?> endpointRegistration : endpointRegistrations) {
 			if (endpointRegistration instanceof ResourceRegistration) {
@@ -1124,7 +1124,7 @@ public class ContextController {
 	private void collectFilterDTOs(
 		ServletContextDTO servletContextDTO) {
 
-		List<FilterDTO> filterDTOs = new ArrayList<FilterDTO>();
+		List<FilterDTO> filterDTOs = new ArrayList<>();
 
 		for (FilterRegistration filterRegistration : filterRegistrations) {
 			filterDTOs.add(DTOUtil.clone(filterRegistration.getD()));
@@ -1136,7 +1136,7 @@ public class ContextController {
 	private void collectListenerDTOs(
 		ServletContextDTO servletContextDTO) {
 
-		List<ListenerDTO> listenerDTOs = new ArrayList<ListenerDTO>();
+		List<ListenerDTO> listenerDTOs = new ArrayList<>();
 
 		for (ListenerRegistration listenerRegistration : listenerRegistrations) {
 			listenerDTOs.add(DTOUtil.clone(listenerRegistration.getD()));
@@ -1146,7 +1146,7 @@ public class ContextController {
 	}
 
 	private Map<String, Object> getDTOAttributes(ServletContext servletContext) {
-		Map<String, Object> map = new HashMap<String, Object>();
+		Map<String, Object> map = new HashMap<>();
 
 		for (Enumeration<String> names = servletContext.getAttributeNames();
 				names.hasMoreElements();) {
@@ -1165,7 +1165,7 @@ public class ContextController {
 		List<String> objectClassList = StringPlus.from(listenerReference.getProperty(Constants.OBJECTCLASS));
 
 		List<Class<? extends EventListener>> classes =
-			new ArrayList<Class<? extends EventListener>>();
+			new ArrayList<>();
 
 		if (objectClassList.contains(ServletContextListener.class.getName())) {
 			classes.add(ServletContextListener.class);
@@ -1456,13 +1456,13 @@ public class ContextController {
 	private final String contextPath;
 	private volatile String fullContextPath;
 	private final long contextServiceId;
-	private final Set<EndpointRegistration<?>> endpointRegistrations = new ConcurrentSkipListSet<EndpointRegistration<?>>();
+	private final Set<EndpointRegistration<?>> endpointRegistrations = new ConcurrentSkipListSet<>();
 	private final EventListeners eventListeners = new EventListeners();
-	private final Set<FilterRegistration> filterRegistrations = new ConcurrentSkipListSet<FilterRegistration>();
-	private final ConcurrentMap<String, HttpSessionAdaptor> activeSessions = new ConcurrentHashMap<String, HttpSessionAdaptor>();
+	private final Set<FilterRegistration> filterRegistrations = new ConcurrentSkipListSet<>();
+	private final ConcurrentMap<String, HttpSessionAdaptor> activeSessions = new ConcurrentHashMap<>();
 
 	private final HttpServiceRuntimeImpl httpServiceRuntime;
-	private final Set<ListenerRegistration> listenerRegistrations = new HashSet<ListenerRegistration>();
+	private final Set<ListenerRegistration> listenerRegistrations = new HashSet<>();
 	private final ProxyContext proxyContext;
 	private final ServiceReference<ServletContextHelper> serviceReference;
 	private final String servletContextHelperRefFilter;

--- a/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/context/DispatchTargets.java
+++ b/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/context/DispatchTargets.java
@@ -209,11 +209,11 @@ public class DispatchTargets {
 
 	private static Map<String, String[]> queryStringToParameterMap(String queryString) {
 		if ((queryString == null) || (queryString.length() == 0)) {
-			return new LinkedHashMap<String, String[]>();
+			return new LinkedHashMap<>();
 		}
 
 		try {
-			Map<String, String[]> parameterMap = new LinkedHashMap<String, String[]>();
+			Map<String, String[]> parameterMap = new LinkedHashMap<>();
 			String[] parameters = queryString.split(Const.AMP);
 			for (String parameter : parameters) {
 				int index = parameter.indexOf('=');
@@ -236,7 +236,7 @@ public class DispatchTargets {
 	private static class RequestAttributeSetter implements Closeable {
 
 		private final ServletRequest servletRequest;
-		private final Map<String, Object> oldValues = new HashMap<String, Object>();
+		private final Map<String, Object> oldValues = new HashMap<>();
 
 		public RequestAttributeSetter(ServletRequest servletRequest) {
 			this.servletRequest = servletRequest;
@@ -274,7 +274,7 @@ public class DispatchTargets {
 	private final String requestURI;
 	private final String servletPath;
 	private final String servletName;
-	private final Map<String, Object> specialOverides = new ConcurrentHashMap<String, Object>();
+	private final Map<String, Object> specialOverides = new ConcurrentHashMap<>();
 	private String string;
 
 }

--- a/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/context/ProxyContext.java
+++ b/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/context/ProxyContext.java
@@ -36,7 +36,7 @@ public class ProxyContext {
 	private static final String JAVAX_SERVLET_CONTEXT_TEMPDIR = "javax.servlet.context.tempdir"; //$NON-NLS-1$
 
 	private final ConcurrentMap<ContextController, ContextAttributes> attributesMap =
-		new ConcurrentHashMap<ContextController, ContextAttributes>();
+		new ConcurrentHashMap<>();
 	File proxyContextTempDir;
 	private ServletContext servletContext;
 
@@ -194,7 +194,7 @@ public class ProxyContext {
 		}
 
 		private final Map<String, Object> _map =
-			new ConcurrentHashMap<String, Object>();
+			new ConcurrentHashMap<>();
 	}
 
 }

--- a/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/context/WrappedHttpContext.java
+++ b/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/context/WrappedHttpContext.java
@@ -65,7 +65,7 @@ public class WrappedHttpContext extends DefaultServletContextHelper {
 			return null;
 		}
 
-		final Set<String> result = new HashSet<String>();
+		final Set<String> result = new HashSet<>();
 
 		while (enumeration.hasMoreElements()) {
 			result.add(enumeration.nextElement().getPath());

--- a/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/customizer/ContextErrorPageTrackerCustomizer.java
+++ b/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/customizer/ContextErrorPageTrackerCustomizer.java
@@ -47,7 +47,7 @@ public class ContextErrorPageTrackerCustomizer
 	public AtomicReference<ErrorPageRegistration>
 		addingService(ServiceReference<Servlet> serviceReference) {
 
-		AtomicReference<ErrorPageRegistration> result = new AtomicReference<ErrorPageRegistration>();
+		AtomicReference<ErrorPageRegistration> result = new AtomicReference<>();
 		if (!httpServiceRuntime.matches(serviceReference)) {
 			return result;
 		}

--- a/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/customizer/ContextFilterTrackerCustomizer.java
+++ b/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/customizer/ContextFilterTrackerCustomizer.java
@@ -43,7 +43,7 @@ public class ContextFilterTrackerCustomizer
 	public AtomicReference<FilterRegistration> addingService(
 		ServiceReference<Filter> serviceReference) {
 
-		AtomicReference<FilterRegistration> result = new AtomicReference<FilterRegistration>();
+		AtomicReference<FilterRegistration> result = new AtomicReference<>();
 		if (!httpServiceRuntime.matches(serviceReference)) {
 			return result;
 		}

--- a/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/customizer/ContextListenerTrackerCustomizer.java
+++ b/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/customizer/ContextListenerTrackerCustomizer.java
@@ -43,7 +43,7 @@ public class ContextListenerTrackerCustomizer
 	public AtomicReference<ListenerRegistration> addingService(
 		ServiceReference<EventListener> serviceReference) {
 
-		AtomicReference<ListenerRegistration> result = new AtomicReference<ListenerRegistration>();
+		AtomicReference<ListenerRegistration> result = new AtomicReference<>();
 		if (!httpServiceRuntime.matches(serviceReference)) {
 			return result;
 		}

--- a/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/customizer/ContextResourceTrackerCustomizer.java
+++ b/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/customizer/ContextResourceTrackerCustomizer.java
@@ -46,7 +46,7 @@ public class ContextResourceTrackerCustomizer
 	public AtomicReference<ResourceRegistration> addingService(
 		ServiceReference<Object> serviceReference) {
 
-		AtomicReference<ResourceRegistration> result = new AtomicReference<ResourceRegistration>();
+		AtomicReference<ResourceRegistration> result = new AtomicReference<>();
 		if (!httpServiceRuntime.matches(serviceReference)) {
 			return result;
 		}

--- a/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/customizer/ContextServletTrackerCustomizer.java
+++ b/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/customizer/ContextServletTrackerCustomizer.java
@@ -46,7 +46,7 @@ public class ContextServletTrackerCustomizer
 	public AtomicReference<ServletRegistration> addingService(
 		ServiceReference<Servlet> serviceReference) {
 
-		AtomicReference<ServletRegistration> result = new AtomicReference<ServletRegistration>();
+		AtomicReference<ServletRegistration> result = new AtomicReference<>();
 		if (!httpServiceRuntime.matches(serviceReference)) {
 			return result;
 		}

--- a/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/multipart/MultipartSupportImpl.java
+++ b/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/multipart/MultipartSupportImpl.java
@@ -93,7 +93,7 @@ public class MultipartSupportImpl implements MultipartSupport {
 			throw new ServletException("Not a multipart request!"); //$NON-NLS-1$
 		}
 
-		ArrayList<Part> parts = new ArrayList<Part>();
+		ArrayList<Part> parts = new ArrayList<>();
 
 		try {
 			for (Object item : upload.parseRequest(request)) {

--- a/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/multipart/MultipartSupportPart.java
+++ b/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/multipart/MultipartSupportPart.java
@@ -96,7 +96,7 @@ public class MultipartSupportPart implements Part {
 	private class IteratorCollection extends AbstractList<String> {
 
 		public IteratorCollection(Iterator<String> iterator) {
-			this.collection = new ArrayList<String>();
+			this.collection = new ArrayList<>();
 			while (iterator.hasNext()) {
 				collection.add(iterator.next());
 			}

--- a/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/servlet/HttpServletRequestWrapperImpl.java
+++ b/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/servlet/HttpServletRequestWrapperImpl.java
@@ -33,12 +33,12 @@ import org.osgi.service.http.HttpContext;
 
 public class HttpServletRequestWrapperImpl extends HttpServletRequestWrapper {
 
-	private final Deque<DispatchTargets> dispatchTargets = new LinkedList<DispatchTargets>();
+	private final Deque<DispatchTargets> dispatchTargets = new LinkedList<>();
 	private final HttpServletRequest request;
 	private List<Part> parts;
 	private final Lock lock = new ReentrantLock();
 
-	private static final Set<String> dispatcherAttributes =	new HashSet<String>();
+	private static final Set<String> dispatcherAttributes =	new HashSet<>();
 
 	static {
 		dispatcherAttributes.add(RequestDispatcher.ERROR_EXCEPTION);
@@ -451,7 +451,7 @@ public class HttpServletRequestWrapperImpl extends HttpServletRequestWrapper {
 
 	@Override
 	public Collection<Part> getParts() throws IOException, ServletException {
-		return new ArrayList<Part>(getParts0());
+		return new ArrayList<>(getParts0());
 	}
 
 	public AsyncContext startAsync() throws IllegalStateException {

--- a/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/servlet/HttpSessionAdaptor.java
+++ b/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/servlet/HttpSessionAdaptor.java
@@ -66,7 +66,7 @@ public class HttpSessionAdaptor implements HttpSession, Serializable {
 	}
 
 	private Collection<String> getAttributeNames0() {
-		Collection<String> result = new ArrayList<String>();
+		Collection<String> result = new ArrayList<>();
 		Enumeration<String> containerSessionAttributes = session.getAttributeNames();
 		while(containerSessionAttributes.hasMoreElements()) {
 			String attribute = containerSessionAttributes.nextElement();

--- a/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/servlet/HttpSessionTracker.java
+++ b/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/servlet/HttpSessionTracker.java
@@ -113,7 +113,7 @@ public class HttpSessionTracker implements HttpSessionInvalidator {
 
 	private final ConcurrentMap<String, Set<HttpSessionAdaptor>>
 		httpSessionAdaptorsMap =
-			new ConcurrentHashMap<String, Set<HttpSessionAdaptor>>();
+			new ConcurrentHashMap<>();
 	private final HttpServiceRuntimeImpl httpServiceRuntime;
 
 }

--- a/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/servlet/ResourceServlet.java
+++ b/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/servlet/ResourceServlet.java
@@ -163,12 +163,7 @@ public class ResourceServlet extends HttpServlet {
 								// of a message when we use a Writer we lose control of the exact byte count and
 								// defer the problem to the Servlet Engine's Writer implementation.
 							}
-						} catch (FileNotFoundException e) {
-							// FileNotFoundException may indicate the following scenarios
-							// - url is a directory
-							// - url is not accessible
-							sendError(resp, HttpServletResponse.SC_FORBIDDEN);
-						} catch (SecurityException e) {
+						} catch (FileNotFoundException | SecurityException e) {
 							// SecurityException may indicate the following scenarios
 							// - url is not accessible
 							sendError(resp, HttpServletResponse.SC_FORBIDDEN);

--- a/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/servlet/ServletContextAdaptor.java
+++ b/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/servlet/ServletContextAdaptor.java
@@ -39,7 +39,7 @@ public class ServletContextAdaptor {
 	}
 
 	private static Map<Method, Method> createContextToHandlerMethods() {
-		Map<Method, Method> methods = new HashMap<Method, Method>();
+		Map<Method, Method> methods = new HashMap<>();
 		Method[] handlerMethods =
 			ServletContextAdaptor.class.getDeclaredMethods();
 
@@ -449,7 +449,7 @@ public class ServletContextAdaptor {
 	private final static String SIMPLE_NAME =
 		ServletContextAdaptor.class.getSimpleName();
 
-	private final static ThreadLocal<ServletContext> servletContextTL = new ThreadLocal<ServletContext>();
+	private final static ThreadLocal<ServletContext> servletContextTL = new ThreadLocal<>();
 
 	private final AccessControlContext acc;
 	private final Bundle bundle;

--- a/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/util/DTOUtil.java
+++ b/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/util/DTOUtil.java
@@ -58,8 +58,8 @@ public class DTOUtil {
 			throw new HttpWhiteboardFailureException("'errorPage' expects String, String[] or Collection<String>", DTOConstants.FAILURE_REASON_VALIDATION_FAILED); //$NON-NLS-1$
 		}
 
-		List<String> exceptions = new ArrayList<String>();
-		Set<Long> errorCodeSet = new LinkedHashSet<Long>();
+		List<String> exceptions = new ArrayList<>();
+		Set<Long> errorCodeSet = new LinkedHashSet<>();
 
 		for(String errorPage : errorPages) {
 			try {
@@ -471,14 +471,14 @@ public class DTOUtil {
 		if (initParams == null) {
 			return Collections.emptyMap();
 		}
-		return new HashMap<String, String>(initParams);
+		return new HashMap<>(initParams);
 	}
 
 	public static <V> Map<String, Object> copyGenericMap(Map<String, V> value) {
 		if ((value == null) || value.isEmpty()) {
 			return Collections.emptyMap();
 		}
-		HashMap<String, Object> result = new HashMap<String, Object>();
+		HashMap<String, Object> result = new HashMap<>();
 		for (Map.Entry<String, V> entry : value.entrySet()) {
 			result.put(entry.getKey(), mapValue(entry.getValue()));
 		}
@@ -580,15 +580,15 @@ public class DTOUtil {
 	}
 
 	private static <E> List<E> newList(int size) {
-		return new ArrayList<E>(size);
+		return new ArrayList<>(size);
 	}
 
 	private static <E> Set<E> newSet(int size) {
-		return new HashSet<E>(size);
+		return new HashSet<>(size);
 	}
 
 	private static <K, V> Map<K, V> newMap(int size) {
-		return new HashMap<K, V>(size);
+		return new HashMap<>(size);
 	}
 
 	private static String[] sort(String[] values) {

--- a/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/util/EventListeners.java
+++ b/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/util/EventListeners.java
@@ -35,7 +35,7 @@ public class EventListeners {
 			return Collections.emptyList();
 		}
 
-		return new ListenerList<E>(list) ;
+		return new ListenerList<>(list) ;
 	}
 
 	public <E extends EventListener> void put(
@@ -49,7 +49,7 @@ public class EventListeners {
 
 		if (list == null) {
 			final List<ListenerRegistration> newList =
-				new CopyOnWriteArrayList<ListenerRegistration>();
+				new CopyOnWriteArrayList<>();
 
 			list = map.putIfAbsent(clazz, newList);
 
@@ -96,7 +96,7 @@ public class EventListeners {
 	}
 
 	private ConcurrentMap<Class<? extends EventListener>, List<ListenerRegistration>> map =
-		new ConcurrentHashMap<Class<? extends EventListener>, List<ListenerRegistration>>();
+		new ConcurrentHashMap<>();
 
 	class ListenerList<R extends EventListener> extends AbstractList<R> {
 

--- a/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/util/ServiceProperties.java
+++ b/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/util/ServiceProperties.java
@@ -38,7 +38,7 @@ public class ServiceProperties {
 	static public Map<String, String> parseInitParams(
 		ServiceReference<?> serviceReference, String prefix, ServletContext parentContext) {
 
-		Map<String, String> initParams = new HashMap<String, String>();
+		Map<String, String> initParams = new HashMap<>();
 
 		if (parentContext != null) {
 			// use the parent context init params;

--- a/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/util/ServiceReferenceMap.java
+++ b/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/util/ServiceReferenceMap.java
@@ -25,7 +25,7 @@ public class ServiceReferenceMap extends AbstractMap<String, Object> {
 	public ServiceReferenceMap(ServiceReference<?> serviceReference) {
 		String[] propertyKeys = serviceReference.getPropertyKeys();
 
-		entries = new HashSet<Map.Entry<String,Object>>(propertyKeys.length);
+		entries = new HashSet<>(propertyKeys.length);
 
 		for (String key : propertyKeys) {
 			Map.Entry<String,Object> entry = new ReferenceEntry(

--- a/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/util/StringPlus.java
+++ b/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/util/StringPlus.java
@@ -35,7 +35,7 @@ public class StringPlus {
 			if (!collection.isEmpty() &&
 				String.class.isInstance(collection.iterator().next())) {
 
-				return new ArrayList<String>((Collection<String>)object);
+				return new ArrayList<>((Collection<String>)object);
 			}
 		}
 

--- a/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/util/UMDictionaryMap.java
+++ b/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/util/UMDictionaryMap.java
@@ -22,7 +22,7 @@ import java.util.*;
 public class UMDictionaryMap <K, V> implements Map<K, V> {
 
 	public UMDictionaryMap(Dictionary<K, V> dictionary) {
-		Map<K, V> map = new HashMap<K, V>();
+		Map<K, V> map = new HashMap<>();
 
 		if (dictionary != null) {
 			for (Enumeration<K> em = dictionary.keys(); em.hasMoreElements();) {

--- a/bundles/org.eclipse.equinox.http.servletbridge/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.http.servletbridge/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.equinox.http.servletbridge;singleton:=true
-Bundle-Version: 1.2.100.qualifier
+Bundle-Version: 1.2.200.qualifier
 Bundle-Activator: org.eclipse.equinox.http.servletbridge.internal.Activator
 Bundle-Localization: plugin
 Import-Package: javax.servlet;version="2.3",

--- a/bundles/org.eclipse.equinox.metatype/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.metatype/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
-Bundle-Version: 1.6.100.qualifier
+Bundle-Version: 1.6.200.qualifier
 Bundle-SymbolicName: org.eclipse.equinox.metatype
 Bundle-Activator: org.eclipse.equinox.metatype.impl.Activator
 Import-Package: javax.xml.parsers,

--- a/bundles/org.eclipse.equinox.metatype/pom.xml
+++ b/bundles/org.eclipse.equinox.metatype/pom.xml
@@ -19,7 +19,7 @@
 </parent>
   <groupId>org.eclipse.equinox</groupId>
   <artifactId>org.eclipse.equinox.metatype</artifactId>
-  <version>1.6.100-SNAPSHOT</version>
+  <version>1.6.200-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   <build>
     <plugins>

--- a/bundles/org.eclipse.equinox.metatype/src/org/eclipse/equinox/metatype/impl/Activator.java
+++ b/bundles/org.eclipse.equinox.metatype/src/org/eclipse/equinox/metatype/impl/Activator.java
@@ -59,8 +59,8 @@ public class Activator implements BundleActivator {
 		Filter filter = context.createFilter(FILTER);
 		synchronized (this) {
 			lsTracker = logServiceTracker = new LogTracker(context, System.out);
-			mtpTracker = metaTypeProviderTracker = new ServiceTracker<Object, Object>(context, filter, null);
-			spfTracker = saxParserFactoryTracker = new ServiceTracker<SAXParserFactory, SAXParserFactory>(context, SAXParserFactory.class, new SAXParserFactoryTrackerCustomizer(context, lsTracker, mtpTracker));
+			mtpTracker = metaTypeProviderTracker = new ServiceTracker<>(context, filter, null);
+			spfTracker = saxParserFactoryTracker = new ServiceTracker<>(context, SAXParserFactory.class, new SAXParserFactoryTrackerCustomizer(context, lsTracker, mtpTracker));
 		}
 		// Do this first to make logging available as early as possible.
 		lsTracker.open();
@@ -218,8 +218,8 @@ public class Activator implements BundleActivator {
 		}
 
 		private void registerMetaTypeService() {
-			Dictionary<String, Object> properties = new Hashtable<String, Object>(7);
-			properties = new Hashtable<String, Object>(7);
+			Dictionary<String, Object> properties = new Hashtable<>(7);
+			properties = new Hashtable<>(7);
 			properties.put(Constants.SERVICE_VENDOR, "IBM"); //$NON-NLS-1$
 			properties.put(Constants.SERVICE_DESCRIPTION, MetaTypeMsg.SERVICE_DESCRIPTION);
 			properties.put(Constants.SERVICE_PID, SERVICE_PID);

--- a/bundles/org.eclipse.equinox.metatype/src/org/eclipse/equinox/metatype/impl/AttributeDefinitionImpl.java
+++ b/bundles/org.eclipse.equinox.metatype/src/org/eclipse/equinox/metatype/impl/AttributeDefinitionImpl.java
@@ -41,8 +41,8 @@ public class AttributeDefinitionImpl extends LocalizationElement implements Equi
 	private final ExtendableHelper helper;
 
 	private volatile String[] _defaults = null;
-	private volatile ArrayList<String> _values = new ArrayList<String>(7);
-	private volatile ArrayList<String> _labels = new ArrayList<String>(7);
+	private volatile ArrayList<String> _values = new ArrayList<>(7);
+	private volatile ArrayList<String> _labels = new ArrayList<>(7);
 
 	/**
 	 * Constructor of class AttributeDefinitionImpl.

--- a/bundles/org.eclipse.equinox.metatype/src/org/eclipse/equinox/metatype/impl/DataParser.java
+++ b/bundles/org.eclipse.equinox.metatype/src/org/eclipse/equinox/metatype/impl/DataParser.java
@@ -162,7 +162,7 @@ public class DataParser {
 	private class AbstractHandler extends DefaultHandler {
 		protected ContentHandler _doc_handler;
 		protected boolean _isParsedDataValid = true;
-		protected Map<String, Map<String, String>> extensionAttributes = new HashMap<String, Map<String, String>>();
+		protected Map<String, Map<String, String>> extensionAttributes = new HashMap<>();
 		protected String elementId;
 		protected String elementName;
 
@@ -203,7 +203,7 @@ public class DataParser {
 					continue;
 				Map<String, String> value = extensionAttributes.get(key);
 				if (value == null) {
-					value = new HashMap<String, String>();
+					value = new HashMap<>();
 					extensionAttributes.put(key, value);
 				}
 				value.put(getName(attributes.getLocalName(i), attributes.getQName(i)), attributes.getValue(i));
@@ -321,8 +321,8 @@ public class DataParser {
 		// not the PID or FPID of this OCD.
 		String _refID;
 		ObjectClassDefinitionImpl _ocd;
-		List<AttributeDefinitionImpl> _ads = new ArrayList<AttributeDefinitionImpl>(7);
-		List<Icon> icons = new ArrayList<Icon>(5);
+		List<AttributeDefinitionImpl> _ads = new ArrayList<>(7);
+		List<Icon> icons = new ArrayList<>(5);
 
 		public OcdHandler(ContentHandler handler) {
 			super(handler);

--- a/bundles/org.eclipse.equinox.metatype/src/org/eclipse/equinox/metatype/impl/MetaTypeProviderImpl.java
+++ b/bundles/org.eclipse.equinox.metatype/src/org/eclipse/equinox/metatype/impl/MetaTypeProviderImpl.java
@@ -179,7 +179,7 @@ public class MetaTypeProviderImpl implements MetaTypeProvider {
 	public synchronized String[] getLocales() {
 		if (_locales != null)
 			return checkForDefault(_locales);
-		List<String> localizationFiles = new ArrayList<String>(7);
+		List<String> localizationFiles = new ArrayList<>(7);
 		// get all the localization resources for PIDS
 		for (ObjectClassDefinitionImpl ocd : _allPidOCDs.values()) {
 			String localization = ocd.getLocalization();
@@ -194,7 +194,7 @@ public class MetaTypeProviderImpl implements MetaTypeProvider {
 		}
 		if (localizationFiles.size() == 0)
 			localizationFiles.add(getBundleLocalization(_bundle));
-		Vector<String> locales = new Vector<String>(7);
+		Vector<String> locales = new Vector<>(7);
 		for (String localizationFile : localizationFiles) {
 			int iSlash = localizationFile.lastIndexOf(DIRECTORY_SEP);
 			String baseDir;

--- a/bundles/org.eclipse.equinox.metatype/src/org/eclipse/equinox/metatype/impl/MetaTypeProviderTracker.java
+++ b/bundles/org.eclipse.equinox.metatype/src/org/eclipse/equinox/metatype/impl/MetaTypeProviderTracker.java
@@ -47,7 +47,7 @@ public class MetaTypeProviderTracker implements EquinoxMetaTypeInformation {
 		if (_bundle.getState() != Bundle.ACTIVE)
 			return new String[0]; // return none if not active
 		MetaTypeProviderWrapper[] wrappers = getMetaTypeProviders();
-		ArrayList<String> results = new ArrayList<String>();
+		ArrayList<String> results = new ArrayList<>();
 		for (MetaTypeProviderWrapper wrapper : wrappers) {
 			// return only the correct type of pids (regular or factory)
 			if (factory == wrapper.factory) {
@@ -87,7 +87,7 @@ public class MetaTypeProviderTracker implements EquinoxMetaTypeInformation {
 		if (_bundle.getState() != Bundle.ACTIVE)
 			return new String[0]; // return none if not active
 		MetaTypeProviderWrapper[] wrappers = getMetaTypeProviders();
-		ArrayList<String> locales = new ArrayList<String>();
+		ArrayList<String> locales = new ArrayList<>();
 		// collect all the unique locales from all providers we found
 		for (MetaTypeProviderWrapper wrapper : wrappers) {
 			String[] wrappedLocales = wrapper.getLocales();
@@ -106,7 +106,7 @@ public class MetaTypeProviderTracker implements EquinoxMetaTypeInformation {
 		Map<ServiceReference<Object>, Object> services = _tracker.getTracked();
 		if (services.isEmpty())
 			return new MetaTypeProviderWrapper[0];
-		Set<MetaTypeProviderWrapper> result = new HashSet<MetaTypeProviderWrapper>();
+		Set<MetaTypeProviderWrapper> result = new HashSet<>();
 		for (Entry<ServiceReference<Object>, Object> entry : services.entrySet()) {
 			ServiceReference<Object> serviceReference = entry.getKey();
 			if (serviceReference.getBundle() == _bundle) {
@@ -233,7 +233,7 @@ public class MetaTypeProviderTracker implements EquinoxMetaTypeInformation {
 					AttributeDefinition[] ads = ocd.getAttributeDefinitions(filter);
 					if (ads == null || ads.length == 0)
 						return new EquinoxAttributeDefinition[0];
-					Collection<EquinoxAttributeDefinition> result = new ArrayList<EquinoxAttributeDefinition>(ads.length);
+					Collection<EquinoxAttributeDefinition> result = new ArrayList<>(ads.length);
 					for (final AttributeDefinition ad : ads) {
 						result.add(new EquinoxAttributeDefinition() {
 							public String getName() {

--- a/bundles/org.eclipse.equinox.metatype/src/org/eclipse/equinox/metatype/impl/MetaTypeServiceImpl.java
+++ b/bundles/org.eclipse.equinox.metatype/src/org/eclipse/equinox/metatype/impl/MetaTypeServiceImpl.java
@@ -34,7 +34,7 @@ import org.xml.sax.SAXException;
 public class MetaTypeServiceImpl implements EquinoxMetaTypeService, SynchronousBundleListener {
 	private static String CACHE_FILE = "metaTypeCache"; //$NON-NLS-1$
 	SAXParserFactory _parserFactory;
-	private Hashtable<Long, EquinoxMetaTypeInformation> _mtps = new Hashtable<Long, EquinoxMetaTypeInformation>(7);
+	private Hashtable<Long, EquinoxMetaTypeInformation> _mtps = new Hashtable<>(7);
 
 	private final LogTracker logger;
 	private final ServiceTracker<Object, Object> metaTypeProviderTracker;

--- a/bundles/org.eclipse.equinox.metatype/src/org/eclipse/equinox/metatype/impl/ObjectClassDefinitionImpl.java
+++ b/bundles/org.eclipse.equinox.metatype/src/org/eclipse/equinox/metatype/impl/ObjectClassDefinitionImpl.java
@@ -76,7 +76,7 @@ public class ObjectClassDefinitionImpl extends LocalizationElement implements Eq
 			ocd.addAttributeDefinition((AttributeDefinitionImpl) ad.clone(), false);
 		}
 		if (icons != null) {
-			ocd.setIcons(new ArrayList<Icon>(icons));
+			ocd.setIcons(new ArrayList<>(icons));
 		}
 		return ocd;
 	}

--- a/bundles/org.eclipse.equinox.metatype/src/org/eclipse/equinox/metatype/impl/ValueTokenizer.java
+++ b/bundles/org.eclipse.equinox.metatype/src/org/eclipse/equinox/metatype/impl/ValueTokenizer.java
@@ -24,7 +24,7 @@ public class ValueTokenizer {
 	private static final char ESCAPE = '\\';
 
 	private final LogTracker logger;
-	private final List<String> values = new ArrayList<String>();
+	private final List<String> values = new ArrayList<>();
 
 	/*
 	 * Constructor of class ValueTokenizer

--- a/bundles/org.eclipse.equinox.preferences/src/org/eclipse/core/internal/preferences/DefaultPreferences.java
+++ b/bundles/org.eclipse.equinox.preferences/src/org/eclipse/core/internal/preferences/DefaultPreferences.java
@@ -392,11 +392,7 @@ public class DefaultPreferences extends EclipsePreferences {
 		} catch (FileNotFoundException e) {
 			if (EclipsePreferences.DEBUG_PREFERENCE_GENERAL)
 				PrefsMessages.message("Preference customization file not found: " + filename); //$NON-NLS-1$
-		} catch (IOException e) {
-			String message = NLS.bind(PrefsMessages.preferences_loadException, filename);
-			IStatus status = new Status(IStatus.ERROR, PrefsMessages.OWNER_NAME, IStatus.ERROR, message, e);
-			RuntimeLog.log(status);
-		} catch (IllegalArgumentException e) {
+		} catch (IOException | IllegalArgumentException e) {
 			String message = NLS.bind(PrefsMessages.preferences_loadException, filename);
 			IStatus status = new Status(IStatus.ERROR, PrefsMessages.OWNER_NAME, IStatus.ERROR, message, e);
 			RuntimeLog.log(status);

--- a/bundles/org.eclipse.equinox.preferences/src/org/eclipse/core/internal/preferences/EclipsePreferences.java
+++ b/bundles/org.eclipse.equinox.preferences/src/org/eclipse/core/internal/preferences/EclipsePreferences.java
@@ -696,11 +696,7 @@ public class EclipsePreferences implements IEclipsePreferences, IScope {
 			if (DEBUG_PREFERENCE_GENERAL)
 				PrefsMessages.message("Preference file does not exist: " + location); //$NON-NLS-1$
 			return result;
-		} catch (IOException e) {
-			String message = NLS.bind(PrefsMessages.preferences_loadException, location);
-			log(new Status(IStatus.INFO, PrefsMessages.OWNER_NAME, IStatus.INFO, message, e));
-			throw new BackingStoreException(message, e);
-		} catch (IllegalArgumentException e) {
+		} catch (IOException | IllegalArgumentException e) {
 			String message = NLS.bind(PrefsMessages.preferences_loadException, location);
 			log(new Status(IStatus.INFO, PrefsMessages.OWNER_NAME, IStatus.INFO, message, e));
 			throw new BackingStoreException(message, e);

--- a/bundles/org.eclipse.equinox.preferences/src/org/eclipse/core/internal/preferences/PreferencesService.java
+++ b/bundles/org.eclipse.equinox.preferences/src/org/eclipse/core/internal/preferences/PreferencesService.java
@@ -892,9 +892,7 @@ public class PreferencesService implements IPreferencesService {
 		Properties properties = new Properties();
 		try {
 			properties.load(input);
-		} catch (IOException e) {
-			throw new CoreException(createStatusError(PrefsMessages.preferences_importProblems, e));
-		} catch (IllegalArgumentException e) {
+		} catch (IOException | IllegalArgumentException e) {
 			throw new CoreException(createStatusError(PrefsMessages.preferences_importProblems, e));
 		} finally {
 			try {
@@ -1113,9 +1111,7 @@ public class PreferencesService implements IPreferencesService {
 			prefs.accept(visitor);
 		} catch (FileNotFoundException e) {
 			// ignore...if the file does not exist then all is OK
-		} catch (CoreException e) {
-			result.add(createStatusError(PrefsMessages.preferences_validationException, e));
-		} catch (BackingStoreException e) {
+		} catch (CoreException | BackingStoreException e) {
 			result.add(createStatusError(PrefsMessages.preferences_validationException, e));
 		}
 		return result;

--- a/bundles/org.eclipse.equinox.region.tests/bundles_src/CapabilityProvider2/capabilityprovider2/Activator.java
+++ b/bundles/org.eclipse.equinox.region.tests/bundles_src/CapabilityProvider2/capabilityprovider2/Activator.java
@@ -23,11 +23,11 @@ public class Activator implements BundleActivator {
 
 	@Override
 	public void start(final BundleContext context) throws Exception {
-		new ServiceTracker<pkg1.a.A, pkg1.a.A>(context, pkg1.a.A.class, new ServiceTrackerCustomizer<pkg1.a.A, pkg1.a.A>() {
+		new ServiceTracker<>(context, pkg1.a.A.class, new ServiceTrackerCustomizer<pkg1.a.A, pkg1.a.A>() {
 
 			@Override
 			public pkg1.a.A addingService(ServiceReference<pkg1.a.A> reference) {
-				Dictionary<String, Object> props = new Hashtable<String, Object>();
+				Dictionary<String, Object> props = new Hashtable<>();
 				props.put("bundle.id", context.getBundle().getBundleId());
 				context.registerService(Boolean.class, Boolean.TRUE, props);
 				return null;

--- a/bundles/org.eclipse.equinox.region.tests/bundles_src/ServiceClient1/serviceclient1/Activator.java
+++ b/bundles/org.eclipse.equinox.region.tests/bundles_src/ServiceClient1/serviceclient1/Activator.java
@@ -23,11 +23,11 @@ public class Activator implements BundleActivator {
 
 	@Override
 	public void start(final BundleContext context) throws Exception {
-		new ServiceTracker<pkg2.a.A, pkg2.a.A>(context, pkg2.a.A.class, new ServiceTrackerCustomizer<pkg2.a.A, pkg2.a.A>() {
+		new ServiceTracker<>(context, pkg2.a.A.class, new ServiceTrackerCustomizer<pkg2.a.A, pkg2.a.A>() {
 
 			@Override
 			public pkg2.a.A addingService(ServiceReference<pkg2.a.A> reference) {
-				Dictionary<String, Object> props = new Hashtable<String, Object>();
+				Dictionary<String, Object> props = new Hashtable<>();
 				props.put("bundle.id", context.getBundle().getBundleId());
 				context.registerService(Boolean.class, Boolean.TRUE, props);
 				return null;

--- a/bundles/org.eclipse.equinox.region.tests/src/org/eclipse/equinox/region/internal/tests/BundleIdBasedRegionTests.java
+++ b/bundles/org.eclipse.equinox.region.tests/src/org/eclipse/equinox/region/internal/tests/BundleIdBasedRegionTests.java
@@ -70,7 +70,7 @@ public class BundleIdBasedRegionTests {
 
 	@Before
 	public void setUp() throws Exception {
-		this.threadLocal = new ThreadLocal<Region>();
+		this.threadLocal = new ThreadLocal<>();
 		this.mockBundle = mock(Bundle.class);
 		when(this.mockBundle.getSymbolicName()).thenReturn(BUNDLE_SYMBOLIC_NAME);
 		when(this.mockBundle.getVersion()).thenReturn(BUNDLE_VERSION);
@@ -132,7 +132,7 @@ public class BundleIdBasedRegionTests {
 	public void testAddBundle() throws BundleException {
 		when(this.mockGraph.iterator()).thenReturn(this.regionIterator);
 
-		HashSet<FilteredRegion> edges = new HashSet<FilteredRegion>();
+		HashSet<FilteredRegion> edges = new HashSet<>();
 		edges.add(new FilteredRegion() {
 
 			@Override

--- a/bundles/org.eclipse.equinox.region.tests/src/org/eclipse/equinox/region/internal/tests/StandardRegionDigraphPeristenceTests.java
+++ b/bundles/org.eclipse.equinox.region.tests/src/org/eclipse/equinox/region/internal/tests/StandardRegionDigraphPeristenceTests.java
@@ -42,7 +42,7 @@ public class StandardRegionDigraphPeristenceTests {
 		StubBundle stubSystemBundle = new StubBundle(0L, "osgi.framework", new Version("0"), "loc");
 		systemBundleContext = (StubBundleContext) stubSystemBundle.getBundleContext();
 		systemBundleContext.addInstalledBundle(stubSystemBundle);
-		threadLocal = new ThreadLocal<Region>();
+		threadLocal = new ThreadLocal<>();
 		this.digraph = RegionReflectionUtils.newStandardRegionDigraph(systemBundleContext, threadLocal);
 		this.persistence = digraph.getRegionDigraphPersistence();
 		Region boot = digraph.createRegion(BOOT_REGION);
@@ -80,7 +80,7 @@ public class StandardRegionDigraphPeristenceTests {
 
 	@Test
 	public void testMultiConnection() throws BundleException, InvalidSyntaxException, IOException {
-		List<Region> tails = new ArrayList<Region>();
+		List<Region> tails = new ArrayList<>();
 		// create multiple connections between each region
 		for (Region head : digraph) {
 			for (Region tail : tails) {
@@ -94,7 +94,7 @@ public class StandardRegionDigraphPeristenceTests {
 
 	@Test
 	public void testMultiConnectionCycle() throws BundleException, InvalidSyntaxException, IOException {
-		List<Region> tails = new ArrayList<Region>();
+		List<Region> tails = new ArrayList<>();
 		for (Region region : digraph) {
 			tails.add(region);
 		}
@@ -250,7 +250,7 @@ public class StandardRegionDigraphPeristenceTests {
 
 	static void assertEquals(Set<FilteredRegion> edges1, Set<FilteredRegion> edges2) {
 		Assert.assertEquals(edges1.size(), edges2.size());
-		Map<String, RegionFilter> edges2Map = new HashMap<String, RegionFilter>();
+		Map<String, RegionFilter> edges2Map = new HashMap<>();
 		for (FilteredRegion edge2 : edges2) {
 			edges2Map.put(edge2.getRegion().getName(), edge2.getFilter());
 		}

--- a/bundles/org.eclipse.equinox.region.tests/src/org/eclipse/equinox/region/internal/tests/StandardRegionDigraphPeristenceTests.java
+++ b/bundles/org.eclipse.equinox.region.tests/src/org/eclipse/equinox/region/internal/tests/StandardRegionDigraphPeristenceTests.java
@@ -168,11 +168,8 @@ public class StandardRegionDigraphPeristenceTests {
 	}
 
 	private void readDigraph(byte[] byteArray) throws IOException {
-		ByteArrayInputStream input = new ByteArrayInputStream(byteArray);
-		try {
+		try (ByteArrayInputStream input = new ByteArrayInputStream(byteArray)) {
 			persistence.load(input);
-		} finally {
-			input.close();
 		}
 	}
 

--- a/bundles/org.eclipse.equinox.region.tests/src/org/eclipse/equinox/region/internal/tests/StandardRegionDigraphTests.java
+++ b/bundles/org.eclipse.equinox.region.tests/src/org/eclipse/equinox/region/internal/tests/StandardRegionDigraphTests.java
@@ -328,7 +328,7 @@ public class StandardRegionDigraphTests {
 	}
 
 	static class TestRegionDigraphVisitor implements RegionDigraphVisitor {
-		final Collection<Region> visited = new ArrayList<Region>();
+		final Collection<Region> visited = new ArrayList<>();
 		final String namespace;
 		final Map<String, ?> attributes;
 
@@ -355,7 +355,7 @@ public class StandardRegionDigraphTests {
 		}
 
 		Collection<Region> clearVisited() {
-			Collection<Region> result = new ArrayList<Region>(visited);
+			Collection<Region> result = new ArrayList<>(visited);
 			visited.clear();
 			return result;
 		}
@@ -375,11 +375,11 @@ public class StandardRegionDigraphTests {
 				c);
 		testDigraph.connect(c, testDigraph.createRegionFilterBuilder().allow("d", "(d=x)").build(), d);
 
-		Map<String, String> attributes = new HashMap<String, String>();
+		Map<String, String> attributes = new HashMap<>();
 		attributes.put("d", "x");
 		TestRegionDigraphVisitor visitor = new TestRegionDigraphVisitor("d", attributes);
 
-		Collection<Region> expected = new ArrayList<Region>(Arrays.asList(a, b, c, d));
+		Collection<Region> expected = new ArrayList<>(Arrays.asList(a, b, c, d));
 		for (Region region : expected.toArray(new Region[0])) {
 			testDigraph.visitSubgraph(region, visitor);
 			Collection<Region> visited = visitor.clearVisited();
@@ -391,7 +391,7 @@ public class StandardRegionDigraphTests {
 		attributes.clear();
 		attributes.put("c", "x");
 		visitor = new TestRegionDigraphVisitor("c", attributes);
-		expected = new ArrayList<Region>(Arrays.asList(a, b, c));
+		expected = new ArrayList<>(Arrays.asList(a, b, c));
 		for (Region region : expected.toArray(new Region[0])) {
 			testDigraph.visitSubgraph(region, visitor);
 			Collection<Region> visited = visitor.clearVisited();
@@ -403,7 +403,7 @@ public class StandardRegionDigraphTests {
 		attributes.clear();
 		attributes.put("b", "x");
 		visitor = new TestRegionDigraphVisitor("b", attributes);
-		expected = new ArrayList<Region>(Arrays.asList(a, b));
+		expected = new ArrayList<>(Arrays.asList(a, b));
 		for (Region region : expected.toArray(new Region[0])) {
 			testDigraph.visitSubgraph(region, visitor);
 			Collection<Region> visited = visitor.clearVisited();

--- a/bundles/org.eclipse.equinox.region.tests/src/org/eclipse/equinox/region/internal/tests/hook/RegionBundleCollisionHookTests.java
+++ b/bundles/org.eclipse.equinox.region.tests/src/org/eclipse/equinox/region/internal/tests/hook/RegionBundleCollisionHookTests.java
@@ -66,16 +66,16 @@ public class RegionBundleCollisionHookTests {
 	@Before
 	public void setUp() throws Exception {
 		this.bundleId = 1L;
-		this.regions = new HashMap<String, Region>();
-		this.bundles = new HashMap<String, Bundle>();
+		this.regions = new HashMap<>();
+		this.bundles = new HashMap<>();
 
 		StubBundle stubSystemBundle = new StubBundle(0L, "osgi.framework", new Version("0"), "loc");
 		StubBundleContext stubBundleContext = new StubBundleContext();
 		stubBundleContext.addInstalledBundle(stubSystemBundle);
-		this.threadLocal = new ThreadLocal<Region>();
+		this.threadLocal = new ThreadLocal<>();
 		this.digraph = RegionReflectionUtils.newStandardRegionDigraph(stubBundleContext, this.threadLocal);
 		this.collisionFindHook = RegionReflectionUtils.newRegionBundleCollisionHook(this.digraph, this.threadLocal);
-		this.candidates = new HashSet<Bundle>();
+		this.candidates = new HashSet<>();
 
 		// Create regions A, B, C, D containing bundles A, B, C, D, respectively.
 		createRegion(REGION_A, BUNDLE_A);
@@ -250,7 +250,7 @@ public class RegionBundleCollisionHookTests {
 	}
 
 	private RegionFilter createFilter(String... bundleSymbolicNames) throws InvalidSyntaxException {
-		Collection<String> filters = new ArrayList<String>(bundleSymbolicNames.length);
+		Collection<String> filters = new ArrayList<>(bundleSymbolicNames.length);
 		for (String bundleSymbolicName : bundleSymbolicNames) {
 			filters.add('(' + RegionFilter.VISIBLE_BUNDLE_NAMESPACE + '=' + bundleSymbolicName + ')');
 		}

--- a/bundles/org.eclipse.equinox.region.tests/src/org/eclipse/equinox/region/internal/tests/hook/RegionBundleEventHookTests.java
+++ b/bundles/org.eclipse.equinox.region.tests/src/org/eclipse/equinox/region/internal/tests/hook/RegionBundleEventHookTests.java
@@ -63,13 +63,13 @@ public class RegionBundleEventHookTests {
 	@Before
 	public void setUp() throws Exception {
 		this.bundleId = 1L;
-		this.regions = new HashMap<String, Region>();
-		this.bundles = new HashMap<String, Bundle>();
+		this.regions = new HashMap<>();
+		this.bundles = new HashMap<>();
 
 		StubBundle stubSystemBundle = new StubBundle(0L, "osgi.framework", new Version("0"), "loc");
 		StubBundleContext stubBundleContext = new StubBundleContext();
 		stubBundleContext.addInstalledBundle(stubSystemBundle);
-		this.threadLocal = new ThreadLocal<Region>();
+		this.threadLocal = new ThreadLocal<>();
 		this.digraph = RegionReflectionUtils.newStandardRegionDigraph(stubBundleContext, this.threadLocal);
 		this.bundleEventHook = RegionReflectionUtils.newRegionBundleEventHook(digraph, threadLocal, stubSystemBundle.getBundleId());
 
@@ -226,7 +226,7 @@ public class RegionBundleEventHookTests {
 	@Test
 	public void testEventFromSystemBundle() {
 		Bundle systemBundle = new StubBundle(0L, "sys", BUNDLE_VERSION, "");
-		Collection<BundleContext> contexts = new ArrayList<BundleContext>(Arrays.asList(systemBundle.getBundleContext()));
+		Collection<BundleContext> contexts = new ArrayList<>(Arrays.asList(systemBundle.getBundleContext()));
 		this.bundleEventHook.event(bundleEvent(BUNDLE_A), contexts);
 		assertTrue(contexts.contains(systemBundle.getBundleContext()));
 	}
@@ -234,7 +234,7 @@ public class RegionBundleEventHookTests {
 	@Test
 	public void testEventFromBundleInNoRegion() {
 		Bundle stranger = createBundle("stranger");
-		Collection<BundleContext> contexts = new ArrayList<BundleContext>(Arrays.asList(stranger.getBundleContext()));
+		Collection<BundleContext> contexts = new ArrayList<>(Arrays.asList(stranger.getBundleContext()));
 		this.bundleEventHook.event(bundleEvent(BUNDLE_A), contexts);
 		assertTrue(contexts.isEmpty());
 	}
@@ -267,7 +267,7 @@ public class RegionBundleEventHookTests {
 	}
 
 	private RegionFilter createFilter(boolean negate, String... bundleSymbolicNames) throws InvalidSyntaxException {
-		Collection<String> filters = new ArrayList<String>(bundleSymbolicNames.length);
+		Collection<String> filters = new ArrayList<>(bundleSymbolicNames.length);
 		for (String bundleSymbolicName : bundleSymbolicNames) {
 			filters.add('(' + RegionFilter.VISIBLE_BUNDLE_NAMESPACE + '=' + bundleSymbolicName + ')');
 		}
@@ -290,7 +290,7 @@ public class RegionBundleEventHookTests {
 	}
 
 	private Collection<BundleContext> bundleContexts(String... bundleSymbolicNames) {
-		Collection<BundleContext> contexts = new ArrayList<BundleContext>();
+		Collection<BundleContext> contexts = new ArrayList<>();
 		for (String symbolicName : bundleSymbolicNames) {
 			contexts.add(bundleContext(symbolicName));
 		}

--- a/bundles/org.eclipse.equinox.region.tests/src/org/eclipse/equinox/region/internal/tests/hook/RegionBundleFindHookTests.java
+++ b/bundles/org.eclipse.equinox.region.tests/src/org/eclipse/equinox/region/internal/tests/hook/RegionBundleFindHookTests.java
@@ -66,16 +66,16 @@ public class RegionBundleFindHookTests {
 	@Before
 	public void setUp() throws Exception {
 		this.bundleId = 1L;
-		this.regions = new HashMap<String, Region>();
-		this.bundles = new HashMap<String, Bundle>();
+		this.regions = new HashMap<>();
+		this.bundles = new HashMap<>();
 
 		StubBundle stubSystemBundle = new StubBundle(0L, "osgi.framework", new Version("0"), "loc");
 		StubBundleContext stubBundleContext = new StubBundleContext();
 		stubBundleContext.addInstalledBundle(stubSystemBundle);
-		this.threadLocal = new ThreadLocal<Region>();
+		this.threadLocal = new ThreadLocal<>();
 		this.digraph = RegionReflectionUtils.newStandardRegionDigraph(stubBundleContext, this.threadLocal);
 		this.bundleFindHook = RegionReflectionUtils.newRegionBundleFindHook(this.digraph, stubSystemBundle.getBundleId());
-		this.candidates = new HashSet<Bundle>();
+		this.candidates = new HashSet<>();
 
 		// Create regions A, B, C, D containing bundles A, B, C, D, respectively.
 		createRegion(REGION_A, BUNDLE_A);
@@ -261,7 +261,7 @@ public class RegionBundleFindHookTests {
 	}
 
 	private RegionFilter createFilter(boolean negate, String... bundleSymbolicNames) throws InvalidSyntaxException {
-		Collection<String> filters = new ArrayList<String>(bundleSymbolicNames.length);
+		Collection<String> filters = new ArrayList<>(bundleSymbolicNames.length);
 		for (String bundleSymbolicName : bundleSymbolicNames) {
 			filters.add('(' + RegionFilter.VISIBLE_BUNDLE_NAMESPACE + '=' + bundleSymbolicName + ')');
 		}

--- a/bundles/org.eclipse.equinox.region.tests/src/org/eclipse/equinox/region/internal/tests/hook/RegionResolverHookTests.java
+++ b/bundles/org.eclipse.equinox.region.tests/src/org/eclipse/equinox/region/internal/tests/hook/RegionResolverHookTests.java
@@ -81,15 +81,15 @@ public class RegionResolverHookTests {
 	@Before
 	public void setUp() throws Exception {
 		this.bundleId = 1L;
-		this.regions = new HashMap<String, Region>();
-		this.bundles = new HashMap<String, Bundle>();
-		this.threadLocal = new ThreadLocal<Region>();
+		this.regions = new HashMap<>();
+		this.bundles = new HashMap<>();
+		this.threadLocal = new ThreadLocal<>();
 		StubBundle stubSystemBundle = new StubBundle(0L, "osgi.framework", new Version("0"), "loc");
 		StubBundleContext stubBundleContext = new StubBundleContext();
 		stubBundleContext.addInstalledBundle(stubSystemBundle);
 		this.digraph = RegionReflectionUtils.newStandardRegionDigraph(stubBundleContext, this.threadLocal);
 		this.resolverHook = RegionReflectionUtils.newRegionResolverHook(this.digraph);
-		this.candidates = new HashSet<BundleCapability>();
+		this.candidates = new HashSet<>();
 
 		// Create regions A, B, C, D containing bundles A, B, C, D, respectively.
 		createRegion(REGION_A, BUNDLE_A);
@@ -115,7 +115,7 @@ public class RegionResolverHookTests {
 
 	@Test
 	public void testNoRegionResolvable() {
-		Collection<BundleRevision> resolvable = new ArrayList<BundleRevision>(Collections.singleton(new StubBundleRevision(bundle(BUNDLE_X))));
+		Collection<BundleRevision> resolvable = new ArrayList<>(Collections.singleton(new StubBundleRevision(bundle(BUNDLE_X))));
 		this.resolverHook.filterResolvable(resolvable);
 		assertTrue("Resolvable is not empty" + resolvable, resolvable.isEmpty());
 	}
@@ -176,7 +176,7 @@ public class RegionResolverHookTests {
 
 	@Test
 	public void testResolveSingletonInSameRegions() {
-		List<BundleCapability> collisionCandidates = new ArrayList<BundleCapability>();
+		List<BundleCapability> collisionCandidates = new ArrayList<>();
 		collisionCandidates.add(bundleCapability(BUNDLE_B));
 		collisionCandidates.add(bundleCapability(BUNDLE_C));
 		collisionCandidates.add(bundleCapability(BUNDLE_D));
@@ -188,7 +188,7 @@ public class RegionResolverHookTests {
 	public void testResolveSingletonInDifferentRegions() throws BundleException {
 		region(REGION_A).addBundle(bundle(BUNDLE_X));
 		BundleCapability collision = bundleCapability(BUNDLE_X);
-		List<BundleCapability> collisionCandidates = new ArrayList<BundleCapability>();
+		List<BundleCapability> collisionCandidates = new ArrayList<>();
 		collisionCandidates.add(collision);
 		collisionCandidates.add(bundleCapability(BUNDLE_B));
 		collisionCandidates.add(bundleCapability(BUNDLE_C));
@@ -205,7 +205,7 @@ public class RegionResolverHookTests {
 		region(REGION_A).addBundle(bundle(BUNDLE_X));
 		BundleCapability collisionX = bundleCapability(BUNDLE_X);
 		BundleCapability collisionB = bundleCapability(BUNDLE_B);
-		List<BundleCapability> collisionCandidates = new ArrayList<BundleCapability>();
+		List<BundleCapability> collisionCandidates = new ArrayList<>();
 		collisionCandidates.add(collisionX);
 		collisionCandidates.add(collisionB);
 		collisionCandidates.add(bundleCapability(BUNDLE_C));
@@ -245,14 +245,14 @@ public class RegionResolverHookTests {
 		this.candidates.add(packageCapability(BUNDLE_C, PACKAGE_DUP));
 		this.candidates.add(packageCapability(BUNDLE_D, PACKAGE_DUP));
 
-		Collection<BundleCapability> testCandidates = new ArrayList<BundleCapability>(this.candidates);
+		Collection<BundleCapability> testCandidates = new ArrayList<>(this.candidates);
 		this.resolverHook.filterMatches(bundleRequirement(BUNDLE_A), testCandidates);
 		assertTrue(testCandidates.contains(packageCapability(BUNDLE_A, PACKAGE_DUP)));
 		assertFalse(testCandidates.contains(packageCapability(BUNDLE_B, PACKAGE_DUP)));
 		assertTrue(testCandidates.contains(packageCapability(BUNDLE_C, PACKAGE_DUP)));
 		assertTrue(testCandidates.contains(packageCapability(BUNDLE_D, PACKAGE_DUP)));
 
-		testCandidates = new ArrayList<BundleCapability>(this.candidates);
+		testCandidates = new ArrayList<>(this.candidates);
 		this.resolverHook.filterMatches(bundleRequirement(BUNDLE_B), testCandidates);
 		assertTrue(testCandidates.contains(packageCapability(BUNDLE_A, PACKAGE_DUP)));
 		assertTrue(testCandidates.contains(packageCapability(BUNDLE_B, PACKAGE_DUP)));
@@ -353,7 +353,7 @@ public class RegionResolverHookTests {
 	}
 
 	private RegionFilter createFilter(final String... packageNames) throws InvalidSyntaxException {
-		Collection<String> filters = new ArrayList<String>(packageNames.length);
+		Collection<String> filters = new ArrayList<>(packageNames.length);
 		for (String pkg : packageNames) {
 			filters.add('(' + RegionFilter.VISIBLE_PACKAGE_NAMESPACE + '=' + pkg + ')');
 		}
@@ -403,12 +403,12 @@ public class RegionResolverHookTests {
 
 		@Override
 		public Map<String, String> getDirectives() {
-			return new HashMap<String, String>();
+			return new HashMap<>();
 		}
 
 		@Override
 		public Map<String, Object> getAttributes() {
-			HashMap<String, Object> attributes = new HashMap<String, Object>();
+			HashMap<String, Object> attributes = new HashMap<>();
 			attributes.put(BundleRevision.PACKAGE_NAMESPACE, this.packageName);
 			return attributes;
 		}
@@ -486,12 +486,12 @@ public class RegionResolverHookTests {
 
 		@Override
 		public Map<String, String> getDirectives() {
-			return new HashMap<String, String>();
+			return new HashMap<>();
 		}
 
 		@Override
 		public Map<String, Object> getAttributes() {
-			HashMap<String, Object> attributes = new HashMap<String, Object>();
+			HashMap<String, Object> attributes = new HashMap<>();
 			attributes.put(BundleRevision.BUNDLE_NAMESPACE, bundleSymbolicName);
 			return attributes;
 		}

--- a/bundles/org.eclipse.equinox.region.tests/src/org/eclipse/equinox/region/internal/tests/hook/RegionServiceEventHookTests.java
+++ b/bundles/org.eclipse.equinox.region.tests/src/org/eclipse/equinox/region/internal/tests/hook/RegionServiceEventHookTests.java
@@ -71,14 +71,14 @@ public class RegionServiceEventHookTests {
 	@Before
 	public void setUp() throws Exception {
 		this.bundleId = 1L;
-		this.regions = new HashMap<String, Region>();
-		this.bundles = new HashMap<String, Bundle>();
-		this.serviceReferences = new HashMap<String, ServiceReference<Object>>();
+		this.regions = new HashMap<>();
+		this.bundles = new HashMap<>();
+		this.serviceReferences = new HashMap<>();
 
 		StubBundle stubSystemBundle = new StubBundle(0L, "osgi.framework", new Version("0"), "loc");
 		StubBundleContext stubBundleContext = new StubBundleContext();
 		stubBundleContext.addInstalledBundle(stubSystemBundle);
-		this.threadLocal = new ThreadLocal<Region>();
+		this.threadLocal = new ThreadLocal<>();
 		this.digraph = RegionReflectionUtils.newStandardRegionDigraph(stubBundleContext, this.threadLocal);
 		this.serviceEventHook = RegionReflectionUtils.newRegionServiceEventHook(this.digraph);
 
@@ -224,7 +224,7 @@ public class RegionServiceEventHookTests {
 	@Test
 	public void testEventFromSystemBundle() {
 		Bundle systemBundle = new StubBundle(0L, "sys", BUNDLE_VERSION, "");
-		Collection<BundleContext> contexts = new ArrayList<BundleContext>(Arrays.asList(systemBundle.getBundleContext()));
+		Collection<BundleContext> contexts = new ArrayList<>(Arrays.asList(systemBundle.getBundleContext()));
 		this.serviceEventHook.event(serviceEvent(BUNDLE_A), contexts);
 		assertTrue(contexts.contains(systemBundle.getBundleContext()));
 	}
@@ -232,7 +232,7 @@ public class RegionServiceEventHookTests {
 	@Test
 	public void testEventFromBundleInNoRegion() {
 		Bundle stranger = createBundle("stranger");
-		Collection<BundleContext> contexts = new ArrayList<BundleContext>(Arrays.asList(stranger.getBundleContext()));
+		Collection<BundleContext> contexts = new ArrayList<>(Arrays.asList(stranger.getBundleContext()));
 		this.serviceEventHook.event(serviceEvent(BUNDLE_A), contexts);
 		assertTrue(contexts.isEmpty());
 	}
@@ -252,7 +252,7 @@ public class RegionServiceEventHookTests {
 	}
 
 	private RegionFilter createFilter(final String... referenceNames) throws InvalidSyntaxException {
-		Collection<String> filters = new ArrayList<String>(referenceNames.length);
+		Collection<String> filters = new ArrayList<>(referenceNames.length);
 		for (String referenceName : referenceNames) {
 			filters.add('(' + Constants.OBJECTCLASS + '=' + referenceName + ')');
 		}
@@ -273,18 +273,18 @@ public class RegionServiceEventHookTests {
 	}
 
 	private StubServiceReference<Object> createServiceReference(Bundle stubBundle, String referenceName) {
-		StubServiceRegistration<Object> stubServiceRegistration = new StubServiceRegistration<Object>((StubBundleContext) stubBundle.getBundleContext(), referenceName);
-		StubServiceReference<Object> stubServiceReference = new StubServiceReference<Object>(stubServiceRegistration);
+		StubServiceRegistration<Object> stubServiceRegistration = new StubServiceRegistration<>((StubBundleContext) stubBundle.getBundleContext(), referenceName);
+		StubServiceReference<Object> stubServiceReference = new StubServiceReference<>(stubServiceRegistration);
 		this.serviceReferences.put(referenceName, stubServiceReference);
 
-		StubServiceRegistration<Object> dupServiceRegistration = new StubServiceRegistration<Object>((StubBundleContext) stubBundle.getBundleContext(), DUPLICATE + stubBundle.getBundleId());
-		StubServiceReference<Object> dupServiceReference = new StubServiceReference<Object>(dupServiceRegistration);
+		StubServiceRegistration<Object> dupServiceRegistration = new StubServiceRegistration<>((StubBundleContext) stubBundle.getBundleContext(), DUPLICATE + stubBundle.getBundleId());
+		StubServiceReference<Object> dupServiceReference = new StubServiceReference<>(dupServiceRegistration);
 		this.serviceReferences.put(DUPLICATE + stubBundle.getBundleId(), dupServiceReference);
 		return stubServiceReference;
 	}
 
 	private Collection<BundleContext> bundleContexts(String... bundleSymbolicNames) {
-		Collection<BundleContext> contexts = new ArrayList<BundleContext>();
+		Collection<BundleContext> contexts = new ArrayList<>();
 		for (String symbolicName : bundleSymbolicNames) {
 			contexts.add(bundleContext(symbolicName));
 		}

--- a/bundles/org.eclipse.equinox.region.tests/src/org/eclipse/equinox/region/internal/tests/hook/RegionServiceFindHookTests.java
+++ b/bundles/org.eclipse.equinox.region.tests/src/org/eclipse/equinox/region/internal/tests/hook/RegionServiceFindHookTests.java
@@ -73,17 +73,17 @@ public class RegionServiceFindHookTests {
 	@Before
 	public void setUp() throws Exception {
 		this.bundleId = 1L;
-		this.regions = new HashMap<String, Region>();
-		this.bundles = new HashMap<String, Bundle>();
-		this.serviceReferences = new HashMap<String, ServiceReference<Object>>();
+		this.regions = new HashMap<>();
+		this.bundles = new HashMap<>();
+		this.serviceReferences = new HashMap<>();
 
 		StubBundle stubSystemBundle = new StubBundle(0L, "osgi.framework", new Version("0"), "loc");
 		StubBundleContext stubBundleContext = new StubBundleContext();
 		stubBundleContext.addInstalledBundle(stubSystemBundle);
-		this.threadLocal = new ThreadLocal<Region>();
+		this.threadLocal = new ThreadLocal<>();
 		this.digraph = RegionReflectionUtils.newStandardRegionDigraph(stubBundleContext, this.threadLocal);
 		this.bundleFindHook = RegionReflectionUtils.newRegionServiceFindHook(this.digraph);
-		this.candidates = new HashSet<ServiceReference<?>>();
+		this.candidates = new HashSet<>();
 
 		// Create regions A, B, C, D containing bundles A, B, C, D, respectively.
 		createRegion(REGION_A, BUNDLE_A);
@@ -219,14 +219,14 @@ public class RegionServiceFindHookTests {
 		this.candidates.add(serviceReference(DUPLICATE + bundle(BUNDLE_C).getBundleId()));
 		this.candidates.add(serviceReference(DUPLICATE + bundle(BUNDLE_D).getBundleId()));
 
-		Collection<ServiceReference<?>> testCandidates = new ArrayList<ServiceReference<?>>(this.candidates);
+		Collection<ServiceReference<?>> testCandidates = new ArrayList<>(this.candidates);
 		this.bundleFindHook.find(bundleContext(BUNDLE_A), "", "", false, testCandidates);
 		assertTrue(testCandidates.contains(serviceReference(DUPLICATE + bundle(BUNDLE_A).getBundleId())));
 		assertFalse(testCandidates.contains(serviceReference(DUPLICATE + bundle(BUNDLE_B).getBundleId())));
 		assertTrue(testCandidates.contains(serviceReference(DUPLICATE + bundle(BUNDLE_C).getBundleId())));
 		assertTrue(testCandidates.contains(serviceReference(DUPLICATE + bundle(BUNDLE_D).getBundleId())));
 
-		testCandidates = new ArrayList<ServiceReference<?>>(this.candidates);
+		testCandidates = new ArrayList<>(this.candidates);
 		this.bundleFindHook.find(bundleContext(BUNDLE_A), "", "", false, testCandidates);
 		assertTrue(testCandidates.contains(serviceReference(DUPLICATE + bundle(BUNDLE_A).getBundleId())));
 		assertFalse(testCandidates.contains(serviceReference(DUPLICATE + bundle(BUNDLE_B).getBundleId())));
@@ -315,7 +315,7 @@ public class RegionServiceFindHookTests {
 	}
 
 	private RegionFilter createFilter(final String... referenceNames) throws InvalidSyntaxException {
-		Collection<String> filters = new ArrayList<String>(referenceNames.length);
+		Collection<String> filters = new ArrayList<>(referenceNames.length);
 		for (String referenceName : referenceNames) {
 			filters.add('(' + Constants.OBJECTCLASS + '=' + referenceName + ')');
 		}
@@ -336,12 +336,12 @@ public class RegionServiceFindHookTests {
 	}
 
 	private StubServiceReference<Object> createServiceReference(Bundle stubBundle, String referenceName) {
-		StubServiceRegistration<Object> stubServiceRegistration = new StubServiceRegistration<Object>((StubBundleContext) stubBundle.getBundleContext(), referenceName);
-		StubServiceReference<Object> stubServiceReference = new StubServiceReference<Object>(stubServiceRegistration);
+		StubServiceRegistration<Object> stubServiceRegistration = new StubServiceRegistration<>((StubBundleContext) stubBundle.getBundleContext(), referenceName);
+		StubServiceReference<Object> stubServiceReference = new StubServiceReference<>(stubServiceRegistration);
 		this.serviceReferences.put(referenceName, stubServiceReference);
 
-		StubServiceRegistration<Object> dupServiceRegistration = new StubServiceRegistration<Object>((StubBundleContext) stubBundle.getBundleContext(), DUPLICATE + stubBundle.getBundleId());
-		StubServiceReference<Object> dupServiceReference = new StubServiceReference<Object>(dupServiceRegistration);
+		StubServiceRegistration<Object> dupServiceRegistration = new StubServiceRegistration<>((StubBundleContext) stubBundle.getBundleContext(), DUPLICATE + stubBundle.getBundleId());
+		StubServiceReference<Object> dupServiceReference = new StubServiceReference<>(dupServiceRegistration);
 		this.serviceReferences.put(DUPLICATE + stubBundle.getBundleId(), dupServiceReference);
 		return stubServiceReference;
 	}

--- a/bundles/org.eclipse.equinox.region.tests/src/org/eclipse/equinox/region/tests/BundleInstaller.java
+++ b/bundles/org.eclipse.equinox.region.tests/src/org/eclipse/equinox/region/tests/BundleInstaller.java
@@ -27,7 +27,7 @@ public class BundleInstaller {
 	private final BundleContext context;
 	private final Bundle testBundle;
 	private String rootLocation;
-	private Map<String, Bundle> bundles = new HashMap<String, Bundle>();
+	private Map<String, Bundle> bundles = new HashMap<>();
 	private final ServiceTracker<URLConverter, URLConverter> converter;
 	private final FrameworkWiring frameworkWiring;
 
@@ -37,7 +37,7 @@ public class BundleInstaller {
 		context = systemBundle.getBundleContext();
 		frameworkWiring = systemBundle.adapt(FrameworkWiring.class);
 		rootLocation = bundlesRoot;
-		converter = new ServiceTracker<URLConverter, URLConverter>(context, context.createFilter("(&(objectClass=" + URLConverter.class.getName() + ")(protocol=bundleentry))"), null);
+		converter = new ServiceTracker<>(context, context.createFilter("(&(objectClass=" + URLConverter.class.getName() + ")(protocol=bundleentry))"), null);
 		converter.open();
 		this.testBundle = testBundle;
 	}
@@ -137,7 +137,7 @@ public class BundleInstaller {
 	synchronized public Bundle[] uninstallAllBundles() throws BundleException {
 		if (bundles == null)
 			return null;
-		List<Bundle> result = new ArrayList<Bundle>(bundles.size());
+		List<Bundle> result = new ArrayList<>(bundles.size());
 		for (Bundle bundle : bundles.values()) {
 			try {
 				bundle.uninstall();
@@ -173,7 +173,7 @@ public class BundleInstaller {
 					}
 			}
 		};
-		final Set<Bundle> refreshed = new HashSet<Bundle>();
+		final Set<Bundle> refreshed = new HashSet<>();
 		BundleListener refreshBundleListener = new SynchronousBundleListener() {
 			public void bundleChanged(BundleEvent event) {
 				refreshed.add(event.getBundle());

--- a/bundles/org.eclipse.equinox.region.tests/src/org/eclipse/equinox/region/tests/system/Bug346127Test.java
+++ b/bundles/org.eclipse.equinox.region.tests/src/org/eclipse/equinox/region/tests/system/Bug346127Test.java
@@ -55,7 +55,7 @@ public class Bug346127Test extends AbstractRegionSystemTest {
 	@Override
 	public void setUp() throws Exception {
 		super.setUp();
-		Hashtable<String, Object> properties = new Hashtable<String, Object>();
+		Hashtable<String, Object> properties = new Hashtable<>();
 		properties.put(URLConstants.URL_HANDLER_PROTOCOL, new String[] {"regiondigraphtest"});
 		getContext().registerService(URLStreamHandlerService.class.getName(), new AbstractURLStreamHandlerService() {
 			@Override

--- a/bundles/org.eclipse.equinox.region.tests/src/org/eclipse/equinox/region/tests/system/RegionSystemTests.java
+++ b/bundles/org.eclipse.equinox.region.tests/src/org/eclipse/equinox/region/tests/system/RegionSystemTests.java
@@ -53,7 +53,7 @@ public class RegionSystemTests extends AbstractRegionSystemTest {
 		Region systemRegion = digraph.getRegion(0);
 		// create a disconnected test region
 		Region testRegion = digraph.createRegion(testName.getMethodName());
-		List<Bundle> bundles = new ArrayList<Bundle>();
+		List<Bundle> bundles = new ArrayList<>();
 		// Install all test bundles
 		Bundle pp1, cp2, sc1;
 		bundles.add(pp1 = bundleInstaller.installBundle(PP1, testRegion));
@@ -85,8 +85,8 @@ public class RegionSystemTests extends AbstractRegionSystemTest {
 			bundle.start();
 		}
 		BundleContext context = getContext();
-		ServiceTracker<Boolean, Boolean> cp2Tracker = new ServiceTracker<Boolean, Boolean>(context, context.createFilter("(&(objectClass=java.lang.Boolean)(bundle.id=" + cp2.getBundleId() + "))"), null);
-		ServiceTracker<Boolean, Boolean> sc1Tracker = new ServiceTracker<Boolean, Boolean>(context, context.createFilter("(&(objectClass=java.lang.Boolean)(bundle.id=" + sc1.getBundleId() + "))"), null);
+		ServiceTracker<Boolean, Boolean> cp2Tracker = new ServiceTracker<>(context, context.createFilter("(&(objectClass=java.lang.Boolean)(bundle.id=" + cp2.getBundleId() + "))"), null);
+		ServiceTracker<Boolean, Boolean> sc1Tracker = new ServiceTracker<>(context, context.createFilter("(&(objectClass=java.lang.Boolean)(bundle.id=" + sc1.getBundleId() + "))"), null);
 
 		cp2Tracker.open();
 		sc1Tracker.open();
@@ -101,7 +101,7 @@ public class RegionSystemTests extends AbstractRegionSystemTest {
 	public void testSingleBundleRegions() throws BundleException, InvalidSyntaxException, InterruptedException {
 		// get the system region
 		Region systemRegion = digraph.getRegion(0);
-		Map<String, Bundle> bundles = new HashMap<String, Bundle>();
+		Map<String, Bundle> bundles = new HashMap<>();
 		// create a disconnected test region for each test bundle
 		for (String location : ALL) {
 			Region testRegion = digraph.createRegion(location);
@@ -149,8 +149,8 @@ public class RegionSystemTests extends AbstractRegionSystemTest {
 			bundle.start();
 		}
 		BundleContext context = getContext();
-		ServiceTracker<Boolean, Boolean> cp2Tracker = new ServiceTracker<Boolean, Boolean>(context, context.createFilter("(&(objectClass=java.lang.Boolean)(bundle.id=" + bundles.get(CP2).getBundleId() + "))"), null);
-		ServiceTracker<Boolean, Boolean> sc1Tracker = new ServiceTracker<Boolean, Boolean>(context, context.createFilter("(&(objectClass=java.lang.Boolean)(bundle.id=" + bundles.get(SC1).getBundleId() + "))"), null);
+		ServiceTracker<Boolean, Boolean> cp2Tracker = new ServiceTracker<>(context, context.createFilter("(&(objectClass=java.lang.Boolean)(bundle.id=" + bundles.get(CP2).getBundleId() + "))"), null);
+		ServiceTracker<Boolean, Boolean> sc1Tracker = new ServiceTracker<>(context, context.createFilter("(&(objectClass=java.lang.Boolean)(bundle.id=" + bundles.get(SC1).getBundleId() + "))"), null);
 
 		cp2Tracker.open();
 		sc1Tracker.open();
@@ -282,7 +282,7 @@ public class RegionSystemTests extends AbstractRegionSystemTest {
 		systemRegion.connectRegion(testRegion1, digraph.createRegionFilterBuilder().allow(RegionFilter.VISIBLE_SERVICE_NAMESPACE, "(objectClass=java.lang.Boolean)").build());
 		systemRegion.connectRegion(testRegion2, digraph.createRegionFilterBuilder().allow(RegionFilter.VISIBLE_SERVICE_NAMESPACE, "(objectClass=java.lang.Boolean)").build());
 
-		Map<String, Bundle> bundles = new HashMap<String, Bundle>();
+		Map<String, Bundle> bundles = new HashMap<>();
 		// add bundles to region1
 		bundles.put(PP1, bundleInstaller.installBundle(PP1, testRegion1));
 		bundles.put(SP2, bundleInstaller.installBundle(SP2, testRegion1));
@@ -330,8 +330,8 @@ public class RegionSystemTests extends AbstractRegionSystemTest {
 			bundle.start();
 		}
 		BundleContext context = getContext();
-		ServiceTracker<Boolean, Boolean> cp2Tracker = new ServiceTracker<Boolean, Boolean>(context, context.createFilter("(&(objectClass=java.lang.Boolean)(bundle.id=" + bundles.get(CP2).getBundleId() + "))"), null);
-		ServiceTracker<Boolean, Boolean> sc1Tracker = new ServiceTracker<Boolean, Boolean>(context, context.createFilter("(&(objectClass=java.lang.Boolean)(bundle.id=" + bundles.get(SC1).getBundleId() + "))"), null);
+		ServiceTracker<Boolean, Boolean> cp2Tracker = new ServiceTracker<>(context, context.createFilter("(&(objectClass=java.lang.Boolean)(bundle.id=" + bundles.get(CP2).getBundleId() + "))"), null);
+		ServiceTracker<Boolean, Boolean> sc1Tracker = new ServiceTracker<>(context, context.createFilter("(&(objectClass=java.lang.Boolean)(bundle.id=" + bundles.get(SC1).getBundleId() + "))"), null);
 
 		cp2Tracker.open();
 		sc1Tracker.open();
@@ -492,7 +492,7 @@ public class RegionSystemTests extends AbstractRegionSystemTest {
 	public void testBundleCollisionDisconnectedRegions() throws BundleException, InvalidSyntaxException {
 		// get the system region
 		Region systemRegion = digraph.getRegion(0);
-		Collection<Bundle> bundles = new HashSet<Bundle>();
+		Collection<Bundle> bundles = new HashSet<>();
 		// create 4 disconnected test regions and install each bundle into each region
 		int numRegions = 4;
 		String regionName = "IsolatedRegion_";
@@ -751,7 +751,7 @@ public class RegionSystemTests extends AbstractRegionSystemTest {
 
 	@Test
 	public void testInvalidRegionName() {
-		Collection<String> invalidNames = new ArrayList<String>();
+		Collection<String> invalidNames = new ArrayList<>();
 		invalidNames.addAll(Arrays.asList(":", "bad:Name", ":bad::name:", ":badname", "badname:"));
 		invalidNames.addAll(Arrays.asList("=", "bad=Name", "=bad==name=", "=badname", "badname="));
 		invalidNames.addAll(Arrays.asList("\n", "bad\nName", "\nbad\n\nname\n", "\nbadname", "badname\n"));
@@ -776,7 +776,7 @@ public class RegionSystemTests extends AbstractRegionSystemTest {
 
 	@Test
 	public void testHigherRankedEventHookResolve() throws BundleException {
-		final List<BundleEvent> events = new CopyOnWriteArrayList<BundleEvent>();
+		final List<BundleEvent> events = new CopyOnWriteArrayList<>();
 		SynchronousBundleListener listener = new SynchronousBundleListener() {
 			@Override
 			public void bundleChanged(BundleEvent event) {
@@ -846,7 +846,7 @@ public class RegionSystemTests extends AbstractRegionSystemTest {
 	public void testReplaceConnection() throws BundleException, InvalidSyntaxException {
 		// get the system region
 		Region systemRegion = digraph.getRegion(0);
-		Map<String, Bundle> bundles = new HashMap<String, Bundle>();
+		Map<String, Bundle> bundles = new HashMap<>();
 		// create a disconnected test region for each test bundle
 		for (String location : new String[] {PP1, SP1}) {
 			Region testRegion = digraph.createRegion(location);

--- a/bundles/org.eclipse.equinox.region/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.region/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.equinox.region
-Bundle-Version: 1.5.200.qualifier
+Bundle-Version: 1.5.300.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Fragment-Host: system.bundle
 ExtensionBundle-Activator: org.eclipse.equinox.internal.region.RegionManager

--- a/bundles/org.eclipse.equinox.region/src/org/eclipse/equinox/internal/region/RegionManager.java
+++ b/bundles/org.eclipse.equinox.region/src/org/eclipse/equinox/internal/region/RegionManager.java
@@ -39,13 +39,13 @@ public final class RegionManager implements BundleActivator {
 	private static final String REGION_DOMAIN_PROP = "org.eclipse.equinox.region.domain"; //$NON-NLS-1$
 	private static final String DIGRAPH_FILE = "digraph"; //$NON-NLS-1$
 	private static final String REGION_REGISTER_MBEANS = "org.eclipse.equinox.region.register.mbeans"; //$NON-NLS-1$
-	private static final Dictionary<String, Object> MAX_RANKING = new Hashtable<String, Object>(Collections.singletonMap(Constants.SERVICE_RANKING, Integer.MAX_VALUE));
+	private static final Dictionary<String, Object> MAX_RANKING = new Hashtable<>(Collections.singletonMap(Constants.SERVICE_RANKING, Integer.MAX_VALUE));
 
-	Collection<ServiceRegistration<?>> registrations = new ArrayList<ServiceRegistration<?>>();
+	Collection<ServiceRegistration<?>> registrations = new ArrayList<>();
 
 	private BundleContext bundleContext;
 
-	private final ThreadLocal<Region> threadLocal = new ThreadLocal<Region>();
+	private final ThreadLocal<Region> threadLocal = new ThreadLocal<>();
 
 	private String domain;
 

--- a/bundles/org.eclipse.equinox.region/src/org/eclipse/equinox/internal/region/StandardBundleIdToRegionMapping.java
+++ b/bundles/org.eclipse.equinox.region/src/org/eclipse/equinox/internal/region/StandardBundleIdToRegionMapping.java
@@ -27,7 +27,7 @@ public final class StandardBundleIdToRegionMapping implements BundleIdToRegionMa
 	 * bundleToRegion maps a given bundle id to the region for which it belongs.
 	 * this is a global map for all regions in the digraph
 	 */
-	private final Map<Long, Region> bundleToRegion = new HashMap<Long, Region>();
+	private final Map<Long, Region> bundleToRegion = new HashMap<>();
 
 	/**
 	 * {@inheritDoc} 
@@ -68,7 +68,7 @@ public final class StandardBundleIdToRegionMapping implements BundleIdToRegionMa
 	 */
 	@Override
 	public Set<Long> getBundleIds(Region region) {
-		Set<Long> bundleIds = new HashSet<Long>();
+		Set<Long> bundleIds = new HashSet<>();
 		synchronized (this.monitor) {
 			for (Map.Entry<Long, Region> entry : this.bundleToRegion.entrySet()) {
 				if (entry.getValue() == region) {

--- a/bundles/org.eclipse.equinox.region/src/org/eclipse/equinox/internal/region/StandardRegionDigraph.java
+++ b/bundles/org.eclipse.equinox.region/src/org/eclipse/equinox/internal/region/StandardRegionDigraph.java
@@ -40,7 +40,7 @@ public final class StandardRegionDigraph implements BundleIdToRegionMapping, Reg
 	// bundle id modifications of all regions in this digraph
 	private final Object monitor = new Object();
 
-	private final Map<String, Region> regions = new HashMap<String, Region>();
+	private final Map<String, Region> regions = new HashMap<>();
 
 	// Alien calls may be made to the following object while this.monitor is locked
 	// as this.monitor is higher in the lock hierarchy than this object's own monitor.
@@ -48,7 +48,7 @@ public final class StandardRegionDigraph implements BundleIdToRegionMapping, Reg
 
 	/* edges maps a given region to an immutable set of edges with their tail at the given region. To update
 	 * the edges for a region, the corresponding immutable set is replaced atomically. */
-	private final Map<Region, Set<FilteredRegion>> edges = new HashMap<Region, Set<FilteredRegion>>();
+	private final Map<Region, Set<FilteredRegion>> edges = new HashMap<>();
 
 	private final BundleContext bundleContext;
 
@@ -168,9 +168,9 @@ public final class StandardRegionDigraph implements BundleIdToRegionMapping, Reg
 		synchronized (this.monitor) {
 			Set<FilteredRegion> connections = this.edges.get(tailRegion);
 			if (connections == null) {
-				connections = new HashSet<FilteredRegion>();
+				connections = new HashSet<>();
 			} else {
-				connections = new HashSet<FilteredRegion>(connections);
+				connections = new HashSet<>(connections);
 				for (FilteredRegion edge : connections) {
 					if (headRegion.equals(edge.getRegion())) {
 						if (replace) {
@@ -217,7 +217,7 @@ public final class StandardRegionDigraph implements BundleIdToRegionMapping, Reg
 	@Override
 	public Iterator<Region> iterator() {
 		synchronized (this.monitor) {
-			Set<Region> snapshot = new HashSet<Region>(this.regions.size());
+			Set<Region> snapshot = new HashSet<>(this.regions.size());
 			snapshot.addAll(this.regions.values());
 			return snapshot.iterator();
 		}
@@ -305,7 +305,7 @@ public final class StandardRegionDigraph implements BundleIdToRegionMapping, Reg
 				Set<FilteredRegion> edgeSet = entry.getValue();
 				for (FilteredRegion edge : edgeSet) {
 					if (region.equals(edge.getRegion())) {
-						Set<FilteredRegion> mutableEdgeSet = new HashSet<FilteredRegion>(edgeSet);
+						Set<FilteredRegion> mutableEdgeSet = new HashSet<>(edgeSet);
 						mutableEdgeSet.remove(edge);
 						this.edges.put(r, Collections.unmodifiableSet(mutableEdgeSet));
 						break;
@@ -356,7 +356,7 @@ public final class StandardRegionDigraph implements BundleIdToRegionMapping, Reg
 
 	@Override
 	public Set<Region> getRegions() {
-		Set<Region> result = new HashSet<Region>();
+		Set<Region> result = new HashSet<>();
 		synchronized (this.monitor) {
 			result.addAll(this.regions.values());
 		}
@@ -385,7 +385,7 @@ public final class StandardRegionDigraph implements BundleIdToRegionMapping, Reg
 	private Set<RegionLifecycleListener> getListeners() {
 		if (this.bundleContext == null)
 			return Collections.emptySet();
-		Set<RegionLifecycleListener> listeners = new HashSet<RegionLifecycleListener>();
+		Set<RegionLifecycleListener> listeners = new HashSet<>();
 		try {
 			Collection<ServiceReference<RegionLifecycleListener>> listenerServiceReferences = this.bundleContext.getServiceReferences(RegionLifecycleListener.class, null);
 			for (ServiceReference<RegionLifecycleListener> listenerServiceReference : listenerServiceReferences) {
@@ -415,7 +415,7 @@ public final class StandardRegionDigraph implements BundleIdToRegionMapping, Reg
 	 */
 	Map<Region, Set<FilteredRegion>> getFilteredRegions() {
 		synchronized (this.monitor) {
-			return new HashMap<Region, Set<FilteredRegion>>(this.edges);
+			return new HashMap<>(this.edges);
 		}
 	}
 
@@ -458,12 +458,12 @@ public final class StandardRegionDigraph implements BundleIdToRegionMapping, Reg
 		}
 
 		Map<Region, Set<FilteredRegion>> filteredRegions = replacement.getFilteredRegions();
-		final Set<Region> added = new HashSet<Region>();
+		final Set<Region> added = new HashSet<>();
 		synchronized (this.monitor) {
 			if (check && this.updateCount.get() != replacement.originUpdateCount) {
 				throw new BundleException("The origin update count has changed since the replacement copy was created.", BundleException.INVALID_OPERATION); //$NON-NLS-1$
 			}
-			Map<String, Region> nameToRegion = new HashMap<String, Region>(regions);
+			Map<String, Region> nameToRegion = new HashMap<>(regions);
 			this.regions.clear();
 			this.edges.clear();
 			this.bundleIdToRegionMapping.clear();

--- a/bundles/org.eclipse.equinox.region/src/org/eclipse/equinox/internal/region/StandardRegionFilter.java
+++ b/bundles/org.eclipse.equinox.region/src/org/eclipse/equinox/internal/region/StandardRegionFilter.java
@@ -42,9 +42,9 @@ public final class StandardRegionFilter implements RegionFilter {
 			throw new IllegalArgumentException("filters must not be null."); //$NON-NLS-1$
 		}
 		// must perform deep copy to avoid external changes
-		this.filters = new HashMap<String, Collection<Filter>>((int) ((filters.size() / 0.75) + 1));
+		this.filters = new HashMap<>((int) ((filters.size() / 0.75) + 1));
 		for (Map.Entry<String, Collection<Filter>> namespace : filters.entrySet()) {
-			Collection<Filter> namespaceFilters = new ArrayList<Filter>(namespace.getValue());
+			Collection<Filter> namespaceFilters = new ArrayList<>(namespace.getValue());
 			this.filters.put(namespace.getKey(), namespaceFilters);
 		}
 	}
@@ -54,7 +54,7 @@ public final class StandardRegionFilter implements RegionFilter {
 		if (bundle == null) {
 			return false;
 		}
-		HashMap<String, Object> attrs = new HashMap<String, Object>(4);
+		HashMap<String, Object> attrs = new HashMap<>(4);
 		String bsn = bundle.getSymbolicName();
 		if (bsn != null) {
 			attrs.put(VISIBLE_BUNDLE_NAMESPACE, bsn);
@@ -67,7 +67,7 @@ public final class StandardRegionFilter implements RegionFilter {
 
 	@Override
 	public boolean isAllowed(BundleRevision bundle) {
-		HashMap<String, Object> attrs = new HashMap<String, Object>(4);
+		HashMap<String, Object> attrs = new HashMap<>(4);
 		String bsn = bundle.getSymbolicName();
 		if (bsn != null) {
 			attrs.put(VISIBLE_BUNDLE_NAMESPACE, bsn);
@@ -184,7 +184,7 @@ public final class StandardRegionFilter implements RegionFilter {
 
 	@Override
 	public Map<String, Collection<String>> getSharingPolicy() {
-		Map<String, Collection<String>> result = new HashMap<String, Collection<String>>((int) ((filters.size() / 0.75) + 1));
+		Map<String, Collection<String>> result = new HashMap<>((int) ((filters.size() / 0.75) + 1));
 		for (Map.Entry<String, Collection<Filter>> namespace : filters.entrySet()) {
 			result.put(namespace.getKey(), getFilters(namespace.getValue()));
 		}
@@ -192,7 +192,7 @@ public final class StandardRegionFilter implements RegionFilter {
 	}
 
 	private static Collection<String> getFilters(Collection<Filter> filters) {
-		Collection<String> result = new ArrayList<String>(filters.size());
+		Collection<String> result = new ArrayList<>(filters.size());
 		for (Filter filter : filters) {
 			result.add(filter.toString());
 		}

--- a/bundles/org.eclipse.equinox.region/src/org/eclipse/equinox/internal/region/StandardRegionFilterBuilder.java
+++ b/bundles/org.eclipse.equinox.region/src/org/eclipse/equinox/internal/region/StandardRegionFilterBuilder.java
@@ -26,7 +26,7 @@ public final class StandardRegionFilterBuilder implements RegionFilterBuilder {
 
 	private final Object monitor = new Object();
 
-	private final Map<String, Collection<Filter>> policy = new HashMap<String, Collection<Filter>>();
+	private final Map<String, Collection<Filter>> policy = new HashMap<>();
 
 	@SuppressWarnings("deprecation")
 	@Override
@@ -74,7 +74,7 @@ public final class StandardRegionFilterBuilder implements RegionFilterBuilder {
 		Collection<Filter> namespaceFilters = policy.get(namespace);
 		if (namespaceFilters == null) {
 			// use set to avoid duplicates
-			namespaceFilters = new LinkedHashSet<Filter>();
+			namespaceFilters = new LinkedHashSet<>();
 			policy.put(namespace, namespaceFilters);
 		}
 		return namespaceFilters;

--- a/bundles/org.eclipse.equinox.region/src/org/eclipse/equinox/internal/region/SubgraphTraverser.java
+++ b/bundles/org.eclipse.equinox.region/src/org/eclipse/equinox/internal/region/SubgraphTraverser.java
@@ -56,7 +56,7 @@ final class SubgraphTraverser {
 	}
 
 	private Set<Region> extendPath(Region r, Set<Region> path) {
-		Set<Region> newPath = new HashSet<Region>(path);
+		Set<Region> newPath = new HashSet<>(path);
 		newPath.add(r);
 		return newPath;
 	}

--- a/bundles/org.eclipse.equinox.region/src/org/eclipse/equinox/internal/region/hook/RegionBundleEventHook.java
+++ b/bundles/org.eclipse.equinox.region/src/org/eclipse/equinox/internal/region/hook/RegionBundleEventHook.java
@@ -54,7 +54,7 @@ public final class RegionBundleEventHook implements EventHook {
 		if (event.getType() == BundleEvent.INSTALLED) {
 			bundleInstalled(eventBundle, event.getOrigin());
 		}
-		Map<Region, Boolean> regionAccess = new HashMap<Region, Boolean>();
+		Map<Region, Boolean> regionAccess = new HashMap<>();
 		Iterator<BundleContext> i = contexts.iterator();
 		while (i.hasNext()) {
 			Bundle bundle = RegionBundleFindHook.getBundle(i.next());
@@ -91,7 +91,7 @@ public final class RegionBundleEventHook implements EventHook {
 	}
 
 	private boolean isAccessible(Region region, Bundle candidateBundle) {
-		Collection<Bundle> candidates = new ArrayList<Bundle>(1);
+		Collection<Bundle> candidates = new ArrayList<>(1);
 		candidates.add(candidateBundle);
 		RegionBundleFindHook.find(region, candidates);
 		return !candidates.isEmpty();

--- a/bundles/org.eclipse.equinox.region/src/org/eclipse/equinox/internal/region/hook/RegionBundleFindHook.java
+++ b/bundles/org.eclipse.equinox.region/src/org/eclipse/equinox/internal/region/hook/RegionBundleFindHook.java
@@ -95,7 +95,7 @@ public final class RegionBundleFindHook implements FindHook {
 		}
 
 		private boolean isLifecycleAllowed(RegionFilter filter, Bundle bundle) {
-			HashMap<String, Object> attrs = new HashMap<String, Object>(4);
+			HashMap<String, Object> attrs = new HashMap<>(4);
 			String bsn = bundle.getSymbolicName();
 			if (bsn != null) {
 				attrs.put(RegionFilter.VISIBLE_BUNDLE_NAMESPACE, bsn);

--- a/bundles/org.eclipse.equinox.region/src/org/eclipse/equinox/internal/region/hook/RegionDigraphVisitorBase.java
+++ b/bundles/org.eclipse.equinox.region/src/org/eclipse/equinox/internal/region/hook/RegionDigraphVisitorBase.java
@@ -29,8 +29,8 @@ abstract class RegionDigraphVisitorBase<C> implements RegionDigraphVisitor {
 
 	private final Collection<C> allCandidates;
 
-	private final Stack<Set<C>> allowedStack = new Stack<Set<C>>();
-	private final Stack<Collection<C>> filteredStack = new Stack<Collection<C>>();
+	private final Stack<Set<C>> allowedStack = new Stack<>();
+	private final Stack<Collection<C>> filteredStack = new Stack<>();
 
 	private final Object monitor;
 
@@ -38,7 +38,7 @@ abstract class RegionDigraphVisitorBase<C> implements RegionDigraphVisitor {
 
 	protected RegionDigraphVisitorBase(Collection<C> candidates) {
 		this.allCandidates = candidates;
-		this.allowed = new HashSet<C>();
+		this.allowed = new HashSet<>();
 		this.monitor = new Object();
 	}
 
@@ -63,7 +63,7 @@ abstract class RegionDigraphVisitorBase<C> implements RegionDigraphVisitor {
 	private void pushAllowed() {
 		synchronized (this.monitor) {
 			this.allowedStack.push(this.allowed);
-			this.allowed = new HashSet<C>();
+			this.allowed = new HashSet<>();
 		}
 	}
 
@@ -127,7 +127,7 @@ abstract class RegionDigraphVisitorBase<C> implements RegionDigraphVisitor {
 	@Override
 	public boolean preEdgeTraverse(RegionFilter regionFilter) {
 		// Find the candidates filtered by the previous edge
-		Collection<C> candidates = new ArrayList<C>(peekFiltered());
+		Collection<C> candidates = new ArrayList<>(peekFiltered());
 		// remove any candidates contained in the current region
 		candidates.removeAll(allowed);
 		// apply the filter across remaining candidates

--- a/bundles/org.eclipse.equinox.region/src/org/eclipse/equinox/internal/region/hook/RegionServiceEventHook.java
+++ b/bundles/org.eclipse.equinox.region/src/org/eclipse/equinox/internal/region/hook/RegionServiceEventHook.java
@@ -46,7 +46,7 @@ public final class RegionServiceEventHook implements EventHook {
 	 */
 	public void event(ServiceEvent event, Collection<BundleContext> contexts) {
 		ServiceReference<?> eventService = event.getServiceReference();
-		Map<Region, Boolean> regionAccess = new HashMap<Region, Boolean>();
+		Map<Region, Boolean> regionAccess = new HashMap<>();
 		Iterator<BundleContext> i = contexts.iterator();
 		while (i.hasNext()) {
 			Bundle bundle = RegionBundleFindHook.getBundle(i.next());
@@ -78,7 +78,7 @@ public final class RegionServiceEventHook implements EventHook {
 	}
 
 	private Boolean isAccessible(Region region, ServiceReference<?> candidateServiceReference) {
-		Collection<ServiceReference<?>> candidates = new ArrayList<ServiceReference<?>>(1);
+		Collection<ServiceReference<?>> candidates = new ArrayList<>(1);
 		candidates.add(candidateServiceReference);
 		RegionServiceFindHook.find(region, candidates);
 		return !candidates.isEmpty();

--- a/bundles/org.eclipse.equinox.region/src/org/eclipse/equinox/internal/region/management/StandardManageableRegion.java
+++ b/bundles/org.eclipse.equinox.region/src/org/eclipse/equinox/internal/region/management/StandardManageableRegion.java
@@ -59,7 +59,7 @@ public class StandardManageableRegion implements ManageableRegion {
 	@Override
 	public ManageableRegion[] getDependencies() {
 		Set<FilteredRegion> edges = this.regionDigraph.getEdges(this.region);
-		List<ManageableRegion> dependencies = new ArrayList<ManageableRegion>();
+		List<ManageableRegion> dependencies = new ArrayList<>();
 		for (FilteredRegion edge : edges) {
 			ManageableRegion manageableRegion = this.manageableRegionDigraph.getRegion(edge.getRegion().getName());
 			if (manageableRegion != null) {

--- a/bundles/org.eclipse.equinox.region/src/org/eclipse/equinox/internal/region/management/StandardManageableRegionDigraph.java
+++ b/bundles/org.eclipse.equinox.region/src/org/eclipse/equinox/internal/region/management/StandardManageableRegionDigraph.java
@@ -41,7 +41,7 @@ public final class StandardManageableRegionDigraph implements ManageableRegionDi
 
 	private final RegionObjectNameCreator regionObjectNameCreator;
 
-	private final Map<String, ManageableRegion> manageableRegions = new ConcurrentHashMap<String, ManageableRegion>();
+	private final Map<String, ManageableRegion> manageableRegions = new ConcurrentHashMap<>();
 
 	private final BundleContext bundleContext;
 
@@ -117,7 +117,7 @@ public final class StandardManageableRegionDigraph implements ManageableRegionDi
 		unregisterRegionLifecycleListener();
 		Collection<String> currentRegionNames;
 		synchronized (this.monitor) {
-			currentRegionNames = new ArrayList<String>(this.manageableRegions.keySet());
+			currentRegionNames = new ArrayList<>(this.manageableRegions.keySet());
 		}
 		for (String regionName : currentRegionNames) {
 			removeRegion(regionName);
@@ -152,7 +152,7 @@ public final class StandardManageableRegionDigraph implements ManageableRegionDi
 	 */
 	@Override
 	public ManageableRegion[] getRegions() {
-		List<ManageableRegion> regions = new ArrayList<ManageableRegion>();
+		List<ManageableRegion> regions = new ArrayList<>();
 		synchronized (this.monitor) {
 			for (ManageableRegion manageableRegion : this.manageableRegions.values()) {
 				regions.add(manageableRegion);

--- a/bundles/org.eclipse.equinox.security.ui/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.security.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.security.ui;singleton:=true
-Bundle-Version: 1.3.200.qualifier
+Bundle-Version: 1.3.300.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Import-Package: javax.crypto.spec,

--- a/bundles/org.eclipse.equinox.security.ui/src/org/eclipse/equinox/internal/security/ui/wizard/CertificateImportCertSelectPage.java
+++ b/bundles/org.eclipse.equinox.security.ui/src/org/eclipse/equinox/internal/security/ui/wizard/CertificateImportCertSelectPage.java
@@ -85,9 +85,7 @@ public class CertificateImportCertSelectPage extends WizardPage implements Liste
 				certList.add(certificate);
 			}
 
-		} catch (CertificateException e) {
-			setErrorMessage(e.getMessage());
-		} catch (FileNotFoundException e) {
+		} catch (CertificateException | FileNotFoundException e) {
 			setErrorMessage(e.getMessage());
 		}
 

--- a/bundles/org.eclipse.equinox.security/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.security/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.security;singleton:=true
-Bundle-Version: 1.3.900.qualifier
+Bundle-Version: 1.3.1000.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-Activator: org.eclipse.equinox.internal.security.auth.AuthPlugin

--- a/bundles/org.eclipse.equinox.security/pom.xml
+++ b/bundles/org.eclipse.equinox.security/pom.xml
@@ -19,7 +19,7 @@
 </parent>
   <groupId>org.eclipse.equinox</groupId>
   <artifactId>org.eclipse.equinox.security</artifactId>
-  <version>1.3.900-SNAPSHOT</version>
+  <version>1.3.1000-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <build>

--- a/bundles/org.eclipse.equinox.security/src/org/eclipse/equinox/internal/security/storage/SecurePreferencesRoot.java
+++ b/bundles/org.eclipse.equinox.security/src/org/eclipse/equinox/internal/security/storage/SecurePreferencesRoot.java
@@ -110,9 +110,7 @@ public class SecurePreferencesRoot extends SecurePreferences implements IStorage
 			return;
 
 		Properties properties = new Properties();
-		InputStream is = null;
-		try {
-			is = StorageUtils.getInputStream(location);
+		try (InputStream is = StorageUtils.getInputStream(location)) {
 			if (is != null) {
 				properties.load(is);
 				timestamp = getLastModified();
@@ -122,9 +120,6 @@ public class SecurePreferencesRoot extends SecurePreferences implements IStorage
 			AuthPlugin.getDefault().logError(msg, e);
 			location = null; // don't attempt to use it 
 			return;
-		} finally {
-			if (is != null)
-				is.close();
 		}
 
 		// In future new versions could be added
@@ -193,14 +188,9 @@ public class SecurePreferencesRoot extends SecurePreferences implements IStorage
 		flush(properties, null);
 
 		// output
-		OutputStream stream = null;
-		try {
-			stream = StorageUtils.getOutputStream(location);
+		try (OutputStream stream = StorageUtils.getOutputStream(location)) {
 			properties.store(stream, description);
 			modified = false;
-		} finally {
-			if (stream != null)
-				stream.close();
 		}
 		timestamp = getLastModified();
 	}

--- a/bundles/org.eclipse.equinox.servletbridge/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.servletbridge/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.equinox.servletbridge;singleton:=true
-Bundle-Version: 1.6.100.qualifier
+Bundle-Version: 1.6.200.qualifier
 Bundle-Localization: plugin
 Import-Package: javax.servlet;version="2.3.0",
  javax.servlet.http;version="2.3.0"

--- a/bundles/org.eclipse.equinox.servletbridge/src/org/eclipse/equinox/servletbridge/FrameworkLauncher.java
+++ b/bundles/org.eclipse.equinox.servletbridge/src/org/eclipse/equinox/servletbridge/FrameworkLauncher.java
@@ -853,8 +853,6 @@ public class FrameworkLauncher {
 				in = location.openStream();
 				result.load(in);
 			}
-		} catch (MalformedURLException e) {
-			// no url to load from
 		} catch (IOException e) {
 			// its ok if there is no file
 		} finally {

--- a/bundles/org.eclipse.equinox.servletbridge/src/org/eclipse/equinox/servletbridge/FrameworkLauncher.java
+++ b/bundles/org.eclipse.equinox.servletbridge/src/org/eclipse/equinox/servletbridge/FrameworkLauncher.java
@@ -303,13 +303,8 @@ public class FrameworkLauncher {
 
 	private void writeJarFile(File jarFile, Manifest mf) {
 		try {
-			JarOutputStream jos = null;
-			try {
-				jos = new JarOutputStream(new FileOutputStream(jarFile), mf);
+			try (JarOutputStream jos = new JarOutputStream(new FileOutputStream(jarFile), mf)) {
 				jos.finish();
-			} finally {
-				if (jos != null)
-					jos.close();
 			}
 		} catch (IOException e) {
 			context.log("Error writing extension bundle", e); //$NON-NLS-1$
@@ -318,13 +313,8 @@ public class FrameworkLauncher {
 
 	private Manifest readJarFile(File jarFile) {
 		try {
-			JarInputStream jis = null;
-			try {
-				jis = new JarInputStream(new FileInputStream(jarFile));
+			try (JarInputStream jis = new JarInputStream(new FileInputStream(jarFile))) {
 				return jis.getManifest();
-			} finally {
-				if (jis != null)
-					jis.close();
 			}
 		} catch (IOException e) {
 			context.log("Error reading extension bundle", e); //$NON-NLS-1$

--- a/bundles/org.eclipse.equinox.transforms.hook/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.transforms.hook/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.equinox.transforms.hook
-Bundle-Version: 1.3.100.qualifier
+Bundle-Version: 1.3.200.qualifier
 Fragment-Host: org.eclipse.osgi;bundle-version="[3.10.0,4.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Localization: transformsHook

--- a/bundles/org.eclipse.equinox.transforms.hook/src/org/eclipse/equinox/internal/transforms/CSVParser.java
+++ b/bundles/org.eclipse.equinox.transforms.hook/src/org/eclipse/equinox/internal/transforms/CSVParser.java
@@ -41,7 +41,7 @@ public class CSVParser {
 	public static TransformTuple[] parse(URL transformMapURL, EquinoxLogServices logServices) throws IOException {
 		BufferedReader reader = new BufferedReader(new InputStreamReader(transformMapURL.openStream()));
 		String currentLine = null;
-		List<TransformTuple> list = new ArrayList<TransformTuple>();
+		List<TransformTuple> list = new ArrayList<>();
 		while ((currentLine = reader.readLine()) != null) {
 			if (currentLine.startsWith("#")) { //$NON-NLS-1$
 				continue;

--- a/bundles/org.eclipse.equinox.transforms.hook/src/org/eclipse/equinox/internal/transforms/TransformInstanceListData.java
+++ b/bundles/org.eclipse.equinox.transforms.hook/src/org/eclipse/equinox/internal/transforms/TransformInstanceListData.java
@@ -37,17 +37,17 @@ public class TransformInstanceListData extends ServiceTracker<URL, URL> {
 	/**
 	 * Map from transformer class -> tuple array
 	 */
-	private Map<String, TransformTuple[]> transformerToTuple = new HashMap<String, TransformTuple[]>();
+	private Map<String, TransformTuple[]> transformerToTuple = new HashMap<>();
 
 	/**
 	 * List of all tuples in the system.
 	 */
-	private List<TransformTuple> rawTuples = new ArrayList<TransformTuple>();
+	private List<TransformTuple> rawTuples = new ArrayList<>();
 
 	/**
 	 * Map from bundle ID -> boolean representing whether or not a given bundle currently has any transforms registered against it.
 	 */
-	private Map<String, Boolean> bundleIdToTransformPresence = new HashMap<String, Boolean>();
+	private Map<String, Boolean> bundleIdToTransformPresence = new HashMap<>();
 	private final EquinoxLogServices logServices;
 
 	/**

--- a/bundles/org.eclipse.equinox.transforms.hook/src/org/eclipse/equinox/internal/transforms/TransformerList.java
+++ b/bundles/org.eclipse.equinox.transforms.hook/src/org/eclipse/equinox/internal/transforms/TransformerList.java
@@ -34,7 +34,7 @@ public class TransformerList extends ServiceTracker<Object, Object> {
 	/**
 	 * Local cache of transformers.
 	 */
-	private HashMap<String, StreamTransformer> transformers = new HashMap<String, StreamTransformer>();
+	private HashMap<String, StreamTransformer> transformers = new HashMap<>();
 	private final EquinoxLogServices logServices;
 
 	/**

--- a/bundles/org.eclipse.equinox.weaving.caching/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.weaving.caching/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.equinox.weaving.caching
-Bundle-Version: 1.2.100.qualifier
+Bundle-Version: 1.2.200.qualifier
 Bundle-Name: Standard Caching Service for Equinox Aspects
 Bundle-Vendor: Eclipse.org - Equinox
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/bundles/org.eclipse.equinox.weaving.caching/pom.xml
+++ b/bundles/org.eclipse.equinox.weaving.caching/pom.xml
@@ -19,7 +19,7 @@
 </parent>
   <groupId>org.eclipse.equinox</groupId>
   <artifactId>org.eclipse.equinox.weaving.caching</artifactId>
-  <version>1.2.100-SNAPSHOT</version>
+  <version>1.2.200-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <build>

--- a/bundles/org.eclipse.equinox.weaving.caching/src/org/eclipse/equinox/weaving/internal/caching/CachingServiceFactory.java
+++ b/bundles/org.eclipse.equinox.weaving.caching/src/org/eclipse/equinox/weaving/internal/caching/CachingServiceFactory.java
@@ -37,7 +37,7 @@ import org.osgi.framework.Version;
  */
 public class CachingServiceFactory implements ICachingServiceFactory {
 
-    private final Map<String, ICachingService> bundleCachingServices = new HashMap<String, ICachingService>();
+    private final Map<String, ICachingService> bundleCachingServices = new HashMap<>();
 
     private final BundleContext bundleContext;
 
@@ -55,7 +55,7 @@ public class CachingServiceFactory implements ICachingServiceFactory {
                     "Argument \"bundleContext\" must not be null!"); //$NON-NLS-1$
         }
         this.bundleContext = bundleContext;
-        this.cacheQueue = new ArrayBlockingQueue<CacheItem>(5000);
+        this.cacheQueue = new ArrayBlockingQueue<>(5000);
         this.cacheWriter = new CacheWriter(this.cacheQueue);
         this.cacheWriter.start();
 

--- a/bundles/org.eclipse.equinox.weaving.hook/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.weaving.hook/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Aspect Weaving Hooks Plug-in
 Bundle-SymbolicName: org.eclipse.equinox.weaving.hook
-Bundle-Version: 1.3.100.qualifier
+Bundle-Version: 1.3.200.qualifier
 Fragment-Host: org.eclipse.osgi;bundle-version="[3.10.0,4.0.0)"
 Bundle-Vendor: Eclipse.org - Equinox
 Export-Package: org.eclipse.equinox.service.weaving,

--- a/bundles/org.eclipse.equinox.weaving.hook/src/org/eclipse/equinox/service/weaving/Supplementer.java
+++ b/bundles/org.eclipse.equinox.weaving.hook/src/org/eclipse/equinox/service/weaving/Supplementer.java
@@ -67,7 +67,7 @@ public class Supplementer {
         this.supplementBundle = supplementBundle;
         this.supplementImporter = supplementImporter;
         this.supplementExporter = supplementExporter;
-        this.supplementedBundles = new HashSet<Bundle>();
+        this.supplementedBundles = new HashSet<>();
     }
 
     /**

--- a/bundles/org.eclipse.equinox.weaving.hook/src/org/eclipse/equinox/weaving/adaptors/WeavingAdaptor.java
+++ b/bundles/org.eclipse.equinox.weaving.hook/src/org/eclipse/equinox/weaving/adaptors/WeavingAdaptor.java
@@ -45,7 +45,7 @@ public class WeavingAdaptor implements IWeavingAdaptor {
 
         @Override
         protected Set<Object> initialValue() {
-            return new HashSet<Object>();
+            return new HashSet<>();
         }
 
         public void put(final Object obj) {

--- a/bundles/org.eclipse.equinox.weaving.hook/src/org/eclipse/equinox/weaving/adaptors/WeavingAdaptorFactory.java
+++ b/bundles/org.eclipse.equinox.weaving.hook/src/org/eclipse/equinox/weaving/adaptors/WeavingAdaptorFactory.java
@@ -64,7 +64,7 @@ public class WeavingAdaptorFactory {
 
     private ServiceListener weavingServiceListener;
 
-    private final Map<Bundle, IWeavingService> weavingServices = new ConcurrentHashMap<Bundle, IWeavingService>();
+    private final Map<Bundle, IWeavingService> weavingServices = new ConcurrentHashMap<>();
 
     public WeavingAdaptorFactory() {
     }
@@ -162,7 +162,7 @@ public class WeavingAdaptorFactory {
         initializeStartLevelService(context);
 
         // Service tracker for weaving service
-        weavingServiceFactoryTracker = new ServiceTracker<IWeavingServiceFactory, IWeavingServiceFactory>(
+        weavingServiceFactoryTracker = new ServiceTracker<>(
                 context, IWeavingServiceFactory.class, null);
         weavingServiceFactoryTracker.open();
         if (Debug.DEBUG_WEAVE)
@@ -174,7 +174,7 @@ public class WeavingAdaptorFactory {
             @Override
             public void serviceChanged(final ServiceEvent event) {
                 if (event.getType() == ServiceEvent.REGISTERED) {
-                    final List<Bundle> bundlesToRefresh = new ArrayList<Bundle>();
+                    final List<Bundle> bundlesToRefresh = new ArrayList<>();
 
                     synchronized (weavingServices) {
                         final Iterator<Bundle> bundleEntries = weavingServices
@@ -197,7 +197,7 @@ public class WeavingAdaptorFactory {
                 if (event.getType() == ServiceEvent.UNREGISTERING
                         && startLevelService != null
                         && startLevelService.getStartLevel() > 0) {
-                    final List<Bundle> bundlesToRefresh = new ArrayList<Bundle>();
+                    final List<Bundle> bundlesToRefresh = new ArrayList<>();
 
                     synchronized (weavingServices) {
                         final Iterator<Bundle> bundleEntries = weavingServices
@@ -229,7 +229,7 @@ public class WeavingAdaptorFactory {
         }
 
         // Service tracker for caching service
-        cachingServiceFactoryTracker = new ServiceTracker<ICachingServiceFactory, ICachingServiceFactory>(
+        cachingServiceFactoryTracker = new ServiceTracker<>(
                 context, ICachingServiceFactory.class, null);
         cachingServiceFactoryTracker.open();
         if (Debug.DEBUG_CACHE)

--- a/bundles/org.eclipse.equinox.weaving.hook/src/org/eclipse/equinox/weaving/hooks/SupplementerRegistry.java
+++ b/bundles/org.eclipse.equinox.weaving.hook/src/org/eclipse/equinox/weaving/hooks/SupplementerRegistry.java
@@ -97,9 +97,9 @@ public class SupplementerRegistry implements ISupplementerRegistry {
     public SupplementerRegistry(final IAdaptorProvider adaptorProvider) {
         this.adaptorProvider = adaptorProvider;
 
-        this.supplementers = new HashMap<String, Supplementer>();
-        this.supplementersByBundle = new HashMap<Long, Supplementer[]>();
-        this.dontWeaveTheseBundles = new HashSet<String>();
+        this.supplementers = new HashMap<>();
+        this.supplementersByBundle = new HashMap<>();
+        this.dontWeaveTheseBundles = new HashSet<>();
 
         this.dontWeaveTheseBundles.add("org.eclipse.osgi");
         this.dontWeaveTheseBundles.add("org.eclipse.core.runtime");
@@ -213,7 +213,7 @@ public class SupplementerRegistry implements ISupplementerRegistry {
 
         if (supplementers.size() > 0
                 && !this.dontWeaveTheseBundles.contains(symbolicName)) {
-            result = new LinkedList<Supplementer>();
+            result = new LinkedList<>();
             for (Supplementer supplementer : supplementers.values()) {
                 if (isSupplementerMatching(symbolicName, imports, exports,
                         supplementer)) {
@@ -314,7 +314,7 @@ public class SupplementerRegistry implements ISupplementerRegistry {
             final Bundle[] supplementedBundles = supplementer
                     .getSupplementedBundles();
             if (supplementedBundles != null && supplementedBundles.length > 0) {
-                final List<Bundle> bundlesToRefresh = new ArrayList<Bundle>(
+                final List<Bundle> bundlesToRefresh = new ArrayList<>(
                         supplementedBundles.length);
                 for (final Bundle bundleToRefresh : supplementedBundles) {
                     if (this.adaptorProvider.getAdaptor(
@@ -332,7 +332,7 @@ public class SupplementerRegistry implements ISupplementerRegistry {
             // remove this supplementer from the list of supplementers per other bundle
             for (Bundle supplementedBundle : supplementedBundles) {
                 final long bundleId = supplementedBundle.getBundleId();
-                final List<Supplementer> supplementerList = new ArrayList<Supplementer>(
+                final List<Supplementer> supplementerList = new ArrayList<>(
                         Arrays.asList(
                                 this.supplementersByBundle.get(bundleId)));
                 supplementerList.remove(supplementer);
@@ -351,7 +351,7 @@ public class SupplementerRegistry implements ISupplementerRegistry {
     private void resupplementInstalledBundles(final Supplementer supplementer) {
         final Bundle[] installedBundles = context.getBundles();
 
-        final List<Bundle> bundlesToRefresh = new ArrayList<Bundle>();
+        final List<Bundle> bundlesToRefresh = new ArrayList<>();
 
         for (Bundle installedBundle : installedBundles) {
             try {
@@ -385,10 +385,10 @@ public class SupplementerRegistry implements ISupplementerRegistry {
                                 .get(bundle.getBundleId());
                         List<Supplementer> enhancedSupplementerList = null;
                         if (existingSupplementers != null) {
-                            enhancedSupplementerList = new ArrayList<Supplementer>(
+                            enhancedSupplementerList = new ArrayList<>(
                                     Arrays.asList(existingSupplementers));
                         } else {
-                            enhancedSupplementerList = new ArrayList<Supplementer>();
+                            enhancedSupplementerList = new ArrayList<>();
                         }
                         if (!enhancedSupplementerList.contains(supplementer)) {
                             enhancedSupplementerList.add(supplementer);

--- a/bundles/org.eclipse.equinox.weaving.hook/src/org/eclipse/equinox/weaving/hooks/WeavingHook.java
+++ b/bundles/org.eclipse.equinox.weaving.hook/src/org/eclipse/equinox/weaving/hooks/WeavingHook.java
@@ -50,7 +50,7 @@ public class WeavingHook extends AbstractWeavingHook {
         if (Debug.DEBUG_GENERAL) Debug.println("- WeavingHook.<init>()");
 
         this.adaptorFactory = new WeavingAdaptorFactory();
-        this.adaptors = new HashMap<Long, IWeavingAdaptor>();
+        this.adaptors = new HashMap<>();
     }
 
     @Override

--- a/bundles/org.eclipse.equinox.weaving.hook/src/org/eclipse/equinox/weaving/hooks/WeavingLoaderDelegateHook.java
+++ b/bundles/org.eclipse.equinox.weaving.hook/src/org/eclipse/equinox/weaving/hooks/WeavingLoaderDelegateHook.java
@@ -44,7 +44,7 @@ public class WeavingLoaderDelegateHook extends ClassLoaderHook {
 
         @Override
         protected Set<String> initialValue() {
-            return new HashSet<String>();
+            return new HashSet<>();
         }
     };
 
@@ -52,7 +52,7 @@ public class WeavingLoaderDelegateHook extends ClassLoaderHook {
 
         @Override
         protected Set<String> initialValue() {
-            return new HashSet<String>();
+            return new HashSet<>();
         }
     };
 
@@ -60,7 +60,7 @@ public class WeavingLoaderDelegateHook extends ClassLoaderHook {
 
         @Override
         protected Set<String> initialValue() {
-            return new HashSet<String>();
+            return new HashSet<>();
         }
     };
 

--- a/bundles/org.eclipse.osgi.compatibility.state/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.osgi.compatibility.state/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.osgi.compatibility.state
-Bundle-Version: 1.2.600.qualifier
+Bundle-Version: 1.2.700.qualifier
 ExtensionBundle-Activator: org.eclipse.osgi.compatibility.state.Activator
 Fragment-Host: org.eclipse.osgi;bundle-version="3.12.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/bundles/org.eclipse.osgi.compatibility.state/src/org/eclipse/osgi/internal/resolver/StateReader.java
+++ b/bundles/org.eclipse.osgi.compatibility.state/src/org/eclipse/osgi/internal/resolver/StateReader.java
@@ -837,9 +837,7 @@ final class StateReader {
 
 	void fullyLoad(BundleDescriptionImpl target) throws IOException {
 		setAccessedFlag(true);
-		DataInputStream in = null;
-		try {
-			in = openLazyFile();
+		try (DataInputStream in = openLazyFile()) {
 			// get the set of bundles that must be loaded according to dependencies
 			List<BundleDescriptionImpl> toLoad = new ArrayList<>();
 			addDependencies(target, toLoad);
@@ -847,9 +845,6 @@ final class StateReader {
 			// look for the lazy data of the toLoad list
 			for (int i = 0; i < skipBytes.length; i++)
 				readBundleDescriptionLazyData(in, skipBytes[i]);
-		} finally {
-			if (in != null)
-				in.close();
 		}
 	}
 

--- a/bundles/org.eclipse.osgi.tests/bundles_src/ext.extclasspath.a.importer/ext/extclasspath/a/importer/Activator.java
+++ b/bundles/org.eclipse.osgi.tests/bundles_src/ext.extclasspath.a.importer/ext/extclasspath/a/importer/Activator.java
@@ -28,11 +28,8 @@ public class Activator implements BundleActivator {
 	}
 
 	private String getURLContent(URL resource) throws IOException {
-		BufferedReader br = new BufferedReader(new InputStreamReader(resource.openStream()));
-		try {
+		try (BufferedReader br = new BufferedReader(new InputStreamReader(resource.openStream()))) {
 			return br.readLine();
-		} finally {
-			br.close();
 		}
 	}
 

--- a/bundles/org.eclipse.osgi.tests/bundles_src/ext.framework.a.importer/ext/framework/a/importer/Activator.java
+++ b/bundles/org.eclipse.osgi.tests/bundles_src/ext.framework.a.importer/ext/framework/a/importer/Activator.java
@@ -32,11 +32,8 @@ public class Activator implements BundleActivator {
 	}
 
 	private String getURLContent(URL resource) throws IOException {
-		BufferedReader br = new BufferedReader(new InputStreamReader(resource.openStream()));
-		try {
+		try (BufferedReader br = new BufferedReader(new InputStreamReader(resource.openStream()))) {
 			return br.readLine();
-		} finally {
-			br.close();
 		}
 	}
 

--- a/bundles/org.eclipse.osgi.tests/bundles_src/ext.framework.a.requires/ext/framework/a/requires/Activator.java
+++ b/bundles/org.eclipse.osgi.tests/bundles_src/ext.framework.a.requires/ext/framework/a/requires/Activator.java
@@ -32,11 +32,8 @@ public class Activator implements BundleActivator {
 	}
 
 	private String getURLContent(URL resource) throws IOException {
-		BufferedReader br = new BufferedReader(new InputStreamReader(resource.openStream()));
-		try {
+		try (BufferedReader br = new BufferedReader(new InputStreamReader(resource.openStream()))) {
 			return br.readLine();
-		} finally {
-			br.close();
 		}
 	}
 

--- a/bundles/org.eclipse.osgi.tests/bundles_src/test.link.a.client/test/link/a/client/Activator.java
+++ b/bundles/org.eclipse.osgi.tests/bundles_src/test.link.a.client/test/link/a/client/Activator.java
@@ -38,13 +38,10 @@ public class Activator implements BundleActivator {
 		URL resource = this.getClass().getResource("/test/link/a/resource.txt"); //$NON-NLS-1$
 		if (resource == null)
 			throw new RuntimeException("Did not find resource.txt"); //$NON-NLS-1$
-		BufferedReader reader = new BufferedReader(new InputStreamReader(resource.openStream()));
-		try {
+		try (BufferedReader reader = new BufferedReader(new InputStreamReader(resource.openStream()))) {
 			String content = reader.readLine();
 			if (!"Test content".equals(content)) //$NON-NLS-1$
 				throw new RuntimeException("Unexpected content in resource.txt: " + content); //$NON-NLS-1$
-		} finally {
-			reader.close();
 		}
 		// test resource that does not exist
 		URL notExist = this.getClass().getResource("/test/link/b/DoesNotExist.txt"); //$NON-NLS-1$

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/appadmin/ApplicationAdminTest.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/appadmin/ApplicationAdminTest.java
@@ -838,9 +838,7 @@ public class ApplicationAdminTest extends OSGiTest {
 			args.put("test.arg2", Integer.valueOf(34)); //$NON-NLS-1$
 			args.put("test.arg3", Long.valueOf(34)); //$NON-NLS-1$
 			app.schedule("schedule.1", args, "org/osgi/application/timer", "(minute=*)", true); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-		} catch (InvalidSyntaxException e) {
-			fail("Failed to schedule an application", e); //$NON-NLS-1$
-		} catch (ApplicationException e) {
+		} catch (InvalidSyntaxException | ApplicationException e) {
 			fail("Failed to schedule an application", e); //$NON-NLS-1$
 		}
 	}
@@ -898,9 +896,7 @@ public class ApplicationAdminTest extends OSGiTest {
 			args.put("test.arg3", Long.valueOf(34)); //$NON-NLS-1$
 			// make it non-recurring
 			app.schedule("schedule.2", args, "org/osgi/application/timer", "(minute=*)", false); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-		} catch (InvalidSyntaxException e) {
-			fail("Failed to schedule an application", e); //$NON-NLS-1$
-		} catch (ApplicationException e) {
+		} catch (InvalidSyntaxException | ApplicationException e) {
 			fail("Failed to schedule an application", e); //$NON-NLS-1$
 		}
 	}
@@ -973,9 +969,7 @@ public class ApplicationAdminTest extends OSGiTest {
 		ApplicationDescriptor app = getApplication(PI_OSGI_TESTS + ".simpleApp"); //$NON-NLS-1$
 		try {
 			app.schedule("schedule.duplicate1", null, "org/osgi/application/timer", "(minute=*)", true); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-		} catch (InvalidSyntaxException e) {
-			fail("Failed to schedule an application", e); //$NON-NLS-1$
-		} catch (ApplicationException e) {
+		} catch (InvalidSyntaxException | ApplicationException e) {
 			fail("Failed to schedule an application", e); //$NON-NLS-1$
 		}
 		try {

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/bundles/DiscardBundleTests.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/bundles/DiscardBundleTests.java
@@ -209,11 +209,8 @@ public class DiscardBundleTests extends AbstractBundleTests {
 		File file = new File(root, BUNDLE_DIR + '/' + BUNDLE_MANIFEST);
 		assertTrue("Could not make directories", file.getParentFile().mkdirs());
 		Manifest manifest = createBundleManifest();
-		FileOutputStream fos = new FileOutputStream(file);
-		try {
+		try (FileOutputStream fos = new FileOutputStream(file)) {
 			manifest.write(fos);
-		} finally {
-			fos.close();
 		}
 	}
 

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/bundles/MultiReleaseJarTests.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/bundles/MultiReleaseJarTests.java
@@ -520,11 +520,8 @@ public class MultiReleaseJarTests extends AbstractBundleTests {
 		if (url == null) {
 			return RNF;
 		}
-		BufferedReader br = new BufferedReader(new InputStreamReader(url.openStream()));
-		try {
+		try (BufferedReader br = new BufferedReader(new InputStreamReader(url.openStream()))) {
 			return br.readLine();
-		} finally {
-			br.close();
 		}
 	}
 

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/bundles/NativeCodeBundleTests.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/bundles/NativeCodeBundleTests.java
@@ -154,11 +154,8 @@ public class NativeCodeBundleTests extends AbstractBundleTests {
 	}
 
 	private String getContent(String file) throws IOException {
-		BufferedReader br = new BufferedReader(new InputStreamReader(new FileInputStream(file)));
-		try {
+		try (BufferedReader br = new BufferedReader(new InputStreamReader(new FileInputStream(file)))) {
 			return br.readLine();
-		} finally {
-			br.close();
 		}
 	}
 

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/hooks/framework/BundleFileWrapperFactoryHookTests.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/hooks/framework/BundleFileWrapperFactoryHookTests.java
@@ -77,16 +77,13 @@ public class BundleFileWrapperFactoryHookTests extends AbstractFrameworkHookTest
 	private String readURL(URL url) {
 		StringBuilder sb = new StringBuilder();
 		try {
-			BufferedReader reader = new BufferedReader(new InputStreamReader(url.openStream()));
-			try {
+			try (BufferedReader reader = new BufferedReader(new InputStreamReader(url.openStream()))) {
 				for (String line = reader.readLine(); line != null;) {
 					sb.append(line);
 					line = reader.readLine();
 					if (line != null)
 						sb.append('\n');
 				}
-			} finally {
-				reader.close();
 			}
 		} catch (IOException e) {
 			fail("Unexpected exception reading url: " + url.toExternalForm(), e); //$NON-NLS-1$

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/listeners/ExceptionHandlerTests.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/listeners/ExceptionHandlerTests.java
@@ -74,9 +74,7 @@ public class ExceptionHandlerTests {
 			Assert.assertEquals(true, eventReceived.getThrowable() instanceof NullPointerException);
 		} catch (MalformedURLException e) {
 			// Does not happen
-		} catch (BundleException e) {
-			e.printStackTrace();
-		} catch (IOException e) {
+		} catch (BundleException | IOException e) {
 			e.printStackTrace();
 		}
 		OSGiTestsActivator.getContext().removeFrameworkListener(fwkListener);
@@ -104,9 +102,7 @@ public class ExceptionHandlerTests {
 			System.setProperty("eclipse.exitOnError", "true");
 		} catch (MalformedURLException e) {
 			// Does not happen
-		} catch (BundleException e) {
-			e.printStackTrace();
-		} catch (IOException e) {
+		} catch (BundleException | IOException e) {
 			e.printStackTrace();
 		}
 		OSGiTestsActivator.getContext().removeFrameworkListener(fwkListener);

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/services/datalocation/FileManagerTests.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/services/datalocation/FileManagerTests.java
@@ -122,13 +122,10 @@ public class FileManagerTests extends OSGiTest {
 	}
 
 	void writeToFile(File file, String str) throws IOException {
-		FileOutputStream fos = new FileOutputStream(file);
-		try {
+		try (FileOutputStream fos = new FileOutputStream(file)) {
 			fos.write(str.getBytes());
 			fos.flush();
 			fos.getFD().sync();
-		} finally {
-			fos.close();
 		}
 	}
 

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/services/datalocation/StreamManagerTests.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/services/datalocation/StreamManagerTests.java
@@ -88,13 +88,10 @@ public class StreamManagerTests extends OSGiTest {
 	}
 
 	void writeToFile(File file, String str) throws IOException {
-		FileOutputStream fos = new FileOutputStream(file);
-		try {
+		try (FileOutputStream fos = new FileOutputStream(file)) {
 			fos.write(str.getBytes());
 			fos.flush();
 			fos.getFD().sync();
-		} finally {
-			fos.close();
 		}
 	}
 

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/services/resolver/OSGiCapabilityTest.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/services/resolver/OSGiCapabilityTest.java
@@ -50,9 +50,7 @@ public class OSGiCapabilityTest extends AbstractStateTest {
 			CaseInsensitiveDictionaryMap<String, String> headers = new CaseInsensitiveDictionaryMap<>();
 			ManifestElement.parseBundleManifest(url.openStream(), headers);
 			return headers.asUnmodifiableDictionary();
-		} catch (IOException e) {
-			fail("Unexpected error loading manifest: " + manifest, e);
-		} catch (BundleException e) {
+		} catch (IOException | BundleException e) {
 			fail("Unexpected error loading manifest: " + manifest, e);
 		}
 		return null;

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/services/resolver/StateResolverTest.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/services/resolver/StateResolverTest.java
@@ -3804,9 +3804,7 @@ public class StateResolverTest extends AbstractStateTest {
 			CaseInsensitiveDictionaryMap<String, String> headers = new CaseInsensitiveDictionaryMap<>();
 			ManifestElement.parseBundleManifest(url.openStream(), headers);
 			return headers.asUnmodifiableDictionary();
-		} catch (IOException e) {
-			fail("Unexpected error loading manifest: " + manifest, e);
-		} catch (BundleException e) {
+		} catch (IOException | BundleException e) {
 			fail("Unexpected error loading manifest: " + manifest, e);
 		}
 		return null;

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/storage/FrameworkExtensionInstaller.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/storage/FrameworkExtensionInstaller.java
@@ -80,8 +80,6 @@ public class FrameworkExtensionInstaller {
 				result.setAccessible(true);
 			}
 			return result;
-		} catch (SecurityException e) {
-			// if we do not have the permissions then we will not find the method
 		} catch (NoSuchMethodException | RuntimeException e) {
 			// do nothing look in super class below
 			// have to avoid blowing up <clinit>


### PR DESCRIPTION
Apply JDT clean ups

- "Use diamond operator"
- "Use try-with-resource"
- "Use try with multi-catch"

to Equinox-sources and ignore embedded felix and osgi sources.

The last clean up required manual removal of now unused Exception type imports but that problem has been reported to JDT.