### PR TITLE
Leverage enhanced ConfigurationSessionTestSuite

### DIFF
--- a/bundles/org.eclipse.osgi.tests/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.osgi.tests/META-INF/MANIFEST.MF
@@ -6,11 +6,16 @@ Bundle-Version: 3.16.800.qualifier
 Bundle-Vendor: Eclipse.org
 Require-Bundle: 
  org.eclipse.core.runtime,
- org.eclipse.core.tests.harness,
+ org.eclipse.core.tests.harness;bundle-version="3.13.0",
  org.eclipse.test.performance,
  org.junit
 Bundle-ActivationPolicy: lazy
-Import-Package: org.osgi.service.event; resolution:="optional"
+Import-Package: org.osgi.service.event,
+ org.osgi.util.function,
+ org.osgi.util.measurement,
+ org.osgi.util.position,
+ org.osgi.util.promise,
+ org.osgi.util.xml
 Export-Package: org.eclipse.osgi.tests.bundles,
  org.eclipse.osgi.tests.appadmin
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/bundles/org.eclipse.osgi.tests/pom.xml
+++ b/bundles/org.eclipse.osgi.tests/pom.xml
@@ -44,51 +44,6 @@
                 <type>p2-installable-unit</type>
                 <versionRange>0.0.0</versionRange>
               </requirement>
-              <requirement>
-                <id>org.eclipse.jdt.junit4.runtime</id>
-                <type>p2-installable-unit</type>
-                <versionRange>0.0.0</versionRange>
-              </requirement>
-              <requirement>
-                <id>org.eclipse.jdt.junit5.runtime</id>
-                <type>p2-installable-unit</type>
-                <versionRange>0.0.0</versionRange>
-              </requirement>
-              <requirement>
-                <id>org.eclipse.pde.junit.runtime</id>
-                <type>p2-installable-unit</type>
-                <versionRange>0.0.0</versionRange>
-              </requirement>
-              <requirement>
-                <id>org.osgi.util.function</id>
-                <type>eclipse-plugin</type>
-                <versionRange>0.0.0</versionRange>
-              </requirement>
-              <requirement>
-                <id>org.osgi.util.measurement</id>
-                <type>eclipse-plugin</type>
-                <versionRange>0.0.0</versionRange>
-              </requirement>
-              <requirement>
-                <id>org.osgi.util.position</id>
-                <type>eclipse-plugin</type>
-                <versionRange>0.0.0</versionRange>
-              </requirement>
-              <requirement>
-                <id>org.osgi.util.promise</id>
-                <type>eclipse-plugin</type>
-                <versionRange>0.0.0</versionRange>
-              </requirement>
-              <requirement>
-                <id>org.osgi.util.xml</id>
-                <type>eclipse-plugin</type>
-                <versionRange>0.0.0</versionRange>
-              </requirement>
-              <requirement>
-                <id>org.eclipse.equinox.event</id>
-                <type>eclipse-plugin</type>
-                <versionRange>0.0.0</versionRange>
-              </requirement>
             </extraRequirements>
           </dependency-resolution>
         </configuration>

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/OSGiTest.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/OSGiTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.osgi.tests;
 
 import org.eclipse.core.tests.harness.CoreTest;
+import org.eclipse.core.tests.session.ConfigurationSessionTestSuite;
 import org.osgi.framework.BundleContext;
 
 /**
@@ -34,4 +35,16 @@ public class OSGiTest extends CoreTest {
 	public BundleContext getContext() {
 		return OSGiTestsActivator.getContext();
 	}
+
+	public static void addRequiredOSGiTestsBundles(ConfigurationSessionTestSuite suite) {
+		suite.addMinimalBundleSet();
+		suite.addThisBundle();
+		suite.addBundle(org.osgi.util.function.Function.class);
+		suite.addBundle(org.osgi.util.measurement.Measurement.class);
+		suite.addBundle(org.osgi.util.position.Position.class);
+		suite.addBundle(org.osgi.util.promise.Promise.class);
+		suite.addBundle(org.osgi.util.xml.XMLParserActivator.class);
+		suite.addBundle(org.osgi.service.event.Event.class);
+	}
+
 }

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/appadmin/ApplicationAdminTest.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/appadmin/ApplicationAdminTest.java
@@ -52,18 +52,8 @@ public class ApplicationAdminTest extends OSGiTest {
 		TestSuite suite = new TestSuite(ApplicationAdminTest.class.getName());
 
 		ConfigurationSessionTestSuite appAdminSessionTest = new ConfigurationSessionTestSuite(PI_OSGI_TESTS, ApplicationAdminTest.class.getName());
-		String[] ids = ConfigurationSessionTestSuite.MINIMAL_BUNDLE_SET;
-		for (String id : ids) {
-			appAdminSessionTest.addBundle(id);
-		}
-		appAdminSessionTest.addBundle(PI_OSGI_TESTS);
+		addRequiredOSGiTestsBundles(appAdminSessionTest);
 		appAdminSessionTest.setApplicationId(testRunnerApp);
-		appAdminSessionTest.addBundle("org.osgi.util.function");
-		appAdminSessionTest.addBundle("org.osgi.util.measurement");
-		appAdminSessionTest.addBundle("org.osgi.util.position");
-		appAdminSessionTest.addBundle("org.osgi.util.promise");
-		appAdminSessionTest.addBundle("org.osgi.util.xml");
-		appAdminSessionTest.addBundle("org.osgi.service.event");
 
 		try {
 			appAdminSessionTest.getSetup().setSystemProperty("eclipse.application.registerDescriptors", "true"); //$NON-NLS-1$//$NON-NLS-2$

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/appadmin/ApplicationRelaunchTest.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/appadmin/ApplicationRelaunchTest.java
@@ -37,13 +37,8 @@ public class ApplicationRelaunchTest extends OSGiTest {
 		TestSuite suite = new TestSuite(ApplicationRelaunchTest.class.getName());
 
 		ConfigurationSessionTestSuite appAdminSessionTest = new ConfigurationSessionTestSuite(PI_OSGI_TESTS, ApplicationRelaunchTest.class.getName());
-		String[] ids = ConfigurationSessionTestSuite.MINIMAL_BUNDLE_SET;
-		for (String id : ids) {
-			appAdminSessionTest.addBundle(id);
-		}
-		appAdminSessionTest.addBundle(PI_OSGI_TESTS);
+		addRequiredOSGiTestsBundles(appAdminSessionTest);
 		appAdminSessionTest.setApplicationId(testRunnerRelauncherApp);
-		appAdminSessionTest.addBundle("org.osgi.service.event");
 
 		try {
 			appAdminSessionTest.getSetup().setSystemProperty("eclipse.application.registerDescriptors", "true"); //$NON-NLS-1$//$NON-NLS-2$

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/configuration/EclipseStarterConfigIniTest.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/configuration/EclipseStarterConfigIniTest.java
@@ -31,20 +31,13 @@ public class EclipseStarterConfigIniTest extends OSGiTest {
 		TestSuite suite = new TestSuite(EclipseStarterConfigIniTest.class.getName());
 
 		ConfigurationSessionTestSuite falseCompatBootDelegation = new ConfigurationSessionTestSuite(PI_OSGI_TESTS, EclipseStarterConfigIniTest.class.getName());
-		String[] ids = ConfigurationSessionTestSuite.MINIMAL_BUNDLE_SET;
-		for (String id : ids) {
-			falseCompatBootDelegation.addBundle(id);
-		}
-		falseCompatBootDelegation.addBundle(PI_OSGI_TESTS);
+		addRequiredOSGiTestsBundles(falseCompatBootDelegation);
 		falseCompatBootDelegation.addTest(new EclipseStarterConfigIniTest("testFalseCompatBootDelegation"));
 		falseCompatBootDelegation.setConfigIniValue("osgi.compatibility.bootdelegation", "false");
 		suite.addTest(falseCompatBootDelegation);
 
 		ConfigurationSessionTestSuite defaultCompatBootDelegation = new ConfigurationSessionTestSuite(PI_OSGI_TESTS, EclipseStarterConfigIniTest.class.getName());
-		for (String id : ids) {
-			defaultCompatBootDelegation.addBundle(id);
-		}
-		defaultCompatBootDelegation.addBundle(PI_OSGI_TESTS);
+		addRequiredOSGiTestsBundles(defaultCompatBootDelegation);
 		defaultCompatBootDelegation.addTest(new EclipseStarterConfigIniTest("testDefaultCompatBootDelegation"));
 		suite.addTest(defaultCompatBootDelegation);
 		return suite;

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/configuration/EclipseStarterConfigurationAreaTest.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/configuration/EclipseStarterConfigurationAreaTest.java
@@ -30,12 +30,8 @@ public class EclipseStarterConfigurationAreaTest extends OSGiTest {
 		TestSuite suite = new TestSuite(EclipseStarterConfigurationAreaTest.class.getName());
 
 		ConfigurationSessionTestSuite initialization = new ConfigurationSessionTestSuite(PI_OSGI_TESTS, EclipseStarterConfigurationAreaTest.class.getName());
-		String[] ids = ConfigurationSessionTestSuite.MINIMAL_BUNDLE_SET;
+		addRequiredOSGiTestsBundles(initialization);
 		initialization.addBundle("org.eclipse.osgi.compatibility.state");
-		for (String id : ids) {
-			initialization.addBundle(id);
-		}
-		initialization.addBundle(PI_OSGI_TESTS);
 		// disable clean-up, we want to reuse the configuration
 		initialization.setCleanup(false);
 		initialization.addTest(new EclipseStarterConfigurationAreaTest("testInitializeExtension"));
@@ -46,10 +42,7 @@ public class EclipseStarterConfigurationAreaTest extends OSGiTest {
 
 		ConfigurationSessionTestSuite removeExtension = new ConfigurationSessionTestSuite(PI_OSGI_TESTS, EclipseStarterConfigurationAreaTest.class.getName());
 		removeExtension.setConfigurationPath(configPath);
-		for (String id : ids) {
-			removeExtension.addBundle(id);
-		}
-		removeExtension.addBundle(PI_OSGI_TESTS);
+		addRequiredOSGiTestsBundles(removeExtension);
 		removeExtension.addTest(new EclipseStarterConfigurationAreaTest("testRemoveExtension"));
 		suite.addTest(removeExtension);
 		return suite;

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/configuration/MovableConfigurationAreaTest.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/configuration/MovableConfigurationAreaTest.java
@@ -16,9 +16,13 @@ package org.eclipse.osgi.tests.configuration;
 import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
-import junit.framework.*;
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.tests.harness.*;
+import org.eclipse.core.tests.harness.BundleTestingHelper;
+import org.eclipse.core.tests.harness.FileSystemComparator;
+import org.eclipse.core.tests.harness.FileSystemHelper;
 import org.eclipse.core.tests.session.ConfigurationSessionTestSuite;
 import org.eclipse.osgi.tests.OSGiTest;
 import org.eclipse.osgi.tests.OSGiTestsActivator;
@@ -47,11 +51,7 @@ public class MovableConfigurationAreaTest extends OSGiTest {
 		TestSuite suite = new TestSuite(MovableConfigurationAreaTest.class.getName());
 
 		ConfigurationSessionTestSuite initialization = new ConfigurationSessionTestSuite(PI_OSGI_TESTS, MovableConfigurationAreaTest.class.getName());
-		String[] ids = ConfigurationSessionTestSuite.MINIMAL_BUNDLE_SET;
-		for (String id : ids) {
-			initialization.addBundle(id);
-		}
-		initialization.addBundle(PI_OSGI_TESTS);
+		addRequiredOSGiTestsBundles(initialization);
 		initialization.setReadOnly(true);
 		// disable clean-up, we want to reuse the configuration
 		initialization.setCleanup(false);
@@ -74,9 +74,7 @@ public class MovableConfigurationAreaTest extends OSGiTest {
 
 		ConfigurationSessionTestSuite afterMoving = new ConfigurationSessionTestSuite(PI_OSGI_TESTS, MovableConfigurationAreaTest.class.getName());
 		afterMoving.setConfigurationPath(destinationPath);
-		for (String id : ids) {
-			afterMoving.addBundle(id);
-		}
+		afterMoving.addMinimalBundleSet();
 		afterMoving.setReadOnly(true);
 		// make sure we don't allow priming for the first run
 		afterMoving.setPrime(false);

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/configuration/ReadOnlyConfigurationAreaTest.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/configuration/ReadOnlyConfigurationAreaTest.java
@@ -30,11 +30,7 @@ public class ReadOnlyConfigurationAreaTest extends OSGiTest {
 	public static Test suite() {
 		ConfigurationSessionTestSuite suite = new ConfigurationSessionTestSuite(PI_OSGI_TESTS, ReadOnlyConfigurationAreaTest.class);
 		suite.setReadOnly(true);
-		String[] ids = ConfigurationSessionTestSuite.MINIMAL_BUNDLE_SET;
-		for (String id : ids) {
-			suite.addBundle(id);
-		}
-		suite.addBundle(PI_OSGI_TESTS);
+		addRequiredOSGiTestsBundles(suite);
 		return suite;
 	}
 

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/security/BaseSecurityTest.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/security/BaseSecurityTest.java
@@ -65,14 +65,6 @@ public class BaseSecurityTest extends CoreTest {
 
 	private ServiceRegistration trustReg = null;
 
-	protected static void addDefaultSecurityBundles(ConfigurationSessionTestSuite suite) {
-		String[] ids = ConfigurationSessionTestSuite.MINIMAL_BUNDLE_SET;
-		for (String id : ids) {
-			suite.addBundle(id);
-		}
-		suite.addBundle(BUNDLE_SECURITY_TESTS);
-	}
-
 	protected static Certificate getTestCertificate(String alias) throws KeyStoreException {
 		return supportStore.getCertificate(alias);
 	}

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/security/SignedBundleTest.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/security/SignedBundleTest.java
@@ -23,6 +23,7 @@ import org.eclipse.osgi.signedcontent.InvalidContentException;
 import org.eclipse.osgi.signedcontent.SignedContent;
 import org.eclipse.osgi.signedcontent.SignedContentEntry;
 import org.eclipse.osgi.signedcontent.SignerInfo;
+import org.eclipse.osgi.tests.OSGiTest;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleException;
 
@@ -83,7 +84,7 @@ public class SignedBundleTest extends BaseSecurityTest {
 
 	public static Test suite() {
 		ConfigurationSessionTestSuite suite = new ConfigurationSessionTestSuite(BUNDLE_SECURITY_TESTS, "Unit session tests for SignedContent");
-		addDefaultSecurityBundles(suite);
+		OSGiTest.addRequiredOSGiTestsBundles(suite);
 		suite.addTestSuite(SignedBundleTest.class);
 		return suite;
 	}

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/services/datalocation/LocationAreaSessionTest.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/services/datalocation/LocationAreaSessionTest.java
@@ -16,7 +16,9 @@ package org.eclipse.osgi.tests.services.datalocation;
 import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
-import junit.framework.*;
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
 import org.eclipse.core.tests.session.ConfigurationSessionTestSuite;
 import org.eclipse.core.tests.session.SetupManager.SetupException;
 import org.eclipse.osgi.internal.location.LocationHelper;
@@ -47,11 +49,7 @@ public class LocationAreaSessionTest extends OSGiTest {
 
 		// attempt to lock same location with a session
 		ConfigurationSessionTestSuite sessionLock = new ConfigurationSessionTestSuite(PI_OSGI_TESTS, LocationAreaSessionTest.class.getName());
-		String[] ids = ConfigurationSessionTestSuite.MINIMAL_BUNDLE_SET;
-		for (String id : ids) {
-			sessionLock.addBundle(id);
-		}
-		sessionLock.addBundle(PI_OSGI_TESTS);
+		addRequiredOSGiTestsBundles(sessionLock);
 		try {
 			sessionLock.getSetup().setSystemProperty(TEST_LOCATION_DIR, testLocationLockDir);
 		} catch (SetupException e) {
@@ -70,10 +68,7 @@ public class LocationAreaSessionTest extends OSGiTest {
 
 		// attempt to lock the location with a session
 		sessionLock = new ConfigurationSessionTestSuite(PI_OSGI_TESTS, LocationAreaSessionTest.class.getName());
-		for (String id : ids) {
-			sessionLock.addBundle(id);
-		}
-		sessionLock.addBundle(PI_OSGI_TESTS);
+		addRequiredOSGiTestsBundles(sessionLock);
 		try {
 			sessionLock.getSetup().setSystemProperty(TEST_LOCATION_DIR, testLocationLockDir);
 		} catch (SetupException e) {
@@ -95,11 +90,7 @@ public class LocationAreaSessionTest extends OSGiTest {
 
 		// attempt to lock same location with a session
 		sessionLock = new ConfigurationSessionTestSuite(PI_OSGI_TESTS, LocationAreaSessionTest.class.getName());
-		ids = ConfigurationSessionTestSuite.MINIMAL_BUNDLE_SET;
-		for (String id : ids) {
-			sessionLock.addBundle(id);
-		}
-		sessionLock.addBundle(PI_OSGI_TESTS);
+		addRequiredOSGiTestsBundles(sessionLock);
 		try {
 			sessionLock.getSetup().setSystemProperty(TEST_LOCATION_DIR, testLocationLockDir);
 		} catch (SetupException e) {
@@ -120,10 +111,7 @@ public class LocationAreaSessionTest extends OSGiTest {
 
 		// attempt to lock the location with a session
 		sessionLock = new ConfigurationSessionTestSuite(PI_OSGI_TESTS, LocationAreaSessionTest.class.getName());
-		for (String id : ids) {
-			sessionLock.addBundle(id);
-		}
-		sessionLock.addBundle(PI_OSGI_TESTS);
+		addRequiredOSGiTestsBundles(sessionLock);
 		try {
 			sessionLock.getSetup().setSystemProperty(TEST_LOCATION_DIR, testLocationLockDir);
 		} catch (SetupException e) {

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/util/TextProcessorSessionTest.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/util/TextProcessorSessionTest.java
@@ -13,7 +13,8 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.util;
 
-import org.eclipse.core.tests.session.*;
+import org.eclipse.core.tests.session.ConfigurationSessionTestSuite;
+import org.eclipse.core.tests.session.Setup;
 import org.eclipse.core.tests.session.SetupManager.SetupException;
 import org.eclipse.osgi.tests.OSGiTest;
 
@@ -29,11 +30,7 @@ public class TextProcessorSessionTest extends ConfigurationSessionTestSuite {
 	public TextProcessorSessionTest(String pluginId, Class clazz, String language) {
 		super(pluginId, clazz);
 		lang = language;
-		String[] ids = ConfigurationSessionTestSuite.MINIMAL_BUNDLE_SET;
-		for (String id : ids) {
-			addBundle(id);
-		}
-		addBundle(OSGiTest.PI_OSGI_TESTS);
+		OSGiTest.addRequiredOSGiTestsBundles(this);
 	}
 
 	/* (non-Javadoc)


### PR DESCRIPTION
Use the enhancements of https://github.com/eclipse-platform/eclipse.platform/pull/54

Use addMinimalBundleSet(), addThisBundle() and addBundle(Class) and leverage the fact that o.e.core.tests.harness now pulls all requirements into the test-runtime. Use the same pattern for the additionally required osgi bundles, which happens automatically if addBundle(Class) is used.

In combination with https://github.com/eclipse-platform/eclipse.platform/pull/54 this also fixes https://github.com/eclipse-equinox/equinox/issues/81.

It will only succeed after the next I-build once https://github.com/eclipse-platform/eclipse.platform/pull/54 is available.