### PR TITLE
Recover from Service-Factory deadlock

### DIFF
--- a/bundles/org.eclipse.equinox.ds.tests/.gitignore
+++ b/bundles/org.eclipse.equinox.ds.tests/.gitignore
@@ -1,1 +1,2 @@
 /scr_test
+/OSGI-INF/org.eclipse.*.xml

--- a/bundles/org.eclipse.equinox.ds.tests/OSGI-INF/org.eclipse.equinox.ds.tests.LazyServiceComponentActivationDeadLockTest$Component1.xml
+++ b/bundles/org.eclipse.equinox.ds.tests/OSGI-INF/org.eclipse.equinox.ds.tests.LazyServiceComponentActivationDeadLockTest$Component1.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.3.0" name="org.eclipse.equinox.ds.tests.LazyServiceComponentActivationDeadLockTest$Component1">
-   <service>
-      <provide interface="org.eclipse.equinox.ds.tests.LazyServiceComponentActivationDeadLockTest$Component1"/>
-   </service>
-   <reference cardinality="1..1" field="a" interface="org.eclipse.equinox.ds.tests.LazyServiceComponentActivationDeadLockTest$Component2" name="a"/>
-   <reference cardinality="1..1" field="b" interface="org.eclipse.equinox.ds.tests.LazyServiceComponentActivationDeadLockTest$Component4" name="b"/>
-   <implementation class="org.eclipse.equinox.ds.tests.LazyServiceComponentActivationDeadLockTest$Component1"/>
-</scr:component>

--- a/bundles/org.eclipse.equinox.ds.tests/OSGI-INF/org.eclipse.equinox.ds.tests.LazyServiceComponentActivationDeadLockTest$Component2.xml
+++ b/bundles/org.eclipse.equinox.ds.tests/OSGI-INF/org.eclipse.equinox.ds.tests.LazyServiceComponentActivationDeadLockTest$Component2.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.3.0" name="org.eclipse.equinox.ds.tests.LazyServiceComponentActivationDeadLockTest$Component2">
-   <service>
-      <provide interface="org.eclipse.equinox.ds.tests.LazyServiceComponentActivationDeadLockTest$Component2"/>
-   </service>
-   <reference cardinality="0..n" field="c3s" field-option="update" interface="org.eclipse.equinox.ds.tests.LazyServiceComponentActivationDeadLockTest$Component3" name="c3s" policy="dynamic"/>
-   <implementation class="org.eclipse.equinox.ds.tests.LazyServiceComponentActivationDeadLockTest$Component2"/>
-</scr:component>

--- a/bundles/org.eclipse.equinox.ds.tests/OSGI-INF/org.eclipse.equinox.ds.tests.LazyServiceComponentActivationDeadLockTest$Component3.xml
+++ b/bundles/org.eclipse.equinox.ds.tests/OSGI-INF/org.eclipse.equinox.ds.tests.LazyServiceComponentActivationDeadLockTest$Component3.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.3.0" name="org.eclipse.equinox.ds.tests.LazyServiceComponentActivationDeadLockTest$Component3">
-   <service>
-      <provide interface="org.eclipse.equinox.ds.tests.LazyServiceComponentActivationDeadLockTest$Component3"/>
-   </service>
-   <reference cardinality="1..1" field="a" interface="org.eclipse.equinox.ds.tests.LazyServiceComponentActivationDeadLockTest$Component2" name="a"/>
-   <reference cardinality="1..1" field="b" interface="org.eclipse.equinox.ds.tests.LazyServiceComponentActivationDeadLockTest$Component5" name="b"/>
-   <implementation class="org.eclipse.equinox.ds.tests.LazyServiceComponentActivationDeadLockTest$Component3"/>
-</scr:component>

--- a/bundles/org.eclipse.equinox.ds.tests/OSGI-INF/org.eclipse.equinox.ds.tests.LazyServiceComponentActivationDeadLockTest$Component4$AwaitComponent5Activation.xml
+++ b/bundles/org.eclipse.equinox.ds.tests/OSGI-INF/org.eclipse.equinox.ds.tests.LazyServiceComponentActivationDeadLockTest$Component4$AwaitComponent5Activation.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="activated" name="org.eclipse.equinox.ds.tests.LazyServiceComponentActivationDeadLockTest$Component4$AwaitComponent5Activation">
-   <service>
-      <provide interface="org.eclipse.equinox.ds.tests.LazyServiceComponentActivationDeadLockTest$Component4$AwaitComponent5Activation"/>
-   </service>
-   <implementation class="org.eclipse.equinox.ds.tests.LazyServiceComponentActivationDeadLockTest$Component4$AwaitComponent5Activation"/>
-</scr:component>

--- a/bundles/org.eclipse.equinox.ds.tests/OSGI-INF/org.eclipse.equinox.ds.tests.LazyServiceComponentActivationDeadLockTest$Component4.xml
+++ b/bundles/org.eclipse.equinox.ds.tests/OSGI-INF/org.eclipse.equinox.ds.tests.LazyServiceComponentActivationDeadLockTest$Component4.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.3.0" name="org.eclipse.equinox.ds.tests.LazyServiceComponentActivationDeadLockTest$Component4">
-   <service>
-      <provide interface="org.eclipse.equinox.ds.tests.LazyServiceComponentActivationDeadLockTest$Component4"/>
-   </service>
-   <reference cardinality="1..1" field="a" interface="org.eclipse.equinox.ds.tests.LazyServiceComponentActivationDeadLockTest$Component4$AwaitComponent5Activation" name="a"/>
-   <reference cardinality="1..1" field="b" interface="org.eclipse.equinox.ds.tests.LazyServiceComponentActivationDeadLockTest$Component5" name="b"/>
-   <implementation class="org.eclipse.equinox.ds.tests.LazyServiceComponentActivationDeadLockTest$Component4"/>
-</scr:component>

--- a/bundles/org.eclipse.equinox.ds.tests/OSGI-INF/org.eclipse.equinox.ds.tests.LazyServiceComponentActivationDeadLockTest$Component5$ActivationStartedIndicator.xml
+++ b/bundles/org.eclipse.equinox.ds.tests/OSGI-INF/org.eclipse.equinox.ds.tests.LazyServiceComponentActivationDeadLockTest$Component5$ActivationStartedIndicator.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="activated" name="org.eclipse.equinox.ds.tests.LazyServiceComponentActivationDeadLockTest$Component5$ActivationStartedIndicator">
-   <service>
-      <provide interface="org.eclipse.equinox.ds.tests.LazyServiceComponentActivationDeadLockTest$Component5$ActivationStartedIndicator"/>
-   </service>
-   <implementation class="org.eclipse.equinox.ds.tests.LazyServiceComponentActivationDeadLockTest$Component5$ActivationStartedIndicator"/>
-</scr:component>

--- a/bundles/org.eclipse.equinox.ds.tests/OSGI-INF/org.eclipse.equinox.ds.tests.LazyServiceComponentActivationDeadLockTest$Component5.xml
+++ b/bundles/org.eclipse.equinox.ds.tests/OSGI-INF/org.eclipse.equinox.ds.tests.LazyServiceComponentActivationDeadLockTest$Component5.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.3.0" name="org.eclipse.equinox.ds.tests.LazyServiceComponentActivationDeadLockTest$Component5">
-   <service>
-      <provide interface="org.eclipse.equinox.ds.tests.LazyServiceComponentActivationDeadLockTest$Component5"/>
-   </service>
-   <reference cardinality="1..1" field="a" interface="org.eclipse.equinox.ds.tests.LazyServiceComponentActivationDeadLockTest$Component5$ActivationStartedIndicator" name="a"/>
-   <reference cardinality="0..n" field="c1s" field-option="update" interface="org.eclipse.equinox.ds.tests.LazyServiceComponentActivationDeadLockTest$Component1" name="c1s" policy="dynamic"/>
-   <implementation class="org.eclipse.equinox.ds.tests.LazyServiceComponentActivationDeadLockTest$Component5"/>
-</scr:component>

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/serviceregistry/ServiceFactoryUse.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/serviceregistry/ServiceFactoryUse.java
@@ -219,6 +219,9 @@ public class ServiceFactoryUse<S> extends ServiceUse<S> {
 				}
 			});
 		} catch (Throwable t) {
+			if (t instanceof ServiceException && ((ServiceException) t).getType() == ServiceUse.DEADLOCK) {
+				throw t;
+			}
 			if (debug.DEBUG_SERVICES) {
 				Debug.println(factory + ".getService() exception: " + t.getMessage()); //$NON-NLS-1$
 				Debug.printStackTrace(t);


### PR DESCRIPTION
Follow up of https://github.com/eclipse-equinox/equinox/pull/68, with a first attempt to implement a recovery strategy to resolve an encountered deadlock during the use of service-factories.

In case of an encountered Deadlock between Service-Factories, this approach simply checks if the current service-factory invocation is the first one of this thread and then makes a new attempt to call the factory.
In order to make a new deadlock more unlikely the thread sleeps for a random period that becomes even longer with further attempts, hoping that the other threads involved the deadlock sleep for another time that is different enough so that the race-condition does not occur anymore.

This PR is a first draft with a relatively naive approach, but at least it worked in the test-cases added for #68:
- Assumes it is possible without restrictions to 
- Currently requires Java-9's `StackWalker`, but this can be reworked to use means available in Java-8.

Alternatively creates of Service-factories could be adjusted to handle encountered deadlocks, but this would likely require changes outside of Equinox and maybe some spec-work in OSGi. 

I'm on vacation for the next two weeks, but wanted to share this current state/the basic idea already.