### PR TITLE
Revert cleanup on ServletRegistration (#88)

### DIFF
--- a/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/registration/ServletRegistration.java
+++ b/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/registration/ServletRegistration.java
@@ -37,13 +37,17 @@ public class ServletRegistration extends EndpointRegistration<ServletDTO> {
 	static {
 		ServiceLoader<MultipartSupportFactory> loader = ServiceLoader.load(MultipartSupportFactory.class);
 
-		for (MultipartSupportFactory element : loader) {
+		Iterator<MultipartSupportFactory> iterator = loader.iterator();
+
+		while (iterator.hasNext()) {
 			try {
-				factory = element;
+				// Note: we intentionally trigger next() inside the try/catch block
+				// to fail early if optional imports are missing
+				factory = iterator.next();
 				break;
 			}
 			catch (Throwable t) {
-				// ignore, it means our optional imports are missing.
+				// ignore ServiceConfigurationError, it means our optional imports are missing.
 			}
 		}
 	}


### PR DESCRIPTION
This reverts change on ServletRegistration from commit
a1a9eaf5879c77a3aa029ac318a826cceadb59ff because it doesn't ignore error on 
(intended) initialization of
org.eclipse.equinox.http.servlet.internal.multipart.MultipartSupportFactoryImpl

Fixes https://github.com/eclipse-equinox/equinox/issues/88

Explanation: the cleanup moved potentially dangerous `iterator.next();` code (that throws `ServiceConfigurationError`) **outside** of the try/catch block.