### PR TITLE
The org.eclipse.equinox.jsp.jasper bundle should allow a newer version

### DIFF
--- a/bundles/org.eclipse.equinox.jsp.jasper/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.jsp.jasper/META-INF/MANIFEST.MF
@@ -4,13 +4,13 @@ Bundle-Name: %bundleName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.equinox.jsp.jasper
-Bundle-Version: 1.1.600.qualifier
+Bundle-Version: 1.1.700.qualifier
 Bundle-Activator: org.eclipse.equinox.internal.jsp.jasper.Activator
 Import-Package: javax.servlet;version="[2.4, 5.0)",
  javax.servlet.annotation;version="[2.6, 5.0)";resolution:=optional,
  javax.servlet.descriptor;version="[2.6, 5.0)";resolution:=optional,
  javax.servlet.http;version="[2.4, 5.0)",
- javax.servlet.jsp;version="[2.0, 2.3)",
+ javax.servlet.jsp;version="[2.0, 3.0)",
  org.apache.jasper.servlet;version="[0, 8)",
  org.osgi.framework;version="1.3.0",
  org.osgi.service.http;version="1.2.0",


### PR DESCRIPTION
of javax.servlet.jsp than 2.3.

The Orbit 2.2.0 version of javax.servlet.jsp has been removed from the
target platform by the following PR and the newer version 2.3.3 version
is now available, so the org.eclipse.equinox.jsp.jasper should
accommodate that new version.

https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/412