### PR TITLE
org.apache.jasper.glassfish and com.sun.el versions have gone backwards

### DIFF
--- a/features/org.eclipse.equinox.sdk/forceQualifierUpdate.txt
+++ b/features/org.eclipse.equinox.sdk/forceQualifierUpdate.txt
@@ -1,4 +1,5 @@
 # To force a version qualifier update add the bug here
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/438 org.apache.jasper.glassfish and com.sun.el versions have gone backwards
 Bug 528810 - Compilation failure in I20171214-2000
 Bug 533464 - Build failure in I20180411-0530
 Bug 444188 - EclipsePreferences is not thread safe


### PR DESCRIPTION
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/438