### PR TITLE
Path: Keep windows flag during canonicalize (fixes #102)

### DIFF
--- a/bundles/org.eclipse.equinox.common.tests/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.common.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Common Eclipse Runtime Tests
 Bundle-Vendor: Eclipse.org - Equinox
 Bundle-SymbolicName: org.eclipse.equinox.common.tests;singleton:=true
-Bundle-Version: 3.15.400.qualifier
+Bundle-Version: 3.15.500.qualifier
 Automatic-Module-Name: org.eclipse.equinox.common.tests
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy

--- a/bundles/org.eclipse.equinox.common.tests/src/org/eclipse/equinox/common/tests/PathTest.java
+++ b/bundles/org.eclipse.equinox.common.tests/src/org/eclipse/equinox/common/tests/PathTest.java
@@ -120,6 +120,22 @@ public class PathTest extends CoreTest {
 		assertEquals("4.1.win", combo, win.removeTrailingSeparator().append(aftString));
 		// append path to root path uses optimized code
 		assertEquals("4.2.win", combo, Path.forWindows("/").append(win).append(aftString));
+		assertEquals("4.21.win", combo,
+				Path.forWindows("/").append(win).append("..").append("third").append(aftString));
+		assertEquals("4.2X.win", Path.forWindows("/").append("x"),
+				Path.forWindows("/").append("x").append("..").append("x"));
+		assertEquals("4.2XY/.win", Path.forWindows("\\").append("x/y"),
+				Path.forWindows("\\").append("x").append("y").append("../..").append("x/y"));
+		assertEquals("4.2XY\\.win", Path.forWindows("/").append("x\\y"),
+				Path.forWindows("/").append("x").append("y").append("..\\..").append("x\\y"));
+		assertEquals("4.22.win", combo,
+				Path.forWindows("/").append(win).append("..\\..").append("second\\third").append(aftString));
+		assertEquals("4.23.win", combo,
+				Path.forWindows("/").append(win).append("..\\..\\..").append("first\\second\\third").append(aftString));
+		assertEquals("4.24.win", combo,
+				Path.forWindows("/").append(win).append("..\\..\\..").append(win).append(aftString));
+		assertEquals("4.25.win", combo,
+				Path.forWindows("/").append(win).append("../../..").append(win).append(aftString));
 		assertEquals("4.3.win", combo, Path.forWindows("/").append(posix).append(aftString));
 		// append path to empty path uses optimized code
 		assertEquals("4.4.win", combo, Path.forWindows("").append(win).append(aftString).makeAbsolute());

--- a/bundles/org.eclipse.equinox.common/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.common/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.common; singleton:=true
-Bundle-Version: 3.16.200.qualifier
+Bundle-Version: 3.16.300.qualifier
 Bundle-Localization: plugin
 Export-Package: org.eclipse.core.internal.boot;x-friends:="org.eclipse.core.resources,org.eclipse.pde.build",
  org.eclipse.core.internal.runtime;common=split;mandatory:=common;

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/Path.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/Path.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 20122 IBM Corporation and others.
+ * Copyright (c) 2000, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/Path.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/Path.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2015 IBM Corporation and others.
+ * Copyright (c) 2000, 20122 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -357,7 +357,7 @@ public class Path implements IPath, Cloneable {
 				collapseParentReferences();
 				//paths of length 0 have no trailing separator
 				if (segments.length == 0)
-					flags &= (HAS_LEADING | IS_UNC);
+					flags &= ~HAS_TRAILING;
 				//recompute hash because canonicalize affects hash
 				flags = (flags & ALL_FLAGS) | (computeHashCode() << 4);
 				return true;

--- a/features/org.eclipse.equinox.core.feature/feature.xml
+++ b/features/org.eclipse.equinox.core.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.equinox.core.feature"
       label="%featureName"
-      version="1.13.800.qualifier"
+      version="1.13.900.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/features/org.eclipse.equinox.server.core/feature.xml
+++ b/features/org.eclipse.equinox.server.core/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.equinox.server.core"
       label="%featureName"
-      version="1.14.700.qualifier"
+      version="1.14.800.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">


### PR DESCRIPTION
The WINDOWS flag was lost when escaping to root path with appending ".."