### PR TITLE
Open libraries with RTLD_NODELETE on linux

### DIFF
--- a/bundles/org.eclipse.equinox.security.linux/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.security.linux/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %fragmentName
 Bundle-SymbolicName: org.eclipse.equinox.security.linux;singleton:=true
-Bundle-Version: 1.0.200.qualifier
+Bundle-Version: 1.0.300.qualifier
 Bundle-Vendor: %providerName
 Fragment-Host: org.eclipse.equinox.security;bundle-version="[1.0.0,2.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-11
@@ -11,4 +11,4 @@ Eclipse-PlatformFilter: (osgi.os=linux)
 Export-Package: org.eclipse.equinox.internal.security.linux;x-internal:=true
 Automatic-Module-Name: org.eclipse.equinox.security.linux
 Eclipse-BundleShape: dir
-Require-Bundle: com.sun.jna;bundle-version="5.8.0"
+Require-Bundle: com.sun.jna;bundle-version="[5.8.0,6.0.0)"

--- a/bundles/org.eclipse.equinox.security.linux/pom.xml
+++ b/bundles/org.eclipse.equinox.security.linux/pom.xml
@@ -20,7 +20,7 @@
 </parent>
   <groupId>org.eclipse.equinox</groupId>
   <artifactId>org.eclipse.equinox.security.linux</artifactId>
-  <version>1.0.200-SNAPSHOT</version>
+  <version>1.0.300-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <build>

--- a/features/org.eclipse.equinox.core.sdk/feature.xml
+++ b/features/org.eclipse.equinox.core.sdk/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.equinox.core.sdk"
       label="%featureName"
-      version="3.23.500.qualifier"
+      version="3.23.600.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">


### PR DESCRIPTION
Problem:
========
Sometimes eclipse throws following error on error stream when HTTPS proxy with user and password exists and thread gets stuck at fLibSecret.secret_service_get_sync(..)

~~~~~~~~~~~~~~~~~~~~~~~~~
(java:3835014): GLib-GObject-WARNING **: 02:47:42.753: cannot register existing type 'SecretService'

(java:3835014): GLib-GObject-WARNING **: 02:47:42.753: cannot add private field to invalid (non-instantiatable) type '<invalid>'

(java:3835014): GLib-GObject-CRITICAL **: 02:47:42.753: g_type_add_interface_static: assertion 'G_TYPE_IS_INSTANTIATABLE (instance_type)' failed

(java:3835014): GLib-GObject-CRITICAL **: 02:47:42.753: g_type_add_interface_static: assertion 'G_TYPE_IS_INSTANTIATABLE (instance_type)' failed

(java:3835014): GLib-GObject-WARNING **: 02:47:42.753: cannot register existing type 'SecretBackend'

(java:3835014): GLib-GObject-CRITICAL **: 02:47:42.753: g_type_interface_add_prerequisite: assertion 'G_TYPE_IS_INTERFACE (interface_type)' failed

(java:3835014): GLib-GObject-CRITICAL **: 02:47:42.753: g_type_interface_add_prerequisite: assertion 'G_TYPE_IS_INTERFACE (interface_type)' failed

(java:3835014): GLib-CRITICAL **: 02:47:42.753: g_once_init_leave: assertion 'result != 0' failed

(java:3835014): GLib-GObject-CRITICAL **: 02:47:42.753: g_type_add_interface_static: assertion 'G_TYPE_IS_INSTANTIATABLE (instance_type)' failed
~~~~~~~~~~~~~~~~~~~~~~~~~

Reason:
=======
LinuxPasswordProvider.unlockSecretService() is called many times and when this problem occurs, NativeLibrary instance is garbadge collected
and dispose is called on NativeLibrary and handle is closed. When LinuxPasswordProvider.unlockSecretService() is called again, we reload
libraries. Now libsecret has static variables based on which it initializes the secret service. As our library was not loaded with RTLD_NODELETE,
so on unloading the library, the static variables are cleared and reloading the library tries to register the service again which causes the mess
and the error is printed on error stream
Related Link: https://www.spinics.net/lists/gtk/msg21985.html

Solution:
=========
Open libraries with RTLD_NODELETE so that even if handle is closed, the library is not unloaded and on reloading the library, we get the same library
instance and static variables with the same old state.

Also updating the jna version to use latest jna which supports java 18 where finalizers are removed.