### PR TITLE
Simplify and generalize project imports in P2's Oomph setup

### DIFF
--- a/releng/org.eclipse.equinox.releng/Equinox.setup
+++ b/releng/org.eclipse.equinox.releng/Equinox.setup
@@ -269,15 +269,7 @@
         <requirement
             name="*"/>
         <sourceLocator
-            rootFolder="${github.clone.equinox.p2.location/bundles}">
-          <excludedPath>bundles/org.eclipse.equinox.p2.testserver</excludedPath>
-        </sourceLocator>
-        <sourceLocator
-            rootFolder="${github.clone.equinox.p2.location/examples}"/>
-        <sourceLocator
-            rootFolder="${github.clone.equinox.p2.location/features}"/>
-        <sourceLocator
-            rootFolder="${github.clone.equinox.p2.location/org.eclipse.equinox.p2.releng}"/>
+            rootFolder="${github.clone.equinox.p2.location}"/>
       </targlet>
     </setupTask>
     <setupTask


### PR DESCRIPTION
The root .project file of p2 is removed via https://github.com/eclipse-equinox/p2/pull/149

The abandoned project 'org.eclipse.equinox.p2.testserver' has been deleted as part of https://github.com/eclipse-equinox/p2/pull/49.

@merks or do you know another reason why multiple source-locators are required?