### PR TITLE
Add maven descriptors to equinox bundles

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,7 @@ pipeline {
 			steps {
 				sh """
 				mvn clean verify --batch-mode --fail-at-end -Dmaven.repo.local=$WORKSPACE/.m2/repository \
-					-Pbuild-individual-bundles -Pbree-libs -Papi-check -Pverify-maven\
+					-Pbuild-individual-bundles -Pbree-libs -Papi-check -Pverify-maven -Pjavadoc\
 					-Dcompare-version-with-baselines.skip=false \
 					-Dproject.build.sourceEncoding=UTF-8 \
 					-Drt.equinox.binaries.loc=$WORKSPACE/rt.equinox.binaries 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,7 @@ pipeline {
 			steps {
 				sh """
 				mvn clean verify --batch-mode --fail-at-end -Dmaven.repo.local=$WORKSPACE/.m2/repository \
-					-Pbuild-individual-bundles -Pbree-libs -Papi-check \
+					-Pbuild-individual-bundles -Pbree-libs -Papi-check -Pverify-maven\
 					-Dcompare-version-with-baselines.skip=false \
 					-Dproject.build.sourceEncoding=UTF-8 \
 					-Drt.equinox.binaries.loc=$WORKSPACE/rt.equinox.binaries 

--- a/bundles/org.eclipse.equinox.jsp.jasper.registry/build.properties
+++ b/bundles/org.eclipse.equinox.jsp.jasper.registry/build.properties
@@ -19,3 +19,6 @@ bin.includes = META-INF/,\
                plugin.properties
 src.includes = about.html
 
+# due to outdated stuff...
+pom.model.property.tycho.verify.failOnError=false
+pom.model.property.tycho.addMavenDescriptor=false

--- a/bundles/org.eclipse.equinox.jsp.jasper/build.properties
+++ b/bundles/org.eclipse.equinox.jsp.jasper/build.properties
@@ -19,3 +19,6 @@ bin.includes = META-INF/,\
                about.html
 src.includes = about.html
 
+# due to outdated stuff...
+pom.model.property.tycho.verify.failOnError=false
+pom.model.property.tycho.addMavenDescriptor=false

--- a/bundles/org.eclipse.equinox.security.ui/build.properties
+++ b/bundles/org.eclipse.equinox.security.ui/build.properties
@@ -21,3 +21,7 @@ bin.includes = META-INF/,\
                about.html,\
                .options
 src.includes = about.html
+
+## Pulls in platform code that produces bad meta-data!
+pom.model.property.tycho.verify.failOnError=false
+pom.model.property.tycho.addMavenDescriptor=false

--- a/features/build.properties
+++ b/features/build.properties
@@ -1,0 +1,3 @@
+## Currently features pull in UI stuff that produces bad meta-data!
+pom.model.property.tycho.verify.failOnError=false
+pom.model.property.tycho.mapP2Dependencies=false

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,33 @@
 	      </plugin>
       </plugins>
       </build>
-    </profile>  
+    </profile> 
+    <profile>
+    	<id>javadoc</id>
+		<build>
+	    <plugins>
+		  <!-- Must use older version see https://issues.apache.org/jira/projects/MJAVADOC/issues/MJAVADOC-707 -->
+	      <plugin>
+	        <groupId>org.apache.maven.plugins</groupId>
+	        <artifactId>maven-javadoc-plugin</artifactId>
+	        <version>3.0.1</version>
+	        <executions>
+	        <execution>
+	          <id>attach-javadocs</id>
+	          <phase>package</phase>
+	          <goals>
+	            <goal>jar</goal>
+	          </goals>
+	        </execution>
+	      </executions>
+	        <configuration>
+	        	<source>11</source>
+	        	<failOnError>false</failOnError>
+	        </configuration>
+	      </plugin>
+    	</plugins>
+    	</build>
+    </profile> 
   </profiles>
 
   <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,9 @@
     <!-- required by: org.eclipse.equinox.framework:launcher-binary-parent -->
     <rt.equinox.binaries.loc>../../../rt.equinox.binaries</rt.equinox.binaries.loc>
     <target-platform.optionalDependencies>require</target-platform.optionalDependencies>
+    <tycho.addMavenDescriptor>true</tycho.addMavenDescriptor>
+    <tycho.mapP2Dependencies>true</tycho.mapP2Dependencies>
+    <tycho.version>3.1.0-SNAPSHOT</tycho.version>
   </properties>
 
   <!-- 
@@ -53,6 +56,32 @@
         </repository>
       </repositories>
     </profile>
+    <profile>
+      <id>verify-maven</id>
+      <properties>
+          <tycho.verify.failOnError>true</tycho.verify.failOnError>
+      </properties>
+      <build>
+      <plugins>
+	      <plugin>
+	        <groupId>org.eclipse.tycho</groupId>
+	        <artifactId>tycho-packaging-plugin</artifactId>
+	        <executions>
+	          <execution>
+	            <id>validate-pom</id>
+	            <phase>verify</phase>
+	            <goals>
+	              <goal>verify-osgi-pom</goal>
+	            </goals>
+	            <configuration>
+	            	<failOnError>${tycho.verify.failOnError}</failOnError>
+	            </configuration>
+	          </execution>
+	        </executions>
+	      </plugin>
+      </plugins>
+      </build>
+    </profile>  
   </profiles>
 
   <modules>


### PR DESCRIPTION
Reverse mapping of maven meta-data is errorprone and cumbersome, with the new tycho features it is now possible to create good meta-data at the first place.

FYI @mickaelistria @akurtakov @merks 

This also demonstrates the use of the new [verify-osgi-pom mojo](https://github.com/eclipse-tycho/tycho/blob/master/RELEASE_NOTES.md#new-maven-dependency-consistency-check) to check for bad/missing OSGi dependencies.

This will most probably require a bump for every bundle affected, so I'd like to get some feedback first, also one should note that currently the group id `org.eclipse.equinox` is used as derived from the parent.

For local test one can run:
`mvn -Pbuild-individual-bundles -Dproject.build.sourceEncoding=UTF-8 -DskipTests -Drt.equinox.binaries.loc=../equinox.binaries clean verify -Dtycho.localArtifacts=ignore -e -Pverify-maven`

**Just keep in mind to bump the version of the bundle you like to investigate or it will be overwritten by the baseline replace!**