### PR TITLE
Enable the github Warnings publisher for Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,7 +33,8 @@ pipeline {
 				always {
 					archiveArtifacts artifacts: '**/*.log, **/*.jar', allowEmptyArchive: true
 					junit '**/target/surefire-reports/TEST-*.xml'
-					publishIssues issues:[scanForIssues(tool: java()), scanForIssues(tool: mavenConsole())]
+					discoverGitReferenceBuild referenceJob: 'equinox/master'
+					recordIssues publishAllIssues: true, tools: [java(), mavenConsole()]
 				}
 			}
 		}


### PR DESCRIPTION
This enables the Warnings Publisher for Github PRs.
This only shows the warnings, but if one want we later can define Quality gates (e.g. no new java warnings allowed).