### PR TITLE
improve Dark Theme on Windows eclipse-platform/.github#27

### DIFF
--- a/bundles/org.eclipse.equinox.security.ui/src/org/eclipse/equinox/internal/security/ui/storage/StoragePreferencePage.java
+++ b/bundles/org.eclipse.equinox.security.ui/src/org/eclipse/equinox/internal/security/ui/storage/StoragePreferencePage.java
@@ -16,9 +16,11 @@ package org.eclipse.equinox.internal.security.ui.storage;
 import org.eclipse.jface.dialogs.Dialog;
 import org.eclipse.jface.preference.PreferencePage;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.CTabFolder;
 import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.layout.GridData;
-import org.eclipse.swt.widgets.*;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
 import org.eclipse.ui.*;
 
 public class StoragePreferencePage extends PreferencePage implements IWorkbenchPreferencePage {
@@ -30,7 +32,7 @@ public class StoragePreferencePage extends PreferencePage implements IWorkbenchP
 	protected TabAdvanced advancedTab;
 
 	public StoragePreferencePage() {
-		//empty
+		// empty
 	}
 
 	@Override
@@ -41,7 +43,7 @@ public class StoragePreferencePage extends PreferencePage implements IWorkbenchP
 	@Override
 	protected Control createContents(Composite parent) {
 
-		final TabFolder folder = new TabFolder(parent, SWT.TOP);
+		final CTabFolder folder = new CTabFolder(parent, SWT.TOP);
 
 		GridData gd = new GridData(SWT.FILL, SWT.CENTER, true, false);
 		gd.horizontalSpan = 1;

--- a/bundles/org.eclipse.equinox.security.ui/src/org/eclipse/equinox/internal/security/ui/storage/TabAdvanced.java
+++ b/bundles/org.eclipse.equinox.security.ui/src/org/eclipse/equinox/internal/security/ui/storage/TabAdvanced.java
@@ -22,6 +22,8 @@ import org.eclipse.equinox.internal.security.ui.nls.SecUIMessages;
 import org.eclipse.jface.layout.GridLayoutFactory;
 import org.eclipse.jface.layout.LayoutConstants;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.CTabFolder;
+import org.eclipse.swt.custom.CTabItem;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.*;
 import org.osgi.service.prefs.BackingStoreException;
@@ -36,9 +38,10 @@ public class TabAdvanced {
 	private IEclipsePreferences eclipseNode = null;
 	private String defaultCipherAlgorithm;
 
-	public TabAdvanced(TabFolder folder, int index, final Shell shell) {
+	public TabAdvanced(CTabFolder folder, int index, final Shell shell) {
 
-		TabItem tab = new TabItem(folder, SWT.NONE, index);
+		CTabItem tab = new CTabItem(folder, SWT.NONE, index);
+		folder.setSelection(0);
 		tab.setText(SecUIMessages.tabAdvanced);
 		Composite page = new Composite(folder, SWT.NONE);
 		tab.setControl(page);

--- a/bundles/org.eclipse.equinox.security.ui/src/org/eclipse/equinox/internal/security/ui/storage/TabContents.java
+++ b/bundles/org.eclipse.equinox.security.ui/src/org/eclipse/equinox/internal/security/ui/storage/TabContents.java
@@ -25,7 +25,7 @@ import org.eclipse.equinox.internal.security.ui.storage.view.*;
 import org.eclipse.equinox.security.storage.*;
 import org.eclipse.jface.layout.*;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.custom.SashForm;
+import org.eclipse.swt.custom.*;
 import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
@@ -44,10 +44,11 @@ public class TabContents implements ISecurePreferencesSelection, IDeleteListener
 		valuesView.setInput(selectedNode);
 	}
 
-	public TabContents(TabFolder folder, int index, final Shell shell) {
+	public TabContents(CTabFolder folder, int index, final Shell shell) {
 		this.shell = shell;
 
-		TabItem tab = new TabItem(folder, SWT.NONE, index);
+		CTabItem tab = new CTabItem(folder, SWT.NONE, index);
+		folder.setSelection(0);
 		tab.setText(SecUIMessages.tabContents);
 		Composite page = new Composite(folder, SWT.NONE);
 		tab.setControl(page);
@@ -68,7 +69,8 @@ public class TabContents implements ISecurePreferencesSelection, IDeleteListener
 
 		new Label(rightPane, SWT.NONE).setText(SecUIMessages.keysTable);
 
-		Table tableOfValues = new Table(rightPane, SWT.MULTI | SWT.H_SCROLL | SWT.V_SCROLL | SWT.BORDER | SWT.FULL_SELECTION);
+		Table tableOfValues = new Table(rightPane,
+				SWT.MULTI | SWT.H_SCROLL | SWT.V_SCROLL | SWT.BORDER | SWT.FULL_SELECTION);
 		tableOfValues.setLinesVisible(true);
 		tableOfValues.setHeaderVisible(true);
 		tableOfValues.setLayoutData(new GridData(GridData.FILL, GridData.FILL, true, true));
@@ -94,17 +96,14 @@ public class TabContents implements ISecurePreferencesSelection, IDeleteListener
 			validateSave(); // save could fail so re-check
 		}));
 
-		/* Removed for the time being. In future modify/show/export operations could be 
-		 * re-introduced with some special access token required to be entered by the user 
-		Button buttonExport = new Button(buttonBar, SWT.CENTER);
-		buttonExport.setText(SecUIMessages.exportButton);
-		setButtonSize(buttonExport, minButtonWidth);
-		buttonExport.addSelectionListener(new SelectionAdapter() {
-			public void widgetSelected(SelectionEvent e) {
-				export();
-			}
-		});
-		*/
+		/*
+		 * Removed for the time being. In future modify/show/export operations could be
+		 * re-introduced with some special access token required to be entered by the
+		 * user Button buttonExport = new Button(buttonBar, SWT.CENTER);
+		 * buttonExport.setText(SecUIMessages.exportButton); setButtonSize(buttonExport,
+		 * minButtonWidth); buttonExport.addSelectionListener(new SelectionAdapter() {
+		 * public void widgetSelected(SelectionEvent e) { export(); } });
+		 */
 
 		Button buttonDelete = new Button(buttonBar, SWT.PUSH);
 		buttonDelete.setText(SecUIMessages.deleteButton);
@@ -117,7 +116,7 @@ public class TabContents implements ISecurePreferencesSelection, IDeleteListener
 			new Text(page, SWT.READ_ONLY).setText(new Path(location.getFile()).toOSString());
 		}
 
-		sashForm.setWeights(new int[] {30, 70});
+		sashForm.setWeights(new int[] { 30, 70 });
 
 		nodesView = new NodesView(nodeTree, this);
 		valuesView = new ValuesView(tableOfValues, this, shell);
@@ -206,7 +205,7 @@ public class TabContents implements ISecurePreferencesSelection, IDeleteListener
 		defaultStorage.clear();
 		defaultStorage.removeNode();
 
-		// clear it from the list of open storages, delete the file 
+		// clear it from the list of open storages, delete the file
 		InternalExchangeUtils.defaultStorageDelete();
 
 		if (nodesView != null)

--- a/bundles/org.eclipse.equinox.security.ui/src/org/eclipse/equinox/internal/security/ui/storage/TabPassword.java
+++ b/bundles/org.eclipse.equinox.security.ui/src/org/eclipse/equinox/internal/security/ui/storage/TabPassword.java
@@ -27,6 +27,8 @@ import org.eclipse.jface.viewers.ColumnWeightData;
 import org.eclipse.jface.viewers.TableLayout;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.CTabFolder;
+import org.eclipse.swt.custom.CTabItem;
 import org.eclipse.swt.events.*;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
@@ -50,8 +52,9 @@ public class TabPassword {
 
 	protected boolean providerModified = false;
 
-	public TabPassword(TabFolder folder, int index, final Shell shell) {
-		TabItem tab = new TabItem(folder, SWT.NONE, index);
+	public TabPassword(CTabFolder folder, int index, final Shell shell) {
+		CTabItem tab = new CTabItem(folder, SWT.NONE, index);
+		folder.setSelection(0);
 		tab.setText(SecUIMessages.tabPassword);
 		Composite page = new Composite(folder, SWT.NONE);
 		page.setLayoutData(new GridData(GridData.FILL, GridData.FILL, true, false));
@@ -204,7 +207,7 @@ public class TabPassword {
 		HashSet<String> disabledModules = getDisabledModules();
 		for (PasswordProviderDescription module : InternalExchangeUtils.passwordProvidersFind()) {
 			TableItem item = new TableItem(providerTable, SWT.NONE);
-			item.setText(new String[] {module.getName(), Integer.toString(module.getPriority())});
+			item.setText(new String[] { module.getName(), Integer.toString(module.getPriority()) });
 			item.setData(module);
 			if (disabledModules == null)
 				item.setChecked(true);
@@ -254,10 +257,11 @@ public class TabPassword {
 	}
 
 	protected HashSet<String> getDisabledModules() {
-		IScopeContext[] scopes = {ConfigurationScope.INSTANCE, DefaultScope.INSTANCE};
+		IScopeContext[] scopes = { ConfigurationScope.INSTANCE, DefaultScope.INSTANCE };
 		IPreferencesService preferencesService = Platform.getPreferencesService();
 		String defaultPreferenceValue = ""; //$NON-NLS-1$
-		String tmp = preferencesService.getString(PREFERENCES_PLUGIN, IStorageConstants.DISABLED_PROVIDERS_KEY, defaultPreferenceValue, scopes);
+		String tmp = preferencesService.getString(PREFERENCES_PLUGIN, IStorageConstants.DISABLED_PROVIDERS_KEY,
+				defaultPreferenceValue, scopes);
 		HashSet<String> disabledModules = splitModuleIds(tmp);
 		return disabledModules;
 	}
@@ -270,7 +274,8 @@ public class TabPassword {
 		TableItem[] items = providerTable.getItems();
 		for (TableItem item : items) {
 			String moduleId = getModuleId(item);
-			boolean enabled = defaultDisabledModules == null || moduleId == null || !defaultDisabledModules.contains(moduleId);
+			boolean enabled = defaultDisabledModules == null || moduleId == null
+					|| !defaultDisabledModules.contains(moduleId);
 			if (item.getChecked() != enabled) {
 				item.setChecked(enabled);
 				providerModified = true;


### PR DESCRIPTION
Using CTabFolder and CTabItem, instead of TabFolder/TabItem, improves the look when in Dark Theme; the background of the tab no longer has a non-dark background.

This relates to multiple commits to fix:

[Windows][Dark theme] Multiple preference pages use tab widgets, that are not dark theme aware eclipse-platform/.github#27