### PR TITLE
Version bump for 4.26 stream.

### DIFF
--- a/features/org.eclipse.equinox.compendium.sdk/feature.xml
+++ b/features/org.eclipse.equinox.compendium.sdk/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.equinox.compendium.sdk"
       label="%featureName"
-      version="3.22.400.qualifier"
+      version="3.22.500.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">


### PR DESCRIPTION
Needed by
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/624 . As this is the first change in this release stream bump the version instead of touching.