### PR TITLE
Widen require bundle version ranges in o.e.osgi.util

### DIFF
--- a/bundles/org.eclipse.osgi.util/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.osgi.util/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %osgiUtil
 Bundle-SymbolicName: org.eclipse.osgi.util
-Bundle-Version: 3.7.100.qualifier
+Bundle-Version: 3.7.200.qualifier
 Bundle-Description: %osgiUtilDes
 Bundle-Vendor: %eclipse.org
 Bundle-Localization: plugin
@@ -10,8 +10,8 @@ Bundle-DocUrl: http://www.eclipse.org
 Bundle-ContactAddress: www.eclipse.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Automatic-Module-Name: org.eclipse.osgi.util
-Require-Bundle: org.osgi.util.function;bundle-version="[1.2.0,1.3.0)";visibility:=reexport,
- org.osgi.util.promise;bundle-version="[1.2.0,1.3.0)";visibility:=reexport,
- org.osgi.util.measurement;bundle-version="[1.0.0,1.1.0)";visibility:=reexport,
- org.osgi.util.position;bundle-version="[1.0.0,1.1.0)";visibility:=reexport,
- org.osgi.util.xml;bundle-version="[1.0.0,1.1.0)";visibility:=reexport
+Require-Bundle: org.osgi.util.function;bundle-version="[1.2.0,2.0.0)";visibility:=reexport,
+ org.osgi.util.promise;bundle-version="[1.2.0,2.0.0)";visibility:=reexport,
+ org.osgi.util.measurement;bundle-version="[1.0.0,2.0.0)";visibility:=reexport,
+ org.osgi.util.position;bundle-version="[1.0.0,2.0.0)";visibility:=reexport,
+ org.osgi.util.xml;bundle-version="[1.0.0,2.0.0)";visibility:=reexport


### PR DESCRIPTION
o.e.osgi.util is a façade for older plugins to get access to some OSGi packages. Plugins should be importing the OSGi package rather than Require-Bundle on o.e.osgi.util.

Since we need to retain this façade for these older bundle, we must not constrain the versions of the OSGi packages installed in the system. org.osgi.util.promise has released 1.3.0 but this cannot be used with o.e.osgi.util since it incorrectly imports too narrow a version range.

So we widen the version range up to the next major version. This will allows the use of any compatible version of the OSGi packages in the system.