### PR TITLE
The check must run on if job was not skipped

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -12,7 +12,7 @@ jobs:
   unit-test-results:
     name: Unit Test Results
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion == 'success'
+    if: github.event.workflow_run.conclusion != 'skipped'
     permissions:
       checks: write
       pull-requests: write


### PR DESCRIPTION
As per recommendation here
https://github.com/EnricoMi/publish-unit-test-result-action#support-fork-repositories-and-dependabot-branches