### PR TITLE
Add core TCKs implemented by org.eclipse.osgi

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -52,6 +52,10 @@ jobs:
       fail-fast: false
       matrix:
         tck: 
+          - { name: framework,   chapter:  '10', label: 'Framework',           suffix: ' API',                   pattern: "TEST-org.osgi.test.cases.framework-*.xml" }
+          - { name: url,         chapter:  '52', label: 'URL Handlers',        suffix: ' Service Specification', pattern: "TEST-org.osgi.test.cases.url-*.xml" }
+          - { name: resolver,    chapter:  '59', label: 'Resolver',            suffix: ' Service Specification', pattern: "TEST-org.osgi.test.cases.resolver-*.xml" }
+          - { name: log,         chapter: '101', label: 'Log',                 suffix: ' Service Specification', pattern: "TEST-org.osgi.test.cases.log-*.xml" }
           - { name: device,      chapter: '103', label: 'Device Access',       suffix: ' Specification',         pattern: "TEST-org.osgi.test.cases.device-*.xml" }
           - { name: cm,          chapter: '104', label: 'Configuration Admin', suffix: ' Service Specification', pattern: "TEST-org.osgi.test.cases.cm-*.xml"}
           - { name: metatype,    chapter: '105', label: 'Metatype',            suffix: ' Service Specification', pattern: "TEST-org.osgi.test.cases.metatype-*.xml" }
@@ -59,6 +63,8 @@ jobs:
           - { name: useradmin,   chapter: '107', label: 'User Admin',          suffix: ' Service Specification', pattern: "TEST-org.osgi.test.cases.useradmin-*.xml" }
           - { name: event,       chapter: '113', label: 'Event Admin',         suffix: ' Service Specification', pattern: "TEST-org.osgi.test.cases.event-*.xml" }
           - { name: coordinator, chapter: '130', label: 'Coordinator',         suffix: ' Service Specification', pattern: "TEST-org.osgi.test.cases.coordinator-*.xml" }
+          - { name: tracker,     chapter: '701', label: 'Tracker',             suffix: ' Specification',         pattern: "TEST-org.osgi.test.cases.tracker-*.xml" }
+          
     steps:  
       - name: Download and Extract Unit Test Results
         env:

--- a/README.md
+++ b/README.md
@@ -17,13 +17,18 @@ Equinox implements the follwoing specification with the given level of complianc
 
 | Chapter | Specification | Status (green = fully compliant, red = partly compliant)|
 |---|---|---|
+| 10 | [Framework API](https://docs.osgi.org/specification/osgi.core/8.0.0/framework.api.html) | ![](https://gist.githubusercontent.com/eclipse-equinox-bot/d941fe2a4992a018d88e778b48ee3135/raw/tck-badge-framework.svg) |
+| 52 | [URL Handlers Service Specification](https://docs.osgi.org/specification/osgi.core/8.0.0/service.url.html) | ![](https://gist.githubusercontent.com/eclipse-equinox-bot/d941fe2a4992a018d88e778b48ee3135/raw/tck-badge-url.svg) |
+| 58 | [Resolver Service Specification](https://docs.osgi.org/specification/osgi.core/8.0.0/service.resolver.html) | ![](https://gist.githubusercontent.com/eclipse-equinox-bot/d941fe2a4992a018d88e778b48ee3135/raw/tck-badge-resolver.svg) |
+| 101 | [Log Service Specification](https://docs.osgi.org/specification/osgi.core/8.0.0/service.log.html) | ![](https://gist.githubusercontent.com/eclipse-equinox-bot/d941fe2a4992a018d88e778b48ee3135/raw/tck-badge-log.svg) |
 | 103 | [Device Access Specification](https://docs.osgi.org/specification/osgi.cmpn/8.1.0/service.device.html) | ![](https://gist.githubusercontent.com/eclipse-equinox-bot/d941fe2a4992a018d88e778b48ee3135/raw/tck-badge-device.svg) |
 | 104 | [Configuration Admin Service Specification](https://docs.osgi.org/specification/osgi.cmpn/8.1.0/service.cm.html) | ![](https://gist.githubusercontent.com/eclipse-equinox-bot/d941fe2a4992a018d88e778b48ee3135/raw/tck-badge-cm.svg) |
 | 105 | [Metatype Service Specification](https://docs.osgi.org/specification/osgi.cmpn/8.1.0/service.metatype.html) | ![](https://gist.githubusercontent.com/eclipse-equinox-bot/d941fe2a4992a018d88e778b48ee3135/raw/tck-badge-metatype.svg) |
 | 106 | [PreferencesService Specification](https://docs.osgi.org/specification/osgi.cmpn/8.1.0/service.prefs.html) | ![](https://gist.githubusercontent.com/eclipse-equinox-bot/d941fe2a4992a018d88e778b48ee3135/raw/tck-badge-preferences.svg) |
 | 107 | [User Admin Service Specification](https://docs.osgi.org/specification/osgi.cmpn/8.1.0/service.useradmin.html) | ![](https://gist.githubusercontent.com/eclipse-equinox-bot/d941fe2a4992a018d88e778b48ee3135/raw/tck-badge-useradmin.svg) |
-| 130 | [Coordinator Service Specification](https://docs.osgi.org/specification/osgi.cmpn/8.1.0/service.coordinator.html) | ![](https://gist.githubusercontent.com/eclipse-equinox-bot/d941fe2a4992a018d88e778b48ee3135/raw/tck-badge-coordinator.svg) |
 | 113 | [Event Admin Service Specification](https://docs.osgi.org/specification/osgi.cmpn/8.1.0/service.event.html) | ![](https://gist.githubusercontent.com/eclipse-equinox-bot/d941fe2a4992a018d88e778b48ee3135/raw/tck-badge-event.svg) |
+| 130 | [Coordinator Service Specification](https://docs.osgi.org/specification/osgi.cmpn/8.1.0/service.coordinator.html) | ![](https://gist.githubusercontent.com/eclipse-equinox-bot/d941fe2a4992a018d88e778b48ee3135/raw/tck-badge-coordinator.svg) |
+| 701 | [Tracker Specification](https://docs.osgi.org/specification/osgi.core/8.0.0/util.tracker.html) | ![](https://gist.githubusercontent.com/eclipse-equinox-bot/d941fe2a4992a018d88e778b48ee3135/raw/tck-badge-tracker.svg) |
 
 
 # More information

--- a/bundles/org.eclipse.osgi.tck/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.osgi.tck/META-INF/MANIFEST.MF
@@ -1,0 +1,7 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: OSGi Core TCK
+Bundle-SymbolicName: org.eclipse.osgi.tck
+Bundle-Version: 1.0.0
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+

--- a/bundles/org.eclipse.osgi.tck/build.properties
+++ b/bundles/org.eclipse.osgi.tck/build.properties
@@ -1,0 +1,33 @@
+###############################################################################
+# Copyright (c) 2023 Christoph Läubrich and others.
+#
+# This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     Christoph Läubrich - initial API and implementation
+###############################################################################
+bin.includes = META-INF/,.
+
+
+## Configuration for TCK tests to execute for this project
+pom.model.property.tck.artifact = org.eclipse.osgi,org.eclipse.equinox.cm,\
+	org.osgi.test.cases.log,\
+	org.osgi.test.cases.tracker,\
+	org.osgi.test.cases.framework,\
+	org.osgi.test.cases.url,\
+	org.osgi.test.cases.resolver
+	
+#pom.model.property.tck.security = true
+# possible other core tcks that equinox implements?
+#org.osgi.test.cases.bundle.annotations-8.0.0
+#org.osgi.test.cases.condpermadmin-8.0.0
+#org.osgi.test.cases.log.launch-8.0.0
+#org.osgi.test.cases.permissionadmin-8.0.0
+#org.osgi.test.cases.framework.launch-8.0.0
+#org.osgi.test.cases.framework.launch.secure-8.0.0
+#org.osgi.test.cases.framework.secure-8.0.0

--- a/bundles/org.eclipse.osgi/pom.xml
+++ b/bundles/org.eclipse.osgi/pom.xml
@@ -21,7 +21,11 @@
   <artifactId>org.eclipse.osgi</artifactId>
   <version>3.18.300-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
-
+  <properties>
+	  <!-- The actual TCKs are executed in the org.eclipse.osgi.tck module because of reference to other service implementations -->
+	  <tck.skip>true</tck.skip>
+  </properties>
+  
   <build>
     <plugins>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -144,6 +144,7 @@
 			<tck.engine>org.junit.vintage.engine,junit-jupiter-engine</tck.engine>
 			<tck.tester>biz.aQute.tester.junit-platform</tck.tester>
 			<tck.security>false</tck.security>
+			<tck.skip>false</tck.skip>
 		</properties>
 		<build>
 			<plugins>
@@ -171,6 +172,7 @@
 								<bundles>
 									${tck.artifact}
 								</bundles>
+								<skipTests>${tck.skip}</skipTests>
 								<tester>${tck.tester}</tester>
 								<engine>${tck.engine}</engine>
 								<trace>false</trace>
@@ -190,8 +192,10 @@
 			</plugins>
 		</build>
 		<modules>
-			<module>bundles/org.eclipse.equinox.cm</module>
+			<module>bundles/org.eclipse.osgi</module>
+			<module>bundles/org.eclipse.osgi.tck</module>
 			<module>bundles/org.eclipse.equinox.coordinator</module>
+			<module>bundles/org.eclipse.equinox.cm</module>
 			<module>bundles/org.eclipse.equinox.useradmin</module>
 			<module>bundles/org.eclipse.equinox.preferences</module>
 			<module>bundles/org.eclipse.equinox.metatype</module>

--- a/releng/tcks.target
+++ b/releng/tcks.target
@@ -5,13 +5,13 @@
             <dependencies>
                 <dependency>
                     <groupId>org.osgi</groupId>
-                    <artifactId>org.osgi.test.cases.event</artifactId>
+                    <artifactId>org.osgi.test.cases.cm</artifactId>
                     <version>8.1.0</version>
                     <type>jar</type>
                 </dependency>
                 <dependency>
                     <groupId>org.osgi</groupId>
-                    <artifactId>org.osgi.test.cases.cm</artifactId>
+                    <artifactId>org.osgi.test.cases.coordinator</artifactId>
                     <version>8.1.0</version>
                     <type>jar</type>
                 </dependency>
@@ -21,14 +21,24 @@
                     <version>8.1.0</version>
                     <type>jar</type>
                 </dependency>
-                <!-- TODO currently missing on central see https://github.com/osgi/osgi/issues/557
                 <dependency>
                     <groupId>org.osgi</groupId>
-                    <artifactId>org.osgi.test.cases.log</artifactId>
+                    <artifactId>org.osgi.test.cases.event</artifactId>
                     <version>8.1.0</version>
                     <type>jar</type>
                 </dependency>
-                -->
+                <dependency>
+                    <groupId>org.osgi</groupId>
+                    <artifactId>org.osgi.test.cases.framework</artifactId>
+                    <version>8.0.0</version>
+                    <type>jar</type>
+                </dependency>
+                <dependency>
+                    <groupId>org.osgi</groupId>
+                    <artifactId>org.osgi.test.cases.log</artifactId>
+                    <version>8.0.0</version>
+                    <type>jar</type>
+                </dependency>
                 <dependency>
                     <groupId>org.osgi</groupId>
                     <artifactId>org.osgi.test.cases.metatype</artifactId>
@@ -43,15 +53,38 @@
                 </dependency>
                 <dependency>
                     <groupId>org.osgi</groupId>
+                    <artifactId>org.osgi.test.cases.resolver</artifactId>
+                    <version>8.0.0</version>
+                    <type>jar</type>
+                </dependency>
+                <dependency>
+                    <groupId>org.osgi</groupId>
+                    <artifactId>org.osgi.test.cases.tracker</artifactId>
+                    <version>8.0.0</version>
+                    <type>jar</type>
+                </dependency>
+                <dependency>
+                    <groupId>org.osgi</groupId>
+                    <artifactId>org.osgi.test.cases.url</artifactId>
+                    <version>8.0.0</version>
+                    <type>jar</type>
+                </dependency>
+                <dependency>
+                    <groupId>org.osgi</groupId>
                     <artifactId>org.osgi.test.cases.useradmin</artifactId>
                     <version>8.1.0</version>
                     <type>jar</type>
                 </dependency>
+            </dependencies>
+        </location>
+        <location includeDependencyDepth="none" label="TCK Dependencies" missingManifest="generate" type="Maven">
+            <dependencies>
                 <dependency>
-				  <groupId>org.osgi</groupId>
-				  <artifactId>org.osgi.test.cases.coordinator</artifactId>
-				  <version>8.1.0</version>
-				</dependency>
+                    <groupId>org.apache.bcel</groupId>
+                    <artifactId>bcel</artifactId>
+                    <version>5.2</version>
+                    <type>jar</type>
+                </dependency>
             </dependencies>
         </location>
     </locations>


### PR DESCRIPTION
FYI @tjwatson I think this should cover the most important parts equinox implements, is anything missing?

I also added resolver even though it seems the sources are imported from Felix (are these synchronized from time to time?) probably we should test SCR even if it is provided by Felix and not part of Equinox code base?