### PR TITLE
Add a method that returns the registry as an optional

### DIFF
--- a/bundles/org.eclipse.equinox.registry/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.registry/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.registry;singleton:=true
-Bundle-Version: 3.11.200.qualifier
+Bundle-Version: 3.12.0.qualifier
 Bundle-Localization: plugin
 Export-Package: org.eclipse.core.internal.adapter;x-internal:=true,
  org.eclipse.core.internal.registry;x-friends:="org.eclipse.core.runtime",

--- a/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/runtime/RegistryFactory.java
+++ b/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/runtime/RegistryFactory.java
@@ -14,6 +14,7 @@
 package org.eclipse.core.runtime;
 
 import java.io.File;
+import java.util.Optional;
 import org.eclipse.core.internal.registry.ExtensionRegistry;
 import org.eclipse.core.internal.registry.RegistryProviderFactory;
 import org.eclipse.core.internal.registry.osgi.RegistryStrategyOSGI;
@@ -27,6 +28,7 @@ import org.eclipse.core.runtime.spi.RegistryStrategy;
  * </p><ul>
  * <li>{@link #createRegistry(RegistryStrategy, Object, Object)}</li>
  * <li>{@link #getRegistry()}</li>
+ * <li>{@link #registry()}</li>
  * <li>{@link #setDefaultRegistryProvider(IRegistryProvider)}</li>
  * </ul><p>
  * This class is not intended to be subclassed or instantiated.
@@ -73,6 +75,18 @@ public final class RegistryFactory {
 		if (defaultRegistryProvider == null)
 			return null;
 		return defaultRegistryProvider.getRegistry();
+	}
+
+	/**
+	 * Returns an optional describing the default extension registry specified by
+	 * the registry provider. Returns an empty optional if the provider has not been
+	 * set or if the registry has not been created.
+	 *
+	 * @return the optional extension registry
+	 * @since 3.12
+	 */
+	public static Optional<IExtensionRegistry> registry() {
+		return Optional.ofNullable(getRegistry());
 	}
 
 	/**


### PR DESCRIPTION
As per API contract the RegistryFactory can return null, this has some drawbacks:
- callers of the API might be not well aware of this
- additional null checks are required on the caller site

this adds a new registry() method that reaturns an optional and makes it clear to the caller that there might be a chance of getting "nothing" and also allows to convienetly hande the case using modern programming primitives like lamdas or handler chaning.