### PR TITLE
Do not list felix.scr expliictly.

### DIFF
--- a/features/org.eclipse.equinox.core.feature/feature.xml
+++ b/features/org.eclipse.equinox.core.feature/feature.xml
@@ -101,13 +101,6 @@
          unpack="false"/>
 
    <plugin
-         id="org.apache.felix.scr"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
          id="org.osgi.util.function"
          download-size="0"
          install-size="0"


### PR DESCRIPTION
It should be pulled in as a provider of
osgi.extender;filter:="(&(osgi.extender=osgi.component)(version>=1.0)(!(version>=2.0)))"

Change is an effort to reduce the need to "touch" features everytime 3rd party dependency is being updated.