### PR TITLE
Do not list felix.scr expliictly in compendium feature

### DIFF
--- a/features/org.eclipse.equinox.compendium.sdk/feature.xml
+++ b/features/org.eclipse.equinox.compendium.sdk/feature.xml
@@ -146,20 +146,6 @@
          unpack="false"/>
 
    <plugin
-         id="org.apache.felix.scr"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.apache.felix.scr.source"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
          id="org.osgi.service.coordinator"
          download-size="0"
          install-size="0"


### PR DESCRIPTION
It should be pulled in as a provider of
osgi.extender;filter:="(&(osgi.extender=osgi.component)(version>=1.0)(!(version>=2.0)))"

Change is an effort to reduce the need to "touch" features everytime 3rd party dependency is being updated.