### PR TITLE
Fix for NPE in PackageSource.toString()

### DIFF
--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/loader/sources/PackageSource.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/loader/sources/PackageSource.java
@@ -87,7 +87,7 @@ public abstract class PackageSource {
 		builder.append(id).append(" -> "); //$NON-NLS-1$
 		SingleSourcePackage[] suppliers = getSuppliers();
 		if (suppliers == null) {
-			return builder.append(String.valueOf(null)).toString();
+			return builder.append("null").toString(); //$NON-NLS-1$
 		}
 		builder.append('[');
 		for (int i = 0; i < suppliers.length; i++) {


### PR DESCRIPTION
Seen debugging JDT UI Leak test & printing the references

```
java.lang.NullPointerException: Cannot read the array length because
"value" is null
	at java.base/java.lang.String.<init>(String.java:275)
	at java.base/java.lang.String.valueOf(String.java:4229)
	at org.eclipse.osgi.internal.loader.sources.PackageSource.toString(PackageSource.java:90)
	at java.base/java.lang.String.valueOf(String.java:4215)
	at java.base/java.lang.StringBuilder.append(StringBuilder.java:173)
	at java.base/java.util.HashMap$Node.toString(HashMap.java:296)
	at java.base/java.lang.String.valueOf(String.java:4215)
	at java.base/java.lang.StringBuilder.append(StringBuilder.java:173)
	at org.eclipse.jdt.ui.leaktest.reftracker.ReferencedObject.toString(ReferencedObject.java:49)
	at java.base/java.lang.String.valueOf(String.java:4215)
	at java.base/java.lang.StringBuilder.append(StringBuilder.java:173)
	at org.eclipse.jdt.ui.leaktest.reftracker.ReferenceTracker.followFieldReference(ReferenceTracker.java:75)
```