### PR TITLE
Provide IPath.toPath() similar to IPath.toFile()

### DIFF
--- a/bundles/org.eclipse.equinox.common.tests/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.common.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Common Eclipse Runtime Tests
 Bundle-Vendor: Eclipse.org - Equinox
 Bundle-SymbolicName: org.eclipse.equinox.common.tests;singleton:=true
-Bundle-Version: 3.15.500.qualifier
+Bundle-Version: 3.16.0.qualifier
 Automatic-Module-Name: org.eclipse.equinox.common.tests
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy

--- a/bundles/org.eclipse.equinox.common.tests/src/org/eclipse/equinox/common/tests/PathTest.java
+++ b/bundles/org.eclipse.equinox.common.tests/src/org/eclipse/equinox/common/tests/PathTest.java
@@ -1048,26 +1048,26 @@ public class PathTest extends CoreTest {
 		//Case 1, absolute path with no trailing separator
 		IPath anyPath = new Path("/first/second/third");
 
-		assertNotNull("1.0", anyPath.toPath());
-		assertEquals("1.1", java.nio.file.Path.of("/first/second/third"), anyPath.toPath());
+		assertNotNull(anyPath.toPath());
+		assertEquals(java.nio.file.Path.of("/first/second/third"), anyPath.toPath());
 
 		// Case 2, absolute path with trailing separator
 		anyPath = new Path("/first/second/third/");
 
-		assertNotNull("2.0", anyPath.toPath());
-		assertEquals("2.1", java.nio.file.Path.of("/first/second/third/"), anyPath.toPath());
+		assertNotNull(anyPath.toPath());
+		assertEquals(java.nio.file.Path.of("/first/second/third/"), anyPath.toPath());
 
 		// Case 3, relative path with no trailing separator
 		anyPath = new Path("first/second/third");
 
-		assertNotNull("3.0", anyPath.toPath());
-		assertEquals("3.1", java.nio.file.Path.of("first/second/third"), anyPath.toPath());
+		assertNotNull(anyPath.toPath());
+		assertEquals(java.nio.file.Path.of("first/second/third"), anyPath.toPath());
 
 		// Case 4, relative path with trailing separator
 		anyPath = new Path("first/second/third/");
 
-		assertNotNull("4.0", anyPath.toPath());
-		assertEquals("4.1", java.nio.file.Path.of("first/second/third/"), anyPath.toPath());
+		assertNotNull(anyPath.toPath());
+		assertEquals(java.nio.file.Path.of("first/second/third/"), anyPath.toPath());
 
 	}
 }

--- a/bundles/org.eclipse.equinox.common.tests/src/org/eclipse/equinox/common/tests/PathTest.java
+++ b/bundles/org.eclipse.equinox.common.tests/src/org/eclipse/equinox/common/tests/PathTest.java
@@ -1042,4 +1042,32 @@ public class PathTest extends CoreTest {
 		anyPath = new Path("//one/two/three/");
 		assertEquals("5.4", new Path("//"), anyPath.uptoSegment(0));
 	}
+
+	public void testToPath() {
+
+		//Case 1, absolute path with no trailing separator
+		IPath anyPath = new Path("/first/second/third");
+
+		assertNotNull("1.0", anyPath.toPath());
+		assertEquals("1.1", java.nio.file.Path.of("/first/second/third"), anyPath.toPath());
+
+		// Case 2, absolute path with trailing separator
+		anyPath = new Path("/first/second/third/");
+
+		assertNotNull("2.0", anyPath.toPath());
+		assertEquals("2.1", java.nio.file.Path.of("/first/second/third/"), anyPath.toPath());
+
+		// Case 3, relative path with no trailing separator
+		anyPath = new Path("first/second/third");
+
+		assertNotNull("3.0", anyPath.toPath());
+		assertEquals("3.1", java.nio.file.Path.of("first/second/third"), anyPath.toPath());
+
+		// Case 4, relative path with trailing separator
+		anyPath = new Path("first/second/third/");
+
+		assertNotNull("4.0", anyPath.toPath());
+		assertEquals("4.1", java.nio.file.Path.of("first/second/third/"), anyPath.toPath());
+
+	}
 }

--- a/bundles/org.eclipse.equinox.common/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.common/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.common; singleton:=true
-Bundle-Version: 3.17.100.qualifier
+Bundle-Version: 3.18.0.qualifier
 Bundle-Localization: plugin
 Export-Package: org.eclipse.core.internal.boot;x-friends:="org.eclipse.core.resources,org.eclipse.pde.build",
  org.eclipse.core.internal.runtime;common=split;mandatory:=common;

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/IPath.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/IPath.java
@@ -464,6 +464,7 @@ public interface IPath extends Cloneable {
 	 * Returns a <code>java.nio.file.Path</code> corresponding to this path.
 	 *
 	 * @return the path corresponding to this path
+	 * @since 3.18
 	 */
 	default java.nio.file.Path toPath() {
 		return toFile().toPath();

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/IPath.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/IPath.java
@@ -461,6 +461,15 @@ public interface IPath extends Cloneable {
 	public java.io.File toFile();
 
 	/**
+	 * Returns a <code>java.nio.file.Path</code> corresponding to this path.
+	 *
+	 * @return the path corresponding to this path
+	 */
+	default java.nio.file.Path toPath() {
+		return toFile().toPath();
+	}
+
+	/**
 	 * Returns a string representation of this path which uses the
 	 * platform-dependent path separator defined by <code>java.io.File</code>.
 	 * This method is like <code>toString()</code> except that the

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/IPath.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/IPath.java
@@ -467,7 +467,7 @@ public interface IPath extends Cloneable {
 	 * @since 3.18
 	 */
 	default java.nio.file.Path toPath() {
-		return toFile().toPath();
+		return java.nio.file.Path.of(toOSString());
 	}
 
 	/**

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/Path.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/Path.java
@@ -1116,14 +1116,6 @@ public final class Path implements IPath, Cloneable {
 	public File toFile() {
 		return new File(toOSString());
 	}
-	
-	/* (Intentionally not included in javadoc)
-	 * @see IPath#toPath()
-	 */
-	@Override
-	public java.nio.file.Path toPath() {
-		return java.nio.file.Path.of(toOSString());
-	}
 
 	/* (Intentionally not included in javadoc)
 	 * @see IPath#toOSString()

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/Path.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/Path.java
@@ -1116,6 +1116,14 @@ public final class Path implements IPath, Cloneable {
 	public File toFile() {
 		return new File(toOSString());
 	}
+	
+	/* (Intentionally not included in javadoc)
+	 * @see IPath#toPath()
+	 */
+	@Override
+	public java.nio.file.Path toPath() {
+		return java.nio.file.Path.of(toOSString());
+	}
 
 	/* (Intentionally not included in javadoc)
 	 * @see IPath#toOSString()

--- a/features/org.eclipse.equinox.core.feature/feature.xml
+++ b/features/org.eclipse.equinox.core.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.equinox.core.feature"
       label="%featureName"
-      version="1.13.1000.qualifier"
+      version="1.14.0.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/features/org.eclipse.equinox.server.core/feature.xml
+++ b/features/org.eclipse.equinox.server.core/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.equinox.server.core"
       label="%featureName"
-      version="1.14.900.qualifier"
+      version="1.15.0.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">


### PR DESCRIPTION
Although it's possible to do `IPath.toFile().toPath()` this PR adds a convenience method which avoids the additional `File` object creation.