### PR TITLE
Improve interoperabilitiy of IPath and Java's io.File/nio.Path

### DIFF
--- a/bundles/org.eclipse.equinox.common.tests/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.common.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Common Eclipse Runtime Tests
 Bundle-Vendor: Eclipse.org - Equinox
 Bundle-SymbolicName: org.eclipse.equinox.common.tests;singleton:=true
-Bundle-Version: 3.15.500.qualifier
+Bundle-Version: 3.16.0.qualifier
 Automatic-Module-Name: org.eclipse.equinox.common.tests
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy

--- a/bundles/org.eclipse.equinox.common.tests/src/org/eclipse/equinox/common/tests/PathTest.java
+++ b/bundles/org.eclipse.equinox.common.tests/src/org/eclipse/equinox/common/tests/PathTest.java
@@ -17,6 +17,7 @@ package org.eclipse.equinox.common.tests;
 import static org.junit.Assert.assertNotEquals;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
@@ -46,7 +47,7 @@ public class PathTest extends CoreTest {
 
 		assertSame("1.0", with, with.addTrailingSeparator());
 		assertEquals("1.1", with, without.addTrailingSeparator());
-		assertTrue("1.2", without.equals(without.addTrailingSeparator()));
+		assertEquals("1.2", without, without.addTrailingSeparator());
 
 		assertSame("2.0", Path.ROOT, Path.ROOT.addTrailingSeparator());
 		assertEquals("2.1", Path.ROOT, Path.EMPTY.addTrailingSeparator());
@@ -56,7 +57,7 @@ public class PathTest extends CoreTest {
 
 		assertSame("3.0", with, with.addTrailingSeparator());
 		assertEquals("3.1", with, without.addTrailingSeparator());
-		assertTrue("3.2", without.equals(without.addTrailingSeparator()));
+		assertEquals("3.2", without, without.addTrailingSeparator());
 
 		assertSame("4.0", Path.ROOT, Path.ROOT.addTrailingSeparator());
 		assertEquals("4.1", Path.ROOT, Path.EMPTY.addTrailingSeparator());
@@ -66,7 +67,7 @@ public class PathTest extends CoreTest {
 
 		assertSame("5.0", with, with.addTrailingSeparator());
 		assertEquals("5.1", with, without.addTrailingSeparator());
-		assertTrue("5.2", without.equals(without.addTrailingSeparator()));
+		assertEquals("5.2", without, without.addTrailingSeparator());
 
 		assertSame("6.0", Path.ROOT, Path.ROOT.addTrailingSeparator());
 		assertEquals("6.1", Path.ROOT, Path.EMPTY.addTrailingSeparator());
@@ -75,8 +76,8 @@ public class PathTest extends CoreTest {
 	public void testAppend() {
 
 		IPath fore = new Path("/first/second/third/");
-		IPath win = Path.forWindows("/first/second/third/");
-		IPath posix = Path.forPosix("/first/second/third/");
+		IPath win = IPath.forWindows("/first/second/third/");
+		IPath posix = IPath.forPosix("/first/second/third/");
 		String aftString = "/fourth/fifth";
 		IPath aft = new Path(aftString);
 		IPath combo = new Path("/first/second/third/fourth/fifth");
@@ -121,27 +122,27 @@ public class PathTest extends CoreTest {
 		assertEquals("4.0.win", combo, win.append(aftString));
 		assertEquals("4.1.win", combo, win.removeTrailingSeparator().append(aftString));
 		// append path to root path uses optimized code
-		assertEquals("4.2.win", combo, Path.forWindows("/").append(win).append(aftString));
+		assertEquals("4.2.win", combo, IPath.forWindows("/").append(win).append(aftString));
 		assertEquals("4.21.win", combo,
-				Path.forWindows("/").append(win).append("..").append("third").append(aftString));
-		assertEquals("4.2X.win", Path.forWindows("/").append("x"),
-				Path.forWindows("/").append("x").append("..").append("x"));
-		assertEquals("4.2XY/.win", Path.forWindows("\\").append("x/y"),
-				Path.forWindows("\\").append("x").append("y").append("../..").append("x/y"));
-		assertEquals("4.2XY\\.win", Path.forWindows("/").append("x\\y"),
-				Path.forWindows("/").append("x").append("y").append("..\\..").append("x\\y"));
+				IPath.forWindows("/").append(win).append("..").append("third").append(aftString));
+		assertEquals("4.2X.win", IPath.forWindows("/").append("x"),
+				IPath.forWindows("/").append("x").append("..").append("x"));
+		assertEquals("4.2XY/.win", IPath.forWindows("\\").append("x/y"),
+				IPath.forWindows("\\").append("x").append("y").append("../..").append("x/y"));
+		assertEquals("4.2XY\\.win", IPath.forWindows("/").append("x\\y"),
+				IPath.forWindows("/").append("x").append("y").append("..\\..").append("x\\y"));
 		assertEquals("4.22.win", combo,
-				Path.forWindows("/").append(win).append("..\\..").append("second\\third").append(aftString));
+				IPath.forWindows("/").append(win).append("..\\..").append("second\\third").append(aftString));
 		assertEquals("4.23.win", combo,
-				Path.forWindows("/").append(win).append("..\\..\\..").append("first\\second\\third").append(aftString));
+				IPath.forWindows("/").append(win).append("..\\..\\..").append("first\\second\\third").append(aftString));
 		assertEquals("4.24.win", combo,
-				Path.forWindows("/").append(win).append("..\\..\\..").append(win).append(aftString));
+				IPath.forWindows("/").append(win).append("..\\..\\..").append(win).append(aftString));
 		assertEquals("4.25.win", combo,
-				Path.forWindows("/").append(win).append("../../..").append(win).append(aftString));
-		assertEquals("4.3.win", combo, Path.forWindows("/").append(posix).append(aftString));
+				IPath.forWindows("/").append(win).append("../../..").append(win).append(aftString));
+		assertEquals("4.3.win", combo, IPath.forWindows("/").append(posix).append(aftString));
 		// append path to empty path uses optimized code
-		assertEquals("4.4.win", combo, Path.forWindows("").append(win).append(aftString).makeAbsolute());
-		assertEquals("4.5.win", combo, Path.forWindows("").append(posix).append(aftString).makeAbsolute());
+		assertEquals("4.4.win", combo, IPath.forWindows("").append(win).append(aftString).makeAbsolute());
+		assertEquals("4.5.win", combo, IPath.forWindows("").append(posix).append(aftString).makeAbsolute());
 
 		assertEquals("5.0", new Path("/foo"), Path.ROOT.append("../foo"));
 		assertEquals("5.1", new Path("/foo"), Path.ROOT.append("./foo"));
@@ -149,19 +150,19 @@ public class PathTest extends CoreTest {
 		assertEquals("5.3", new Path("c:/foo/bar/xyz"), new Path("c:/foo/bar").append("./xyz"));
 
 		//append preserves device and leading separator of receiver
-		assertEquals("6.1.win", Path.forWindows("c:foo/bar"), Path.forWindows("c:").append("/foo/bar"));
-		assertEquals("6.2.win", Path.forWindows("c:foo/bar"), Path.forWindows("c:").append("foo/bar"));
-		assertEquals("6.3.win", Path.forWindows("c:/foo/bar"), Path.forWindows("c:/").append("/foo/bar"));
-		assertEquals("6.4.win", Path.forWindows("c:/foo/bar"), Path.forWindows("c:/").append("foo/bar"));
-		assertEquals("6.5.win", Path.forWindows("c:foo/bar"), Path.forWindows("c:").append("z:/foo/bar"));
-		assertEquals("6.6.win", Path.forWindows("c:foo/bar"), Path.forWindows("c:").append("z:foo/bar"));
-		assertEquals("6.7.win", Path.forWindows("c:/foo/bar"), Path.forWindows("c:/").append("z:/foo/bar"));
-		assertEquals("6.8.win", Path.forWindows("c:/foo/bar"), Path.forWindows("c:/").append("z:foo/bar"));
-		assertEquals("6.9.win", Path.forWindows("c:/foo"), Path.forWindows("c:/").append("z:foo"));
-		assertEquals("6.10.posix", Path.forPosix("c:/foo/bar"), Path.forPosix("c:").append("/foo/bar"));
-		assertEquals("6.11.posix", Path.forPosix("c:/foo/bar/"), Path.forPosix("c:").append("foo/bar/"));
-		assertEquals("6.12.posix", Path.forPosix("/c:/foo/bar"), Path.forPosix("/c:").append("/foo/bar"));
-		assertEquals("6.13.posix", Path.forPosix("/c:/foo/bar"), Path.forPosix("/c:").append("foo/bar"));
+		assertEquals("6.1.win", IPath.forWindows("c:foo/bar"), IPath.forWindows("c:").append("/foo/bar"));
+		assertEquals("6.2.win", IPath.forWindows("c:foo/bar"), IPath.forWindows("c:").append("foo/bar"));
+		assertEquals("6.3.win", IPath.forWindows("c:/foo/bar"), IPath.forWindows("c:/").append("/foo/bar"));
+		assertEquals("6.4.win", IPath.forWindows("c:/foo/bar"), IPath.forWindows("c:/").append("foo/bar"));
+		assertEquals("6.5.win", IPath.forWindows("c:foo/bar"), IPath.forWindows("c:").append("z:/foo/bar"));
+		assertEquals("6.6.win", IPath.forWindows("c:foo/bar"), IPath.forWindows("c:").append("z:foo/bar"));
+		assertEquals("6.7.win", IPath.forWindows("c:/foo/bar"), IPath.forWindows("c:/").append("z:/foo/bar"));
+		assertEquals("6.8.win", IPath.forWindows("c:/foo/bar"), IPath.forWindows("c:/").append("z:foo/bar"));
+		assertEquals("6.9.win", IPath.forWindows("c:/foo"), IPath.forWindows("c:/").append("z:foo"));
+		assertEquals("6.10.posix", IPath.forPosix("c:/foo/bar"), IPath.forPosix("c:").append("/foo/bar"));
+		assertEquals("6.11.posix", IPath.forPosix("c:/foo/bar/"), IPath.forPosix("c:").append("foo/bar/"));
+		assertEquals("6.12.posix", IPath.forPosix("/c:/foo/bar"), IPath.forPosix("/c:").append("/foo/bar"));
+		assertEquals("6.13.posix", IPath.forPosix("/c:/foo/bar"), IPath.forPosix("/c:").append("foo/bar"));
 
 		assertEquals("6.14", new Path("foo/bar"), new Path("foo").append(new Path("/bar")));
 		assertEquals("6.15", new Path("foo/bar"), new Path("foo").append(new Path("bar")));
@@ -193,40 +194,40 @@ public class PathTest extends CoreTest {
 		assertEquals("8.10.win", win, win.append("c:"));
 
 		// append string respects and preserves the initial path's file system
-		IPath win1 = Path.forWindows("a/b");
+		IPath win1 = IPath.forWindows("a/b");
 		IPath win2 = win1.append("c:d\\e");
 		assertEquals("9.1.win", "a/b/d/e", win2.toString());
 		assertEquals("9.2.win", null, win2.getDevice());
 		assertEquals("9.3.win", 4, win2.segmentCount());
 		assertEquals("9.4.win", "d", win2.segment(2));
 		assertFalse("9.5.win", win2.isValidSegment(":"));
-		IPath posix1 = Path.forPosix("a/b");
+		IPath posix1 = IPath.forPosix("a/b");
 		IPath posix2 = posix1.append("c:d\\e");
 		assertEquals("9.6.posix", "a/b/c:d\\e", posix2.toString());
 		assertEquals("9.7.posix", null, posix2.getDevice());
 		assertEquals("9.8.posix", 3, posix2.segmentCount());
 		assertEquals("9.9.posix", "c:d\\e", posix2.segment(2));
 		assertTrue("9.10.posix", posix2.isValidSegment(":"));
-		assertTrue("9.11", win1.equals(posix1));
-		assertFalse("9.12", win2.equals(posix2));
+		assertEquals("9.11", win1, posix1);
+		assertNotEquals("9.12", win2, posix2);
 
 		// append path respects and preserves the initial path's file system
-		IPath win3 = win1.append(Path.forPosix("c/d/e"));
+		IPath win3 = win1.append(IPath.forPosix("c/d/e"));
 		assertEquals("10.1.win", "a/b/c/d/e", win3.toString());
 		assertEquals("10.2.win", null, win3.getDevice());
 		assertEquals("10.3.win", 5, win3.segmentCount());
 		assertEquals("10.4.win", "c", win3.segment(2));
 		assertFalse("10.5.win", win3.isValidSegment(":"));
-		IPath posix3 = posix1.append(Path.forWindows("c\\d\\e"));
+		IPath posix3 = posix1.append(IPath.forWindows("c\\d\\e"));
 		assertEquals("10.6.posix", "a/b/c/d/e", posix3.toString());
 		assertEquals("10.7.posix", null, posix3.getDevice());
 		assertEquals("10.8.posix", 5, posix3.segmentCount());
 		assertEquals("10.9.posix", "c", posix3.segment(2));
 		assertTrue("10.10.posix", posix3.isValidSegment(":"));
-		assertTrue("10.11", win3.equals(posix3));
+		assertEquals("10.11", win3, posix3);
 
 		// append POSIX path to Windows path may produce invalid segments
-		IPath win4 = win1.append(Path.forPosix("c:d\\e"));
+		IPath win4 = win1.append(IPath.forPosix("c:d\\e"));
 		assertEquals("11.1.win", "a/b/c:d\\e", win4.toString());
 		assertEquals("11.2.win", null, win4.getDevice());
 		assertEquals("11.3.win", 3, win4.segmentCount());
@@ -312,26 +313,26 @@ public class PathTest extends CoreTest {
 
 		//should handle slash before the device (see bug 84697)
 		// fullPath = new java.io.File("D:\\foo\\abc.txt").toURL().getPath()
-		assertEquals("3.0.win", "D:/foo/abc.txt", Path.forWindows("/D:/foo/abc.txt").toString());
+		assertEquals("3.0.win", "D:/foo/abc.txt", IPath.forWindows("/D:/foo/abc.txt").toString());
 		// fullPath = new java.io.File("D:/").toURL().getPath()
-		assertEquals("3.1.win", "D:/", Path.forWindows("/D:/").toString());
+		assertEquals("3.1.win", "D:/", IPath.forWindows("/D:/").toString());
 	}
 
 	public void testFactoryMethods() {
 
-		IPath win = Path.forWindows("a:b\\c/d");
+		IPath win = IPath.forWindows("a:b\\c/d");
 		assertEquals("1.1.win", "a:b/c/d", win.toString());
 		assertEquals("1.2.win", "a:", win.getDevice());
 		assertEquals("1.3.win", 3, win.segmentCount());
 		assertEquals("1.4.win", "b", win.segment(0));
 
-		IPath posix = Path.forPosix("a:b\\c/d");
+		IPath posix = IPath.forPosix("a:b\\c/d");
 		assertEquals("2.5.posix", "a:b\\c/d", posix.toString());
 		assertEquals("2.6.posix", null, posix.getDevice());
 		assertEquals("2.7.posix", 2, posix.segmentCount());
 		assertEquals("2.8.posix", "a:b\\c", posix.segment(0));
 
-		assertFalse("3.1", win.equals(posix));
+		assertNotEquals("3.1", win, posix);
 	}
 
 	public void testFirstSegment() {
@@ -344,46 +345,61 @@ public class PathTest extends CoreTest {
 		assertEquals("2.2", "a", new Path("/a").segment(0));
 		assertEquals("2.3", "a", new Path("a/b").segment(0));
 		assertEquals("2.4", "a", new Path("//a/b").segment(0));
-		assertEquals("2.5.win", "a", Path.forWindows("c:a/b").segment(0));
-		assertEquals("2.6.win", "a", Path.forWindows("c:/a/b").segment(0));
-		assertEquals("2.7.posix", "c:", Path.forPosix("c:/a/b").segment(0));
-		assertEquals("2.8.posix", "c:", Path.forPosix("c:/a\\b").segment(0));
-		assertEquals("2.9.posix", "a", Path.forPosix("a/c:/b").segment(0));
-		assertEquals("2.10.posix", "a\\b", Path.forPosix("a\\b/b").segment(0));
+		assertEquals("2.5.win", "a", IPath.forWindows("c:a/b").segment(0));
+		assertEquals("2.6.win", "a", IPath.forWindows("c:/a/b").segment(0));
+		assertEquals("2.7.posix", "c:", IPath.forPosix("c:/a/b").segment(0));
+		assertEquals("2.8.posix", "c:", IPath.forPosix("c:/a\\b").segment(0));
+		assertEquals("2.9.posix", "a", IPath.forPosix("a/c:/b").segment(0));
+		assertEquals("2.10.posix", "a\\b", IPath.forPosix("a\\b/b").segment(0));
 
 	}
 
-	public void testFromPortableString() {
-		assertEquals("1.0", "", Path.fromPortableString("").toString());
-		assertEquals("1.1", "/", Path.fromPortableString("/").toString());
-		assertEquals("1.2", "a", Path.fromPortableString("a").toString());
-		assertEquals("1.3", "/a", Path.fromPortableString("/a").toString());
-		assertEquals("1.4", "//", Path.fromPortableString("//").toString());
-		assertEquals("1.5", "/a/", Path.fromPortableString("/a/").toString());
+	public void testFromOSString() {
+		List<String> segments = List.of("first", "first/second/third");
+		for (String segment : segments) {
+			assertEquals(IPath.fromPortableString(segment), IPath.fromOSString(osString(segment)));
+			assertEquals(IPath.fromPortableString(segment + "/"), IPath.fromOSString(osString(segment + "/")));
+			assertEquals(IPath.fromPortableString("/" + segment), IPath.fromOSString(osString("/" + segment)));
+			assertEquals(IPath.fromPortableString("/" + segment + "/"),
+					IPath.fromOSString(osString("/" + segment + "/")));
+		}
+	}
 
-		assertEquals("2.1", "a:", Path.fromPortableString("a:").toString());
-		assertEquals("2.2", "a:", Path.fromPortableString("a::").toString());
-		assertEquals("2.3", "a:b:", Path.fromPortableString("a:b::").toString());
-		assertEquals("2.4", "a/b:c", Path.fromPortableString("a/b::c").toString());
-		assertEquals("2.5", "a/b:c", Path.fromPortableString("a/b:c").toString());
-		assertEquals("2.6", "a:b", Path.fromPortableString("a::b").toString());
+	private static String osString(String pathname) {
+		return new java.io.File(pathname).toString();
+	}
+
+	public void testFromPortableString() {
+		assertEquals("1.0", "", IPath.fromPortableString("").toString());
+		assertEquals("1.1", "/", IPath.fromPortableString("/").toString());
+		assertEquals("1.2", "a", IPath.fromPortableString("a").toString());
+		assertEquals("1.3", "/a", IPath.fromPortableString("/a").toString());
+		assertEquals("1.4", "//", IPath.fromPortableString("//").toString());
+		assertEquals("1.5", "/a/", IPath.fromPortableString("/a/").toString());
+
+		assertEquals("2.1", "a:", IPath.fromPortableString("a:").toString());
+		assertEquals("2.2", "a:", IPath.fromPortableString("a::").toString());
+		assertEquals("2.3", "a:b:", IPath.fromPortableString("a:b::").toString());
+		assertEquals("2.4", "a/b:c", IPath.fromPortableString("a/b::c").toString());
+		assertEquals("2.5", "a/b:c", IPath.fromPortableString("a/b:c").toString());
+		assertEquals("2.6", "a:b", IPath.fromPortableString("a::b").toString());
 
 		boolean isLocalPosix = java.io.File.separatorChar == '/';
-		IPath win1 = Path.forWindows("a:b\\c/d");
-		IPath win2 = Path.fromPortableString(win1.toPortableString());
+		IPath win1 = IPath.forWindows("a:b\\c/d");
+		IPath win2 = IPath.fromPortableString(win1.toPortableString());
 		assertEquals("3.1.win", "a:b/c/d", win2.toString());
 		assertEquals("3.2.win", "a:", win2.getDevice());
 		assertEquals("3.3.win", 3, win2.segmentCount());
 		assertEquals("3.4.win", "b", win2.segment(0));
-		assertTrue("3.5.win", win1.equals(win2));
+		assertEquals("3.5.win", win1, win2);
 		assertEquals("3.6.win", isLocalPosix, win2.isValidSegment(":"));
-		IPath posix1 = Path.forPosix("a:b\\c/d");
-		IPath posix2 = Path.fromPortableString(posix1.toPortableString());
+		IPath posix1 = IPath.forPosix("a:b\\c/d");
+		IPath posix2 = IPath.fromPortableString(posix1.toPortableString());
 		assertEquals("3.7.posix", "a:b\\c/d", posix2.toString());
 		assertEquals("3.8.posix", null, posix2.getDevice());
 		assertEquals("3.9.posix", 2, posix2.segmentCount());
 		assertEquals("3.10.posix", "a:b\\c", posix2.segment(0));
-		assertTrue("3.11.posix", posix1.equals(posix2));
+		assertEquals("3.11.posix", posix1, posix2);
 		assertEquals("3.12.posix", isLocalPosix, posix2.isValidSegment(":"));
 	}
 
@@ -439,8 +455,8 @@ public class PathTest extends CoreTest {
 		assertTrue("1.0", new Path("/first/second/third").isAbsolute());
 		assertTrue("1.1", Path.ROOT.isAbsolute());
 		assertTrue("1.2", new Path("//first/second/third").isAbsolute());
-		assertTrue("1.3.win", Path.forWindows("c:/first/second/third").isAbsolute());
-		assertTrue("1.4.posix", Path.forPosix("/c:first/second/third").isAbsolute());
+		assertTrue("1.3.win", IPath.forWindows("c:/first/second/third").isAbsolute());
+		assertTrue("1.4.posix", IPath.forPosix("/c:first/second/third").isAbsolute());
 
 		// negative
 		assertTrue("2.0", !new Path("first/second/third").isAbsolute());
@@ -448,8 +464,8 @@ public class PathTest extends CoreTest {
 		assertTrue("2.2", !new Path("c:first/second/third").isAbsolute());
 
 		// unc
-		assertTrue("3.0.win", Path.forWindows("c://").isAbsolute());
-		assertTrue("3.1.posix", Path.forPosix("//c:/").isAbsolute());
+		assertTrue("3.0.win", IPath.forWindows("c://").isAbsolute());
+		assertTrue("3.1.posix", IPath.forPosix("//c:/").isAbsolute());
 		assertTrue("3.2", new Path("//").isAbsolute());
 		assertTrue("3.3", new Path("//a").isAbsolute());
 		assertTrue("3.4", new Path("//a/b/").isAbsolute());
@@ -462,8 +478,8 @@ public class PathTest extends CoreTest {
 		assertTrue("1.0", Path.EMPTY.isEmpty());
 		assertTrue("1.1", new Path("//").isEmpty());
 		assertTrue("1.2", new Path("").isEmpty());
-		assertTrue("1.3.win", Path.forWindows("c:").isEmpty());
-		assertFalse("1.4.posix", Path.forPosix("c:").isEmpty());
+		assertTrue("1.3.win", IPath.forWindows("c:").isEmpty());
+		assertFalse("1.4.posix", IPath.forPosix("c:").isEmpty());
 		assertTrue("1.5", new Path("///").isEmpty());
 
 		// negative
@@ -502,8 +518,8 @@ public class PathTest extends CoreTest {
 		// positive
 		assertTrue("2.0", Path.ROOT.isRoot());
 		assertTrue("2.1", new Path("/").isRoot());
-		assertTrue("2.2.win", Path.forWindows("/").isRoot());
-		assertTrue("2.3.posix", Path.forPosix("/").isRoot());
+		assertTrue("2.2.win", IPath.forWindows("/").isRoot());
+		assertTrue("2.3.posix", IPath.forPosix("/").isRoot());
 	}
 
 	public void testIsUNC() {
@@ -529,11 +545,11 @@ public class PathTest extends CoreTest {
 		assertTrue("5.0", new Path("//").isUNC());
 		assertTrue("5.1", new Path("//a").isUNC());
 		assertTrue("5.2", new Path("//a/b").isUNC());
-		assertTrue("5.3.win", Path.forWindows("\\\\ThisMachine\\HOME\\foo.jar").isUNC());
+		assertTrue("5.3.win", IPath.forWindows("\\\\ThisMachine\\HOME\\foo.jar").isUNC());
 
-		assertTrue("6.0.win", Path.forWindows("c://a/").setDevice(null).isUNC());
-		assertTrue("6.1.win", Path.forWindows("c:\\/a/b").setDevice(null).isUNC());
-		assertTrue("6.2.win", Path.forWindows("c:\\\\").setDevice(null).isUNC());
+		assertTrue("6.0.win", IPath.forWindows("c://a/").setDevice(null).isUNC());
+		assertTrue("6.1.win", IPath.forWindows("c:\\/a/b").setDevice(null).isUNC());
+		assertTrue("6.2.win", IPath.forWindows("c:\\\\").setDevice(null).isUNC());
 	}
 
 	public void testIsValidPath() {
@@ -550,10 +566,10 @@ public class PathTest extends CoreTest {
 		assertTrue("1.8", test.isValidPath("//a//b//c//d//e//f"));
 
 		// platform-dependent
-		assertFalse("2.1.win", Path.forWindows("").isValidPath("c:b:"));
-		assertFalse("2.2.win", Path.forWindows("").isValidPath("c:a/b:"));
-		assertTrue("2.3.posix", Path.forPosix("").isValidPath("c:b:"));
-		assertTrue("2.4.posix", Path.forPosix("").isValidPath("c:a/b:"));
+		assertFalse("2.1.win", IPath.forWindows("").isValidPath("c:b:"));
+		assertFalse("2.2.win", IPath.forWindows("").isValidPath("c:a/b:"));
+		assertTrue("2.3.posix", IPath.forPosix("").isValidPath("c:b:"));
+		assertTrue("2.4.posix", IPath.forPosix("").isValidPath("c:a/b:"));
 
 		// static methods
 		assertFalse("3.1.win", Path.isValidWindowsPath("c:b:"));
@@ -572,10 +588,10 @@ public class PathTest extends CoreTest {
 		assertFalse("2.2", test.isValidSegment("/"));
 
 		// platform-dependent
-		assertFalse("3.1.win", Path.forWindows("").isValidSegment("\\"));
-		assertFalse("3.2.win", Path.forWindows("").isValidSegment(":"));
-		assertTrue("3.3.posix", Path.forPosix("").isValidSegment("\\"));
-		assertTrue("3.4.posix", Path.forPosix("").isValidSegment(":"));
+		assertFalse("3.1.win", IPath.forWindows("").isValidSegment("\\"));
+		assertFalse("3.2.win", IPath.forWindows("").isValidSegment(":"));
+		assertTrue("3.3.posix", IPath.forPosix("").isValidSegment("\\"));
+		assertTrue("3.4.posix", IPath.forPosix("").isValidSegment(":"));
 
 		// static methods
 		assertFalse("4.1.win", Path.isValidWindowsSegment("\\"));
@@ -673,9 +689,9 @@ public class PathTest extends CoreTest {
 	 * Tests for {@link Path#makeRelativeTo(IPath)}.
 	 */
 	public void testMakeRelativeToWindows() {
-		IPath[] bases = new IPath[] { Path.forWindows("c:/a/"), Path.forWindows("c:/a/b") };
-		IPath[] children = new IPath[] { Path.forWindows("d:/a/"), Path.forWindows("d:/a/b"),
-				Path.forWindows("d:/a/b/c") };
+		IPath[] bases = new IPath[] { IPath.forWindows("c:/a/"), IPath.forWindows("c:/a/b") };
+		IPath[] children = new IPath[] { IPath.forWindows("d:/a/"), IPath.forWindows("d:/a/b"),
+				IPath.forWindows("d:/a/b/c") };
 		for (int i = 0; i < bases.length; i++) {
 			for (int j = 0; j < children.length; j++) {
 				final IPath base = bases[i];
@@ -771,20 +787,12 @@ public class PathTest extends CoreTest {
 	 * This test is for bizarre cases that previously caused errors.
 	 */
 	public void testRegression() {
-		try {
-			new Path("C:\\/eclipse");
-		} catch (Exception e) {
-			fail("1.0", e);
-		}
-		try {
-			IPath path = Path.forWindows("d:\\\\ive");
-			assertTrue("2.0.win", !path.isUNC());
-			assertEquals("2.1.win", 1, path.segmentCount());
-			assertEquals("2.2.win", "ive", path.segment(0));
-		} catch (Exception e) {
-			fail("2.99", e);
-		}
+		new Path("C:\\/eclipse");
 
+		IPath path = IPath.forWindows("d:\\\\ive");
+		assertTrue("2.0.win", !path.isUNC());
+		assertEquals("2.1.win", 1, path.segmentCount());
+		assertEquals("2.2.win", "ive", path.segment(0));
 	}
 
 	public void testRemoveFirstSegments() {
@@ -799,17 +807,17 @@ public class PathTest extends CoreTest {
 		assertEquals("1.8", Path.EMPTY, new Path("/first/second/").removeFirstSegments(3));
 		assertEquals("1.9", new Path("third/fourth"), new Path("/first/second/third/fourth").removeFirstSegments(2));
 
-		assertEquals("2.0.win", Path.forWindows("c:second"), Path.forWindows("c:/first/second").removeFirstSegments(1));
-		assertEquals("2.1.win", Path.forWindows("c:second/third/"), Path.forWindows("c:/first/second/third/")
+		assertEquals("2.0.win", IPath.forWindows("c:second"), IPath.forWindows("c:/first/second").removeFirstSegments(1));
+		assertEquals("2.1.win", IPath.forWindows("c:second/third/"), IPath.forWindows("c:/first/second/third/")
 				.removeFirstSegments(1));
-		assertEquals("2.2.win", Path.forWindows("c:"), Path.forWindows("c:first").removeFirstSegments(1));
-		assertEquals("2.3.win", Path.forWindows("c:"), Path.forWindows("c:/first/").removeFirstSegments(1));
-		assertEquals("2.4.win", Path.forWindows("c:second"), Path.forWindows("c:first/second").removeFirstSegments(1));
-		assertEquals("2.5.win", Path.forWindows("c:"), Path.forWindows("c:").removeFirstSegments(1));
-		assertEquals("2.6.win", Path.forWindows("c:"), Path.forWindows("c:/").removeFirstSegments(1));
-		assertEquals("2.7.win", Path.forWindows("c:"), Path.forWindows("c:/first/second/").removeFirstSegments(2));
-		assertEquals("2.8.win", Path.forWindows("c:"), Path.forWindows("c:/first/second/").removeFirstSegments(3));
-		assertEquals("2.9.win", Path.forWindows("c:third/fourth"), Path.forWindows("c:/first/second/third/fourth")
+		assertEquals("2.2.win", IPath.forWindows("c:"), IPath.forWindows("c:first").removeFirstSegments(1));
+		assertEquals("2.3.win", IPath.forWindows("c:"), IPath.forWindows("c:/first/").removeFirstSegments(1));
+		assertEquals("2.4.win", IPath.forWindows("c:second"), IPath.forWindows("c:first/second").removeFirstSegments(1));
+		assertEquals("2.5.win", IPath.forWindows("c:"), IPath.forWindows("c:").removeFirstSegments(1));
+		assertEquals("2.6.win", IPath.forWindows("c:"), IPath.forWindows("c:/").removeFirstSegments(1));
+		assertEquals("2.7.win", IPath.forWindows("c:"), IPath.forWindows("c:/first/second/").removeFirstSegments(2));
+		assertEquals("2.8.win", IPath.forWindows("c:"), IPath.forWindows("c:/first/second/").removeFirstSegments(3));
+		assertEquals("2.9.win", IPath.forWindows("c:third/fourth"), IPath.forWindows("c:/first/second/third/fourth")
 				.removeFirstSegments(2));
 
 		assertEquals("3.0", new Path("second"), new Path("//first/second").removeFirstSegments(1));
@@ -960,11 +968,11 @@ public class PathTest extends CoreTest {
 		assertEquals("b", new Path("b").hashCode(), new Path("b").hashCode());
 		assertEquals("c", new Path("c:\\d").hashCode(), new Path("c:\\d").hashCode());
 		assertEquals("cd", new Path("c:\\").append("d").hashCode(), new Path("c:\\").append("d").hashCode());
-		assertEquals("cd", Path.forWindows("c:\\d").hashCode(), Path.forWindows("c:\\").append("d").hashCode());
-		assertEquals("OS independent", Path.forWindows("p").append("d").hashCode(),
-				Path.forPosix("p").append("d").hashCode());
-		assertEquals("OS independent", Path.forWindows("p").append("d").hashCode(),
-				Path.forPosix("p").append("d").hashCode());
+		assertEquals("cd", IPath.forWindows("c:\\d").hashCode(), IPath.forWindows("c:\\").append("d").hashCode());
+		assertEquals("OS independent", IPath.forWindows("p").append("d").hashCode(),
+				IPath.forPosix("p").append("d").hashCode());
+		assertEquals("OS independent", IPath.forWindows("p").append("d").hashCode(),
+				IPath.forPosix("p").append("d").hashCode());
 		assertEquals("trailing independent", new Path("p").removeTrailingSeparator().hashCode(),
 				new Path("p").addTrailingSeparator().hashCode());
 	}
@@ -974,22 +982,22 @@ public class PathTest extends CoreTest {
 		assertEquals("b", new Path("a"), new Path("a"));
 		assertEquals("c", new Path("c").append("d"), new Path("c").append("d"));
 		assertEquals("c", new Path("c:\\d"), new Path("c:\\d"));
-		assertEquals("c", Path.forWindows("c:\\d"), Path.forWindows("c:\\d"));
-		assertEquals("c", Path.forPosix("c:\\d"), Path.forPosix("c:\\d"));
-		assertEquals("c", Path.forWindows("c:/d"), Path.forWindows("c:/d"));
-		assertEquals("c", Path.forPosix("c:/d"), Path.forPosix("c:/d"));
-		assertEquals("cd", Path.forWindows("c:\\d"), Path.forWindows("c:\\").append("d"));
+		assertEquals("c", IPath.forWindows("c:\\d"), IPath.forWindows("c:\\d"));
+		assertEquals("c", IPath.forPosix("c:\\d"), IPath.forPosix("c:\\d"));
+		assertEquals("c", IPath.forWindows("c:/d"), IPath.forWindows("c:/d"));
+		assertEquals("c", IPath.forPosix("c:/d"), IPath.forPosix("c:/d"));
+		assertEquals("cd", IPath.forWindows("c:\\d"), IPath.forWindows("c:\\").append("d"));
 		assertEquals("trailing independent", new Path("p").removeTrailingSeparator(),
 				new Path("p").addTrailingSeparator());
-		assertEquals("OS independent", Path.forWindows("p"), Path.forPosix("p"));
+		assertEquals("OS independent", IPath.forWindows("p"), IPath.forPosix("p"));
 		Path hashed = new Path("a");
 		hashed.hashCode();
 		assertEquals("hash independent", new Path("a"), hashed);
 
-		assertFalse("unc dependent", new Path("p").makeUNC(true).equals(new Path("p").makeUNC(false)));
-		assertFalse("absolute dependent", new Path("p").equals(new Path("p").makeAbsolute()));
-		assertFalse("leading/ dependent", new Path("/p").equals(new Path("p")));
-		assertFalse("leading\\ dependent", new Path("\\p").equals(new Path("p")));
+		assertNotEquals("unc dependent", new Path("p").makeUNC(true), new Path("p").makeUNC(false));
+		assertNotEquals("absolute dependent", new Path("p"), new Path("p").makeAbsolute());
+		assertNotEquals("leading/ dependent", new Path("/p"), new Path("p"));
+		assertNotEquals("leading\\ dependent", new Path("\\p"), new Path("p"));
 	}
 
 	public void testUptoSegment() {
@@ -1031,12 +1039,12 @@ public class PathTest extends CoreTest {
 		assertEquals("4.4", new Path("first/second/third/"), anyPath.uptoSegment(4));
 
 		// bug 58835 - upToSegment(0) needs to preserve device
-		anyPath = Path.forWindows("c:/first/second/third");
-		assertEquals("5.0.win", Path.forWindows("c:/"), anyPath.uptoSegment(0));
-		anyPath = Path.forWindows("c:/first/second/third/");
-		assertEquals("5.1.win", Path.forWindows("c:/"), anyPath.uptoSegment(0));
-		anyPath = Path.forWindows("c:first/second/third/");
-		assertEquals("5.2.win", Path.forWindows("c:"), anyPath.uptoSegment(0));
+		anyPath = IPath.forWindows("c:/first/second/third");
+		assertEquals("5.0.win", IPath.forWindows("c:/"), anyPath.uptoSegment(0));
+		anyPath = IPath.forWindows("c:/first/second/third/");
+		assertEquals("5.1.win", IPath.forWindows("c:/"), anyPath.uptoSegment(0));
+		anyPath = IPath.forWindows("c:first/second/third/");
+		assertEquals("5.2.win", IPath.forWindows("c:"), anyPath.uptoSegment(0));
 		anyPath = new Path("//one/two/three");
 		assertEquals("5.3", new Path("//"), anyPath.uptoSegment(0));
 		anyPath = new Path("//one/two/three/");

--- a/bundles/org.eclipse.equinox.common.tests/src/org/eclipse/equinox/common/tests/PathTest.java
+++ b/bundles/org.eclipse.equinox.common.tests/src/org/eclipse/equinox/common/tests/PathTest.java
@@ -16,6 +16,7 @@ package org.eclipse.equinox.common.tests;
 
 import static org.junit.Assert.assertNotEquals;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -401,6 +402,34 @@ public class PathTest extends CoreTest {
 		assertEquals("3.10.posix", "a:b\\c", posix2.segment(0));
 		assertEquals("3.11.posix", posix1, posix2);
 		assertEquals("3.12.posix", isLocalPosix, posix2.isValidSegment(":"));
+	}
+
+	public void testFromFile() {
+		List<String> segments = List.of("first", "first/second/third");
+		for (String segment : segments) {
+			File file0 = new File(segment);
+			assertEquals(file0, IPath.fromFile(file0).toFile());
+			File file1 = new File(segment + "/");
+			assertEquals(file1, IPath.fromFile(file1).toFile());
+			File file2 = new File("/" + segment);
+			assertEquals(file2, IPath.fromFile(file2).toFile());
+			File file3 = new File("/" + segment + "/");
+			assertEquals(file3, IPath.fromFile(file3).toFile());
+		}
+	}
+
+	public void testFromPath() {
+		List<String> segments = List.of("first", "first/second/third");
+		for (String segment : segments) {
+			java.nio.file.Path path0 = java.nio.file.Path.of(segment);
+			assertEquals(path0, IPath.fromPath(path0).toPath());
+			java.nio.file.Path path1 = java.nio.file.Path.of(segment + "/");
+			assertEquals(path1, IPath.fromPath(path1).toPath());
+			java.nio.file.Path path2 = java.nio.file.Path.of("/" + segment);
+			assertEquals(path2, IPath.fromPath(path2).toPath());
+			java.nio.file.Path path3 = java.nio.file.Path.of("/" + segment + "/");
+			assertEquals(path3, IPath.fromPath(path3).toPath());
+		}
 	}
 
 	public void testGetFileExtension() {

--- a/bundles/org.eclipse.equinox.common.tests/src/org/eclipse/equinox/common/tests/PathTest.java
+++ b/bundles/org.eclipse.equinox.common.tests/src/org/eclipse/equinox/common/tests/PathTest.java
@@ -1042,4 +1042,32 @@ public class PathTest extends CoreTest {
 		anyPath = new Path("//one/two/three/");
 		assertEquals("5.4", new Path("//"), anyPath.uptoSegment(0));
 	}
+
+	public void testToPath() {
+
+		//Case 1, absolute path with no trailing separator
+		IPath anyPath = new Path("/first/second/third");
+
+		assertNotNull(anyPath.toPath());
+		assertEquals(java.nio.file.Path.of("/first/second/third"), anyPath.toPath());
+
+		// Case 2, absolute path with trailing separator
+		anyPath = new Path("/first/second/third/");
+
+		assertNotNull(anyPath.toPath());
+		assertEquals(java.nio.file.Path.of("/first/second/third/"), anyPath.toPath());
+
+		// Case 3, relative path with no trailing separator
+		anyPath = new Path("first/second/third");
+
+		assertNotNull(anyPath.toPath());
+		assertEquals(java.nio.file.Path.of("first/second/third"), anyPath.toPath());
+
+		// Case 4, relative path with trailing separator
+		anyPath = new Path("first/second/third/");
+
+		assertNotNull(anyPath.toPath());
+		assertEquals(java.nio.file.Path.of("first/second/third/"), anyPath.toPath());
+
+	}
 }

--- a/bundles/org.eclipse.equinox.common/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.common/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.common; singleton:=true
-Bundle-Version: 3.17.100.qualifier
+Bundle-Version: 3.18.0.qualifier
 Bundle-Localization: plugin
 Export-Package: org.eclipse.core.internal.boot;x-friends:="org.eclipse.core.resources,org.eclipse.pde.build",
  org.eclipse.core.internal.runtime;common=split;mandatory:=common;

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/IPath.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/IPath.java
@@ -461,6 +461,16 @@ public interface IPath extends Cloneable {
 	public java.io.File toFile();
 
 	/**
+	 * Returns a <code>java.nio.file.Path</code> corresponding to this path.
+	 *
+	 * @return the path corresponding to this path
+	 * @since 3.18
+	 */
+	default java.nio.file.Path toPath() {
+		return java.nio.file.Path.of(toOSString());
+	}
+
+	/**
 	 * Returns a string representation of this path which uses the
 	 * platform-dependent path separator defined by <code>java.io.File</code>.
 	 * This method is like <code>toString()</code> except that the

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/IPath.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/IPath.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2015 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -11,6 +11,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     Patrick Tasse - Add extra constructor to Path class (bug 454959)
+ *     Hannes Wellmann - Add static IPath factory methods
  *******************************************************************************/
 package org.eclipse.core.runtime;
 
@@ -53,6 +54,68 @@ public interface IPath extends Cloneable {
 	 * Device separator character constant ":" used in paths.
 	 */
 	public static final char DEVICE_SEPARATOR = ':';
+
+	/**
+	 * Constructs a new path from the given string path. The string path must
+	 * represent a valid file system path on the local file system. The path is
+	 * canonicalized and double slashes are removed except at the beginning. (to
+	 * handle UNC paths). All forward slashes ('/') are treated as segment
+	 * delimiters, and any segment and device delimiters for the local file system
+	 * are also respected.
+	 *
+	 * @param osPath the operating-system specific string path
+	 * @return the IPath representing the given OS specific string path
+	 * @since 3.18
+	 */
+	public static IPath fromOSString(String osPath) {
+		return new Path(osPath);
+	}
+
+	/**
+	 * Constructs a new path from the given path string. The path string must have
+	 * been produced by a previous call to <code>IPath.toPortableString</code>.
+	 *
+	 * @param portablePath the portable path string
+	 * @return the IPath representing the given portable string path
+	 * @see IPath#toPortableString()
+	 * @since 3.18
+	 */
+	public static IPath fromPortableString(String portablePath) {
+		return Path.parsePortableString(portablePath);
+	}
+
+	/**
+	 * Constructs a new POSIX path from the given string path. The string path must
+	 * represent a valid file system path on a POSIX file system. The path is
+	 * canonicalized and double slashes are removed except at the beginning (to
+	 * handle UNC paths). All forward slashes ('/') are treated as segment
+	 * delimiters. This factory method should be used if the string path is for a
+	 * POSIX file system.
+	 *
+	 * @param posixPath the string path
+	 * @return the IPath representing the given POSIX string path
+	 * @since 3.18
+	 */
+	public static IPath forPosix(String posixPath) {
+		return new Path(posixPath, false);
+	}
+
+	/**
+	 * Constructs a new Windows path from the given string path. The string path
+	 * must represent a valid file system path on the Windows file system. The path
+	 * is canonicalized and double slashes are removed except at the beginning (to
+	 * handle UNC paths). All forward slashes ('/') are treated as segment
+	 * delimiters, and any segment ('\') and device (':') delimiters for the Windows
+	 * file system are also respected. This factory method should be used if the
+	 * string path is for the Windows file system.
+	 *
+	 * @param windowsPath the string path
+	 * @return the IPath representing the given Windows string path
+	 * @since 3.18
+	 */
+	public static IPath forWindows(String windowsPath) {
+		return new Path(windowsPath, true);
+	}
 
 	/**
 	 * Returns a new path which is the same as this path but with

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/IPath.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/IPath.java
@@ -11,7 +11,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     Patrick Tasse - Add extra constructor to Path class (bug 454959)
- *     Hannes Wellmann - Add static IPath factory methods
+ *     Hannes Wellmann - Add static IPath factory methods and add methods to create an IPath from a io.File/nio.Path
  *******************************************************************************/
 package org.eclipse.core.runtime;
 
@@ -115,6 +115,28 @@ public interface IPath extends Cloneable {
 	 */
 	public static IPath forWindows(String windowsPath) {
 		return new Path(windowsPath, true);
+	}
+
+	/**
+	 * Constructs a new {@code IPath} from the given {@code File}.
+	 *
+	 * @param file the java.io.File object
+	 * @return the IPath representing the given File object
+	 * @since 3.18
+	 */
+	public static IPath fromFile(java.io.File file) {
+		return fromOSString(file.toString());
+	}
+
+	/**
+	 * Constructs a new {@code IPath} from the given {@code java.nio.file.Path}.
+	 *
+	 * @param path the java.nio.file.Path object
+	 * @return the IPath representing the given Path object
+	 * @since 3.18
+	 */
+	public static IPath fromPath(java.nio.file.Path path) {
+		return fromOSString(path.toString());
 	}
 
 	/**

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/Path.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/Path.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -80,34 +80,47 @@ public final class Path implements IPath, Cloneable {
 	/** flags indicating separators (has leading, is UNC, has trailing, is for Windows) */
 	private final byte flags;
 
-	/** 
-	 * Constructs a new path from the given string path.
-	 * The string path must represent a valid file system path
-	 * on the local file system. 
-	 * The path is canonicalized and double slashes are removed
-	 * except at the beginning. (to handle UNC paths). All forward
-	 * slashes ('/') are treated as segment delimiters, and any
-	 * segment and device delimiters for the local file system are
-	 * also respected.
+	/**
+	 * Constructs a new path from the given string path. The string path must
+	 * represent a valid file system path on the local file system. The path is
+	 * canonicalized and double slashes are removed except at the beginning. (to
+	 * handle UNC paths). All forward slashes ('/') are treated as segment
+	 * delimiters, and any segment and device delimiters for the local file system
+	 * are also respected.
+	 * <p>
+	 * Instead of calling this method it is recommended to call
+	 * {@link IPath#fromOSString(String)} instead.
+	 * </p>
 	 *
-	 * @param pathString the portable string path
+	 * @param pathString the operating-system specific string path
+	 * @return the IPath representing the given OS specific string path
 	 * @see IPath#toPortableString()
+	 * @see IPath#fromOSString(String)
 	 * @since 3.1
 	 */
 	public static IPath fromOSString(String pathString) {
-		return new Path(pathString);
+		return IPath.fromOSString(pathString);
 	}
 
-	/** 
-	 * Constructs a new path from the given path string.
-	 * The path string must have been produced by a previous
-	 * call to <code>IPath.toPortableString</code>.
+	/**
+	 * Constructs a new path from the given path string. The path string must have
+	 * been produced by a previous call to <code>IPath.toPortableString</code>.
+	 * <p>
+	 * Instead of calling this method it is recommended to call
+	 * {@link IPath#fromPortableString(String)} instead.
+	 * </p>
 	 *
 	 * @param pathString the portable path string
+	 * @return the IPath representing the given portable string path
 	 * @see IPath#toPortableString()
+	 * @see IPath#fromPortableString(String)
 	 * @since 3.1
 	 */
 	public static IPath fromPortableString(String pathString) {
+		return IPath.fromPortableString(pathString);
+	}
+
+	static IPath parsePortableString(String pathString) {
 		int firstMatch = pathString.indexOf(DEVICE_SEPARATOR) + 1;
 		//no extra work required if no device characters
 		if (firstMatch <= 0)
@@ -126,45 +139,57 @@ public final class Path implements IPath, Cloneable {
 		char[] chars = pathString.toCharArray();
 		int readOffset = 0, writeOffset = 0, length = chars.length;
 		while (readOffset < length) {
-			if (chars[readOffset] == DEVICE_SEPARATOR)
-				if (++readOffset >= length)
-					break;
+			if (chars[readOffset] == DEVICE_SEPARATOR && ++readOffset >= length) {
+				break;
+			}
 			chars[writeOffset++] = chars[readOffset++];
 		}
 		return new Path(devicePart, new String(chars, 0, writeOffset), RUNNING_ON_WINDOWS);
 	}
 
 	/**
-	 * Constructs a new POSIX path from the given string path. The string path
-	 * must represent a valid file system path on a POSIX file system. The path
-	 * is canonicalized and double slashes are removed except at the beginning
-	 * (to handle UNC paths). All forward slashes ('/') are treated as segment
-	 * delimiters. This factory method should be used if the string path is for
-	 * a POSIX file system.
-	 *
+	 * Constructs a new POSIX path from the given string path. The string path must
+	 * represent a valid file system path on a POSIX file system. The path is
+	 * canonicalized and double slashes are removed except at the beginning (to
+	 * handle UNC paths). All forward slashes ('/') are treated as segment
+	 * delimiters. This factory method should be used if the string path is for a
+	 * POSIX file system.
+	 * <p>
+	 * Instead of calling this method it is recommended to call
+	 * {@link IPath#forPosix(String)} instead.
+	 * </p>
+	 * 
 	 * @param fullPath the string path
+	 * @return the IPath representing the given POSIX string path
 	 * @see #isValidPosixPath(String)
+	 * @see IPath#forPosix(String)
 	 * @since 3.7
 	 */
 	public static Path forPosix(String fullPath) {
-		return new Path(fullPath, false);
+		return (Path) IPath.forPosix(fullPath);
 	}
 
 	/**
 	 * Constructs a new Windows path from the given string path. The string path
-	 * must represent a valid file system path on the Windows file system. The
-	 * path is canonicalized and double slashes are removed except at the
-	 * beginning (to handle UNC paths). All forward slashes ('/') are treated as
-	 * segment delimiters, and any segment ('\') and device (':') delimiters for
-	 * the Windows file system are also respected. This factory method should be
-	 * used if the string path is for the Windows file system.
-	 *
+	 * must represent a valid file system path on the Windows file system. The path
+	 * is canonicalized and double slashes are removed except at the beginning (to
+	 * handle UNC paths). All forward slashes ('/') are treated as segment
+	 * delimiters, and any segment ('\') and device (':') delimiters for the Windows
+	 * file system are also respected. This factory method should be used if the
+	 * string path is for the Windows file system.
+	 * <p>
+	 * Instead of calling this method it is recommended to call
+	 * {@link IPath#forWindows(String)} instead.
+	 * </p>
+	 * 
 	 * @param fullPath the string path
+	 * @return the IPath representing the given Windows string path
 	 * @see #isValidWindowsPath(String)
+	 * @see IPath#forWindows(String)
 	 * @since 3.7
 	 */
 	public static Path forWindows(String fullPath) {
-		return new Path(fullPath, true);
+		return (Path) IPath.forWindows(fullPath);
 	}
 
 	/** 
@@ -224,7 +249,7 @@ public final class Path implements IPath, Cloneable {
 	 * @param forWindows true if the string path is for the Windows file system
 	 * @since 3.7
 	 */
-	private Path(String fullPath, boolean forWindows) {
+	Path(String fullPath, boolean forWindows) {
 		String devicePart = null;
 		if (forWindows) {
 			//convert backslash to forward slash

--- a/features/org.eclipse.equinox.core.feature/feature.xml
+++ b/features/org.eclipse.equinox.core.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.equinox.core.feature"
       label="%featureName"
-      version="1.13.1100.qualifier"
+      version="1.14.0.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/features/org.eclipse.equinox.core.sdk/feature.xml
+++ b/features/org.eclipse.equinox.core.sdk/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.equinox.core.sdk"
       label="%featureName"
-      version="3.23.800.qualifier"
+      version="3.24.0.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/features/org.eclipse.equinox.server.core/feature.xml
+++ b/features/org.eclipse.equinox.server.core/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.equinox.server.core"
       label="%featureName"
-      version="1.14.1000.qualifier"
+      version="1.15.0.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">


### PR DESCRIPTION
This PR adds a convenient factory method to obtain an IPath from a `java.io.File` or `java.nio.file.Path`.

It is already possible to convert an IPath to a io.File and with PR #223 another method to convert to nio.Path is about to be added, but the other way around is currently missing and I usually to something like the following:
```
Path.fromOSString(file/path.toString())
```
The current implementation mimics that, but if necessary or beneficial the segments and device could be queried from the nio.path directly to avoid parsing a string.

In general I wonder if it would be better to add those methods in the IPath interface? And maybe move the other factories as well, at least those that return an IPath.
