### PR TITLE
Fix concurrency issue in equinox caching

### DIFF
--- a/bundles/org.eclipse.equinox.weaving.caching/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.weaving.caching/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.equinox.weaving.caching
-Bundle-Version: 1.2.200.qualifier
+Bundle-Version: 1.2.300.qualifier
 Bundle-Name: Standard Caching Service for Equinox Aspects
 Bundle-Vendor: Eclipse.org - Equinox
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/bundles/org.eclipse.equinox.weaving.caching/src/org/eclipse/equinox/weaving/internal/caching/Activator.java
+++ b/bundles/org.eclipse.equinox.weaving.caching/src/org/eclipse/equinox/weaving/internal/caching/Activator.java
@@ -1,13 +1,13 @@
 /*******************************************************************************
  * Copyright (c) 2008, 2013 Heiko Seeberger and others.
  *
- * This program and the accompanying materials 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0.
- * 
+ *
  * Contributors:
  *   Heiko Seeberger           initial implementation
  *   Martin Lippert            extracted caching service factory
@@ -28,98 +28,91 @@ import org.osgi.framework.ServiceRegistration;
 
 /**
  * {@link BundleActivator} for "org.aspectj.osgi.service.caching".
- * 
+ *
  * @author Heiko Seeberger
  */
 public class Activator implements BundleActivator {
 
-    private static boolean verbose = Boolean
-            .getBoolean("org.aspectj.osgi.verbose"); //$NON-NLS-1$
+	private static boolean verbose = Boolean.getBoolean("org.aspectj.osgi.verbose"); //$NON-NLS-1$
 
-    private CachingServiceFactory cachingServiceFactory;
+	private CachingServiceFactory cachingServiceFactory;
 
-    private ServiceRegistration<?> cachingServiceFactoryRegistration;
+	private ServiceRegistration<?> cachingServiceFactoryRegistration;
 
-    /**
-     * Registers a new {@link CachingServiceFactory} instance as OSGi service
-     * under the interface {@link ICachingService}.
-     * 
-     * @see org.osgi.framework.BundleActivator#start(org.osgi.framework.BundleContext)
-     */
-    public void start(final BundleContext bundleContext) {
-        setDebugEnabled(bundleContext);
+	private void registerCachingServiceFactory(final BundleContext bundleContext) {
+		cachingServiceFactory = new CachingServiceFactory(bundleContext);
+		cachingServiceFactoryRegistration = bundleContext.registerService(ICachingServiceFactory.class.getName(),
+				cachingServiceFactory, null);
+		if (Log.isDebugEnabled()) {
+			Log.debug("Created and registered SingletonCachingService."); //$NON-NLS-1$
+		}
+	}
 
-        if (shouldRegister()) {
-            if (verbose)
-                System.err
-                        .println("[org.eclipse.equinox.weaving.caching] info starting standard caching service ..."); //$NON-NLS-1$
-            registerCachingServiceFactory(bundleContext);
-        } else {
-            if (verbose)
-                System.err
-                        .println("[org.eclipse.equinox.weaving.caching] warning cannot start standard caching service on J9 VM"); //$NON-NLS-1$
-        }
-    }
+	private void setDebugEnabled(final BundleContext bundleContext) {
+		final ServiceReference<?> debugOptionsReference = bundleContext
+				.getServiceReference(DebugOptions.class.getName());
+		if (debugOptionsReference != null) {
+			final DebugOptions debugOptions = (DebugOptions) bundleContext.getService(debugOptionsReference);
+			if (debugOptions != null) {
+				Log.debugEnabled = debugOptions.getBooleanOption("org.eclipse.equinox.weaving.caching/debug", false); //$NON-NLS-1$
+			}
+		}
+		if (debugOptionsReference != null) {
+			bundleContext.ungetService(debugOptionsReference);
+		}
+	}
 
-    /**
-     * Shuts down the {@link CachingServiceFactory}.
-     * 
-     * @see org.osgi.framework.BundleActivator#stop(org.osgi.framework.BundleContext)
-     */
-    public void stop(final BundleContext context) {
-        if (cachingServiceFactoryRegistration != null) {
-            cachingServiceFactory.stop();
-            cachingServiceFactoryRegistration.unregister();
-        }
-        if (Log.isDebugEnabled()) {
-            Log.debug("Shut down and unregistered SingletonCachingService."); //$NON-NLS-1$
-        }
-    }
+	private boolean shouldRegister() {
+		boolean enabled = true;
+		try {
+			Class.forName("com.ibm.oti.vm.VM"); // if this fails we are not on J9 //$NON-NLS-1$
+			final Class<?> sharedClass = Class.forName("com.ibm.oti.shared.Shared"); //$NON-NLS-1$
+			final Method isSharingEnabledMethod = sharedClass.getMethod("isSharingEnabled", (Class[]) null); //$NON-NLS-1$
+			if (isSharingEnabledMethod != null) {
+				final Boolean sharing = (Boolean) isSharingEnabledMethod.invoke(null, (Object[]) null);
+				if (sharing != null && sharing.booleanValue()) {
+					enabled = false;
+				}
+			}
+		} catch (final ClassNotFoundException | SecurityException | NoSuchMethodException | IllegalArgumentException
+				| IllegalAccessException | InvocationTargetException ex) {
+		}
 
-    private void registerCachingServiceFactory(final BundleContext bundleContext) {
-        cachingServiceFactory = new CachingServiceFactory(bundleContext);
-        cachingServiceFactoryRegistration = bundleContext.registerService(
-                ICachingServiceFactory.class.getName(), cachingServiceFactory,
-                null);
-        if (Log.isDebugEnabled()) {
-            Log.debug("Created and registered SingletonCachingService."); //$NON-NLS-1$
-        }
-    }
+		return enabled;
+	}
 
-    private void setDebugEnabled(final BundleContext bundleContext) {
-        final ServiceReference<?> debugOptionsReference = bundleContext
-                .getServiceReference(DebugOptions.class.getName());
-        if (debugOptionsReference != null) {
-            final DebugOptions debugOptions = (DebugOptions) bundleContext
-                    .getService(debugOptionsReference);
-            if (debugOptions != null) {
-                Log.debugEnabled = debugOptions.getBooleanOption(
-                        "org.eclipse.equinox.weaving.caching/debug", false); //$NON-NLS-1$
-            }
-        }
-        if (debugOptionsReference != null) {
-            bundleContext.ungetService(debugOptionsReference);
-        }
-    }
+	/**
+	 * Registers a new {@link CachingServiceFactory} instance as OSGi service under
+	 * the interface {@link ICachingService}.
+	 * 
+	 * @see org.osgi.framework.BundleActivator#start(org.osgi.framework.BundleContext)
+	 */
+	public void start(final BundleContext bundleContext) {
+		setDebugEnabled(bundleContext);
 
-    private boolean shouldRegister() {
-        boolean enabled = true;
-        try {
-            Class.forName("com.ibm.oti.vm.VM"); // if this fails we are not on J9 //$NON-NLS-1$
-            final Class<?> sharedClass = Class
-                    .forName("com.ibm.oti.shared.Shared"); //$NON-NLS-1$
-            final Method isSharingEnabledMethod = sharedClass.getMethod(
-                    "isSharingEnabled", (Class[]) null); //$NON-NLS-1$
-            if (isSharingEnabledMethod != null) {
-                final Boolean sharing = (Boolean) isSharingEnabledMethod
-                        .invoke(null, (Object[]) null);
-                if (sharing != null && sharing.booleanValue()) {
-                    enabled = false;
-                }
-            }
-        } catch (final ClassNotFoundException | SecurityException | NoSuchMethodException | IllegalArgumentException | IllegalAccessException | InvocationTargetException ex) {
-        }
+		if (shouldRegister()) {
+			if (verbose)
+				System.err.println("[org.eclipse.equinox.weaving.caching] info starting standard caching service ..."); //$NON-NLS-1$
+			registerCachingServiceFactory(bundleContext);
+		} else {
+			if (verbose)
+				System.err.println(
+						"[org.eclipse.equinox.weaving.caching] warning cannot start standard caching service on J9 VM"); //$NON-NLS-1$
+		}
+	}
 
-        return enabled;
-    }
+	/**
+	 * Shuts down the {@link CachingServiceFactory}.
+	 * 
+	 * @see org.osgi.framework.BundleActivator#stop(org.osgi.framework.BundleContext)
+	 */
+	public void stop(final BundleContext context) {
+		if (cachingServiceFactoryRegistration != null) {
+			cachingServiceFactory.stop();
+			cachingServiceFactoryRegistration.unregister();
+		}
+		if (Log.isDebugEnabled()) {
+			Log.debug("Shut down and unregistered SingletonCachingService."); //$NON-NLS-1$
+		}
+	}
 }

--- a/bundles/org.eclipse.equinox.weaving.caching/src/org/eclipse/equinox/weaving/internal/caching/BundleCachingService.java
+++ b/bundles/org.eclipse.equinox.weaving.caching/src/org/eclipse/equinox/weaving/internal/caching/BundleCachingService.java
@@ -1,13 +1,13 @@
 /*******************************************************************************
  * Copyright (c) 2008, 2009 Heiko Seeberger and others.
  *
- * This program and the accompanying materials 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0.
- * 
+ *
  * Contributors:
  *     Heiko Seeberger - initial implementation
  *     Martin Lippert - asynchronous cache writing
@@ -38,230 +38,216 @@ import org.osgi.framework.BundleContext;
  * each bundle.
  * </p>
  * <p>
- * 
+ *
  * @author Heiko Seeberger
  * @author Martin Lippert
  */
 public class BundleCachingService implements ICachingService {
 
-    private static final int READ_BUFFER_SIZE = 8 * 1024;
+	private static final int READ_BUFFER_SIZE = 8 * 1024;
 
-    private final Bundle bundle;
+	private final Bundle bundle;
 
-    private File cacheDirectory;
+	private File cacheDirectory;
 
-    private final String cacheKey;
+	private final String cacheKey;
 
-    private final BlockingQueue<CacheItem> cacheWriterQueue;
+	private final BlockingQueue<CacheItem> cacheWriterQueue;
 
-    /**
-     * @param bundleContext Must not be null!
-     * @param bundle Must not be null!
-     * @param key Must not be null!
-     * @param cacheWriterQueue The queue for items to be written to the cache,
-     *            must not be null
-     * @throws IllegalArgumentException if given bundleContext or bundle is
-     *             null.
-     */
-    public BundleCachingService(final BundleContext bundleContext,
-            final Bundle bundle, final String key,
-            final BlockingQueue<CacheItem> cacheWriterQueue) {
+	/**
+	 * @param bundleContext    Must not be null!
+	 * @param bundle           Must not be null!
+	 * @param key              Must not be null!
+	 * @param cacheWriterQueue The queue for items to be written to the cache, must
+	 *                         not be null
+	 * @throws IllegalArgumentException if given bundleContext or bundle is null.
+	 */
+	public BundleCachingService(final BundleContext bundleContext, final Bundle bundle, final String key,
+			final BlockingQueue<CacheItem> cacheWriterQueue) {
 
-        if (bundleContext == null) {
-            throw new IllegalArgumentException(
-                    "Argument \"bundleContext\" must not be null!"); //$NON-NLS-1$
-        }
-        if (bundle == null) {
-            throw new IllegalArgumentException(
-                    "Argument \"bundle\" must not be null!"); //$NON-NLS-1$
-        }
-        if (key == null) {
-            throw new IllegalArgumentException(
-                    "Argument \"key\" must not be null!"); //$NON-NLS-1$
-        }
+		if (bundleContext == null) {
+			throw new IllegalArgumentException("Argument \"bundleContext\" must not be null!"); //$NON-NLS-1$
+		}
+		if (bundle == null) {
+			throw new IllegalArgumentException("Argument \"bundle\" must not be null!"); //$NON-NLS-1$
+		}
+		if (key == null) {
+			throw new IllegalArgumentException("Argument \"key\" must not be null!"); //$NON-NLS-1$
+		}
 
-        this.bundle = bundle;
-        this.cacheKey = hashNamespace(key);
-        this.cacheWriterQueue = cacheWriterQueue;
+		this.bundle = bundle;
+		this.cacheKey = hashNamespace(key);
+		this.cacheWriterQueue = cacheWriterQueue;
 
-        final File dataFile = bundleContext.getDataFile(cacheKey);
-        if (dataFile != null) {
-            final String bundleCacheDir = bundle.getBundleId()
-                    + "-" + bundle.getLastModified(); //$NON-NLS-1$
-            cacheDirectory = new File(dataFile, bundleCacheDir);
-        } else {
-            Log.error("Cannot initialize cache!", null); //$NON-NLS-1$
-        }
-    }
+		final File dataFile = bundleContext.getDataFile(cacheKey);
+		if (dataFile != null) {
+			final String bundleCacheDir = bundle.getBundleId() + "-" + bundle.getLastModified(); //$NON-NLS-1$
+			cacheDirectory = new File(dataFile, bundleCacheDir);
+		} else {
+			Log.error("Cannot initialize cache!", null); //$NON-NLS-1$
+		}
+	}
 
-    /**
-     * @see org.eclipse.equinox.service.weaving.ICachingService#canCacheGeneratedClasses()
-     */
-    public boolean canCacheGeneratedClasses() {
-        return true;
-    }
+	/**
+	 * @see org.eclipse.equinox.service.weaving.ICachingService#canCacheGeneratedClasses()
+	 */
+	public boolean canCacheGeneratedClasses() {
+		return true;
+	}
 
-    /**
-     * @see org.eclipse.equinox.service.weaving.ICachingService#findStoredClass(java.lang.String,
-     *      java.net.URL, java.lang.String)
-     */
-    public CacheEntry findStoredClass(final String namespace,
-            final URL sourceFileURL, final String name) {
+	/**
+	 * @see org.eclipse.equinox.service.weaving.ICachingService#findStoredClass(java.lang.String,
+	 *      java.net.URL, java.lang.String)
+	 */
+	public CacheEntry findStoredClass(final String namespace, final URL sourceFileURL, final String name) {
 
-        if (name == null) {
-            throw new IllegalArgumentException(
-                    "Argument \"name\" must not be null!"); //$NON-NLS-1$
-        }
+		if (name == null) {
+			throw new IllegalArgumentException("Argument \"name\" must not be null!"); //$NON-NLS-1$
+		}
 
-        byte[] storedClass = null;
-        boolean isCached = false;
+		byte[] storedClass = null;
+		boolean isCached = false;
 
-        if (cacheDirectory != null) {
-            final File cachedBytecodeFile = new File(cacheDirectory, name);
-            storedClass = read(name, cachedBytecodeFile);
-            isCached = storedClass != null;
-        }
+		if (cacheDirectory != null) {
+			final File cachedBytecodeFile = new File(cacheDirectory, name);
+			storedClass = read(name, cachedBytecodeFile);
+			isCached = storedClass != null;
+		}
 
-        if (Log.isDebugEnabled()) {
-            Log.debug(MessageFormat.format("for [{0}]: {1} {2}", bundle //$NON-NLS-1$
-                    .getSymbolicName(), ((storedClass != null) ? "Found" //$NON-NLS-1$
-                    : "Found NOT"), name)); //$NON-NLS-1$
-        }
-        return new CacheEntry(isCached, storedClass);
-    }
+		if (Log.isDebugEnabled()) {
+			Log.debug(MessageFormat.format("for [{0}]: {1} {2}", bundle //$NON-NLS-1$
+					.getSymbolicName(),
+					((storedClass != null) ? "Found" //$NON-NLS-1$
+							: "Found NOT"), //$NON-NLS-1$
+					name));
+		}
+		return new CacheEntry(isCached, storedClass);
+	}
 
-    /**
-     * Writes the remaining cache to disk.
-     */
-    public void stop() {
-    }
+	/**
+	 * Hash the shared class namespace using MD5
+	 * 
+	 * @param keyToHash
+	 * @return the MD5 version of the input string
+	 */
+	private String hashNamespace(final String namespace) {
+		MessageDigest md = null;
+		try {
+			md = MessageDigest.getInstance("MD5"); //$NON-NLS-1$
+		} catch (final NoSuchAlgorithmException e) {
+			e.printStackTrace();
+		}
+		final byte[] bytes = md.digest(namespace.getBytes());
+		final StringBuffer result = new StringBuffer();
+		for (final byte b : bytes) {
+			int num;
+			if (b < 0) {
+				num = b + 256;
+			} else {
+				num = b;
+			}
+			String s = Integer.toHexString(num);
+			while (s.length() < 2) {
+				s = "0" + s; //$NON-NLS-1$
+			}
+			result.append(s);
+		}
+		return new String(result);
+	}
 
-    /**
-     * @see org.eclipse.equinox.service.weaving.ICachingService#storeClass(java.lang.String,
-     *      java.net.URL, java.lang.Class, byte[])
-     */
-    public boolean storeClass(final String namespace, final URL sourceFileURL,
-            final Class<?> clazz, final byte[] classbytes) {
-        if (clazz == null) {
-            throw new IllegalArgumentException(
-                    "Argument \"clazz\" must not be null!"); //$NON-NLS-1$
-        }
-        if (classbytes == null) {
-            throw new IllegalArgumentException(
-                    "Argument \"classbytes\" must not be null!"); //$NON-NLS-1$
-        }
-        if (cacheDirectory == null) {
-            return false;
-        }
+	private byte[] read(final String name, final File file) {
+		int length = (int) file.length();
 
-        final CacheItem item = new CacheItem(classbytes, cacheDirectory
-                .getAbsolutePath(), clazz.getName());
+		InputStream in = null;
+		try {
+			byte[] classbytes = new byte[length];
+			int bytesread = 0;
+			int readcount;
 
-        return this.cacheWriterQueue.offer(item);
-    }
+			in = new FileInputStream(file);
 
-    /**
-     * @see org.eclipse.equinox.service.weaving.ICachingService#storeClassAndGeneratedClasses(java.lang.String,
-     *      java.net.URL, java.lang.Class, byte[], java.util.Map)
-     */
-    public boolean storeClassAndGeneratedClasses(final String namespace,
-            final URL sourceFileUrl, final Class<?> clazz,
-            final byte[] classbytes, final Map<String, byte[]> generatedClasses) {
+			if (length > 0) {
+				classbytes = new byte[length];
+				for (; bytesread < length; bytesread += readcount) {
+					readcount = in.read(classbytes, bytesread, length - bytesread);
+					if (readcount <= 0) /* if we didn't read anything */
+						break; /* leave the loop */
+				}
+			} else /* BundleEntry does not know its own length! */ {
+				length = READ_BUFFER_SIZE;
+				classbytes = new byte[length];
+				readloop: while (true) {
+					for (; bytesread < length; bytesread += readcount) {
+						readcount = in.read(classbytes, bytesread, length - bytesread);
+						if (readcount <= 0) /* if we didn't read anything */
+							break readloop; /* leave the loop */
+					}
+					final byte[] oldbytes = classbytes;
+					length += READ_BUFFER_SIZE;
+					classbytes = new byte[length];
+					System.arraycopy(oldbytes, 0, classbytes, 0, bytesread);
+				}
+			}
+			if (classbytes.length > bytesread) {
+				final byte[] oldbytes = classbytes;
+				classbytes = new byte[bytesread];
+				System.arraycopy(oldbytes, 0, classbytes, 0, bytesread);
+			}
+			return classbytes;
+		} catch (final IOException e) {
+			Log.debug(MessageFormat.format("for [{0}]: Cannot read [1] from cache!", bundle //$NON-NLS-1$
+					.getSymbolicName(), name));
+			return null;
+		} finally {
+			if (in != null) {
+				try {
+					in.close();
+				} catch (final IOException e) {
+					Log.error(MessageFormat.format("for [{0}]: Cannot close cache file for [1]!", //$NON-NLS-1$
+							bundle.getSymbolicName(), name), e);
+				}
+			}
+		}
+	}
 
-        final CacheItem item = new CacheItem(classbytes, cacheDirectory
-                .getAbsolutePath(), clazz.getName(), generatedClasses);
+	/**
+	 * Writes the remaining cache to disk.
+	 */
+	public void stop() {
+	}
 
-        return this.cacheWriterQueue.offer(item);
-    }
+	/**
+	 * @see org.eclipse.equinox.service.weaving.ICachingService#storeClass(java.lang.String,
+	 *      java.net.URL, java.lang.Class, byte[])
+	 */
+	public boolean storeClass(final String namespace, final URL sourceFileURL, final Class<?> clazz,
+			final byte[] classbytes) {
+		if (clazz == null) {
+			throw new IllegalArgumentException("Argument \"clazz\" must not be null!"); //$NON-NLS-1$
+		}
+		if (classbytes == null) {
+			throw new IllegalArgumentException("Argument \"classbytes\" must not be null!"); //$NON-NLS-1$
+		}
+		if (cacheDirectory == null) {
+			return false;
+		}
 
-    /**
-     * Hash the shared class namespace using MD5
-     * 
-     * @param keyToHash
-     * @return the MD5 version of the input string
-     */
-    private String hashNamespace(final String namespace) {
-        MessageDigest md = null;
-        try {
-            md = MessageDigest.getInstance("MD5"); //$NON-NLS-1$
-        } catch (final NoSuchAlgorithmException e) {
-            e.printStackTrace();
-        }
-        final byte[] bytes = md.digest(namespace.getBytes());
-        final StringBuffer result = new StringBuffer();
-        for (final byte b : bytes) {
-            int num;
-            if (b < 0) {
-                num = b + 256;
-            } else {
-                num = b;
-            }
-            String s = Integer.toHexString(num);
-            while (s.length() < 2) {
-                s = "0" + s; //$NON-NLS-1$
-            }
-            result.append(s);
-        }
-        return new String(result);
-    }
+		final CacheItem item = new CacheItem(classbytes, cacheDirectory.getAbsolutePath(), clazz.getName());
 
-    private byte[] read(final String name, final File file) {
-        int length = (int) file.length();
+		return this.cacheWriterQueue.offer(item);
+	}
 
-        InputStream in = null;
-        try {
-            byte[] classbytes = new byte[length];
-            int bytesread = 0;
-            int readcount;
+	/**
+	 * @see org.eclipse.equinox.service.weaving.ICachingService#storeClassAndGeneratedClasses(java.lang.String,
+	 *      java.net.URL, java.lang.Class, byte[], java.util.Map)
+	 */
+	public boolean storeClassAndGeneratedClasses(final String namespace, final URL sourceFileUrl, final Class<?> clazz,
+			final byte[] classbytes, final Map<String, byte[]> generatedClasses) {
 
-            in = new FileInputStream(file);
+		final CacheItem item = new CacheItem(classbytes, cacheDirectory.getAbsolutePath(), clazz.getName(),
+				generatedClasses);
 
-            if (length > 0) {
-                classbytes = new byte[length];
-                for (; bytesread < length; bytesread += readcount) {
-                    readcount = in.read(classbytes, bytesread, length
-                            - bytesread);
-                    if (readcount <= 0) /* if we didn't read anything */
-                    break; /* leave the loop */
-                }
-            } else /* BundleEntry does not know its own length! */{
-                length = READ_BUFFER_SIZE;
-                classbytes = new byte[length];
-                readloop: while (true) {
-                    for (; bytesread < length; bytesread += readcount) {
-                        readcount = in.read(classbytes, bytesread, length
-                                - bytesread);
-                        if (readcount <= 0) /* if we didn't read anything */
-                        break readloop; /* leave the loop */
-                    }
-                    final byte[] oldbytes = classbytes;
-                    length += READ_BUFFER_SIZE;
-                    classbytes = new byte[length];
-                    System.arraycopy(oldbytes, 0, classbytes, 0, bytesread);
-                }
-            }
-            if (classbytes.length > bytesread) {
-                final byte[] oldbytes = classbytes;
-                classbytes = new byte[bytesread];
-                System.arraycopy(oldbytes, 0, classbytes, 0, bytesread);
-            }
-            return classbytes;
-        } catch (final IOException e) {
-            Log.debug(MessageFormat.format(
-                    "for [{0}]: Cannot read [1] from cache!", bundle //$NON-NLS-1$
-                            .getSymbolicName(), name));
-            return null;
-        } finally {
-            if (in != null) {
-                try {
-                    in.close();
-                } catch (final IOException e) {
-                    Log.error(MessageFormat.format(
-                            "for [{0}]: Cannot close cache file for [1]!", //$NON-NLS-1$
-                            bundle.getSymbolicName(), name), e);
-                }
-            }
-        }
-    }
+		return this.cacheWriterQueue.offer(item);
+	}
 
 }

--- a/bundles/org.eclipse.equinox.weaving.caching/src/org/eclipse/equinox/weaving/internal/caching/CacheItem.java
+++ b/bundles/org.eclipse.equinox.weaving.caching/src/org/eclipse/equinox/weaving/internal/caching/CacheItem.java
@@ -1,13 +1,13 @@
 /*******************************************************************************
  * Copyright (c) 2009 Martin Lippert and others.
  *
- * This program and the accompanying materials 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0.
- * 
+ *
  * Contributors:
  *     Martin Lippert - initial implementation
  *     Martin Lippert - caching of generated classes
@@ -20,76 +20,74 @@ import java.util.Map;
 /**
  * A CacheItem contains the necessary information to store the cached bytecode
  * of a class to the cache disk storage.
- * 
+ *
  * @author Martin Lippert
  */
 public class CacheItem {
 
-    private final byte[] cachedBytes;
+	private final byte[] cachedBytes;
 
-    private final String directory;
+	private final String directory;
 
-    private final Map<String, byte[]> generatedClasses;
+	private final Map<String, byte[]> generatedClasses;
 
-    private final String name;
+	private final String name;
 
-    /**
-     * Create a new item to be cached
-     * 
-     * @param cachedBytes The bytes to be written to the cache
-     * @param directory The directory to where the bytes should be stored
-     * @param name The name of the file to store the bytes in
-     */
-    public CacheItem(final byte[] cachedBytes, final String directory,
-            final String name) {
-        this(cachedBytes, directory, name, null);
-    }
+	/**
+	 * Create a new item to be cached
+	 * 
+	 * @param cachedBytes The bytes to be written to the cache
+	 * @param directory   The directory to where the bytes should be stored
+	 * @param name        The name of the file to store the bytes in
+	 */
+	public CacheItem(final byte[] cachedBytes, final String directory, final String name) {
+		this(cachedBytes, directory, name, null);
+	}
 
-    /**
-     * Create a new item to be cached
-     * 
-     * @param cachedBytes The bytes to be written to the cache
-     * @param directory The directory to where the bytes should be stored
-     * @param name The name of the file to store the bytes in
-     * @param generatedClasses The generated classes that should be stored
-     *            together with this item (className -> bytecode)
-     */
-    public CacheItem(final byte[] cachedBytes, final String directory,
-            final String name, final Map<String, byte[]> generatedClasses) {
-        this.cachedBytes = cachedBytes;
-        this.directory = directory;
-        this.name = name;
-        this.generatedClasses = generatedClasses;
-    }
+	/**
+	 * Create a new item to be cached
+	 * 
+	 * @param cachedBytes      The bytes to be written to the cache
+	 * @param directory        The directory to where the bytes should be stored
+	 * @param name             The name of the file to store the bytes in
+	 * @param generatedClasses The generated classes that should be stored together
+	 *                         with this item (className -> bytecode)
+	 */
+	public CacheItem(final byte[] cachedBytes, final String directory, final String name,
+			final Map<String, byte[]> generatedClasses) {
+		this.cachedBytes = cachedBytes;
+		this.directory = directory;
+		this.name = name;
+		this.generatedClasses = generatedClasses;
+	}
 
-    /**
-     * @return The bytes to be written to the cache under the given name
-     */
-    public byte[] getCachedBytes() {
-        return cachedBytes;
-    }
+	/**
+	 * @return The bytes to be written to the cache under the given name
+	 */
+	public byte[] getCachedBytes() {
+		return cachedBytes;
+	}
 
-    /**
-     * @return The directory in which the item should be stored
-     */
-    public String getDirectory() {
-        return directory;
-    }
+	/**
+	 * @return The directory in which the item should be stored
+	 */
+	public String getDirectory() {
+		return directory;
+	}
 
-    /**
-     * @return A map containing the generated classes (name -> bytecode) for
-     *         this item or null, if there are no generated classes with this
-     *         one
-     */
-    public Map<String, byte[]> getGeneratedClasses() {
-        return generatedClasses;
-    }
+	/**
+	 * @return A map containing the generated classes (name -> bytecode) for this
+	 *         item or null, if there are no generated classes with this one
+	 */
+	public Map<String, byte[]> getGeneratedClasses() {
+		return generatedClasses;
+	}
 
-    /**
-     * @return The name of the file to be written to the cache
-     */
-    public String getName() {
-        return name;
-    }
+	/**
+	 * @return The name of the file to be written to the cache
+	 */
+	public String getName() {
+		return name;
+	}
 
 }

--- a/bundles/org.eclipse.equinox.weaving.caching/src/org/eclipse/equinox/weaving/internal/caching/CacheItemKey.java
+++ b/bundles/org.eclipse.equinox.weaving.caching/src/org/eclipse/equinox/weaving/internal/caching/CacheItemKey.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Stefan Winkler and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0.
+ *
+ * Contributors:
+ *     Stefan Winkler - initial implementation
+ *******************************************************************************/
+
+package org.eclipse.equinox.weaving.internal.caching;
+
+import java.util.Objects;
+
+/**
+ * A key to find/access {@link CacheItem}s in the lookup map of classes queued
+ * for writing.
+ *
+ * The key consists of the target cache directory and classname of the class
+ * file to be written. We use this composed key instead of concatenating the
+ * strings for performance reasons, as this saves us the otherwise necessary
+ * String concatenation.
+ */
+public final class CacheItemKey {
+	/**
+	 * The String representation of the target cache directory
+	 */
+	public final String directory;
+	/**
+	 * The class name.
+	 */
+	public final String name;
+
+	/**
+	 * Create an instance of the {@link CacheItemKey} for the given directory and
+	 * class name
+	 *
+	 * @param dir The String representation of the target cache directory
+	 * @param n   The class name
+	 */
+	public CacheItemKey(final String dir, final String n) {
+		directory = dir;
+		name = n;
+	}
+
+	@Override
+	public boolean equals(final Object obj) {
+		if (!(obj instanceof CacheItemKey)) {
+			return false;
+		}
+		final CacheItemKey other = (CacheItemKey) obj;
+		return Objects.equals(other.name, name) && Objects.equals(other.directory, directory);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(name, directory);
+	}
+}

--- a/bundles/org.eclipse.equinox.weaving.caching/src/org/eclipse/equinox/weaving/internal/caching/CacheItemKey.java
+++ b/bundles/org.eclipse.equinox.weaving.caching/src/org/eclipse/equinox/weaving/internal/caching/CacheItemKey.java
@@ -39,12 +39,12 @@ public final class CacheItemKey {
 	 * Create an instance of the {@link CacheItemKey} for the given directory and
 	 * class name
 	 *
-	 * @param dir The String representation of the target cache directory
-	 * @param n   The class name
+	 * @param dir  The String representation of the target cache directory
+	 * @param name The class name
 	 */
-	public CacheItemKey(final String dir, final String n) {
-		directory = dir;
-		name = n;
+	public CacheItemKey(final String dir, final String name) {
+		this.directory = dir;
+		this.name = name;
 	}
 
 	@Override

--- a/bundles/org.eclipse.equinox.weaving.caching/src/org/eclipse/equinox/weaving/internal/caching/CacheWriter.java
+++ b/bundles/org.eclipse.equinox.weaving.caching/src/org/eclipse/equinox/weaving/internal/caching/CacheWriter.java
@@ -33,106 +33,103 @@ import java.util.concurrent.BlockingQueue;
  */
 public class CacheWriter {
 
-    private final Thread writerThread;
+	private final Thread writerThread;
 
-    /**
-     * Create a new cache writer for the given queue of cache items
-     *
-     * @param cacheQueue The blocking queue that delivers the cache items to
-     *            store to this cache writer
-     */
-    public CacheWriter(final BlockingQueue<CacheItem> cacheQueue) {
-        this.writerThread = new Thread(new Runnable() {
+	/**
+	 * Create a new cache writer for the given queue of cache items
+	 *
+	 * @param cacheQueue The blocking queue that delivers the cache items to store
+	 *                   to this cache writer
+	 */
+	public CacheWriter(final BlockingQueue<CacheItem> cacheQueue) {
+		this.writerThread = new Thread(new Runnable() {
 
-	    @Override
-            public void run() {
-                try {
-                    while (true) {
-                        final CacheItem item = cacheQueue.take();
-                        try {
-                            store(item);
-                        } catch (final IOException ioe) {
-                            // storing in cache failed, do nothing
-                        }
-                    }
-                } catch (final InterruptedException e) {
-                }
-            }
-        });
-        this.writerThread.setPriority(Thread.MIN_PRIORITY);
-    }
+			@Override
+			public void run() {
+				try {
+					while (true) {
+						final CacheItem item = cacheQueue.take();
+						try {
+							store(item);
+						} catch (final IOException ioe) {
+							// storing in cache failed, do nothing
+						}
+					}
+				} catch (final InterruptedException e) {
+				}
+			}
+		});
+		this.writerThread.setPriority(Thread.MIN_PRIORITY);
+	}
 
-    /**
-     * start the cache writers work (creates a new thread to work on the queue)
-     */
-    public void start() {
-        this.writerThread.start();
-    }
+	/**
+	 * start the cache writers work (creates a new thread to work on the queue)
+	 */
+	public void start() {
+		this.writerThread.start();
+	}
 
-    /**
-     * stops the cache writer
-     */
-    public void stop() {
-        this.writerThread.interrupt();
-    }
+	/**
+	 * stops the cache writer
+	 */
+	public void stop() {
+		this.writerThread.interrupt();
+	}
 
-    /**
-     * store the cache item to disk
-     *
-     * This operation creates the appropriate directory for the cache item if it
-     * does not exist
-     *
-     * @param item the cache item to store to disc
-     * @throws IOException if an error occurs while writing to the cache
-     */
-    protected void store(final CacheItem item) throws IOException {
+	/**
+	 * store the cache item to disk
+	 *
+	 * This operation creates the appropriate directory for the cache item if it
+	 * does not exist
+	 *
+	 * @param item the cache item to store to disc
+	 * @throws IOException if an error occurs while writing to the cache
+	 */
+	protected void store(final CacheItem item) throws IOException {
 
-        // write out generated classes first
-        final Map<String, byte[]> generatedClasses = item.getGeneratedClasses();
-        if (generatedClasses != null) {
-            for (final Entry<String, byte[]> entry : generatedClasses
-                    .entrySet()) {
-                final String className = entry.getKey();
-                final byte[] classBytes = entry.getValue();
-                storeSingleClass(className, classBytes, item.getDirectory());
-            }
-        }
+		// write out generated classes first
+		final Map<String, byte[]> generatedClasses = item.getGeneratedClasses();
+		if (generatedClasses != null) {
+			for (final Entry<String, byte[]> entry : generatedClasses.entrySet()) {
+				final String className = entry.getKey();
+				final byte[] classBytes = entry.getValue();
+				storeSingleClass(className, classBytes, item.getDirectory());
+			}
+		}
 
-        // write out the woven class
-        storeSingleClass(item.getName(), item.getCachedBytes(),
-                item.getDirectory());
-    }
+		// write out the woven class
+		storeSingleClass(item.getName(), item.getCachedBytes(), item.getDirectory());
+	}
 
-    private void storeSingleClass(final String className,
-            final byte[] classBytes, final String cacheDirectory)
-            throws FileNotFoundException, IOException {
-        DataOutputStream outCache = null;
-        FileOutputStream fosCache = null;
-        try {
-            final File directory = new File(cacheDirectory);
-            if (!directory.exists()) {
-                directory.mkdirs();
-            }
+	private void storeSingleClass(final String className, final byte[] classBytes, final String cacheDirectory)
+			throws FileNotFoundException, IOException {
+		DataOutputStream outCache = null;
+		FileOutputStream fosCache = null;
+		try {
+			final File directory = new File(cacheDirectory);
+			if (!directory.exists()) {
+				directory.mkdirs();
+			}
 
-            fosCache = new FileOutputStream(new File(directory, className));
-            outCache = new DataOutputStream(new BufferedOutputStream(fosCache));
+			fosCache = new FileOutputStream(new File(directory, className));
+			outCache = new DataOutputStream(new BufferedOutputStream(fosCache));
 
-            outCache.write(classBytes);
-        } finally {
-            if (outCache != null) {
-                try {
-                    outCache.flush();
-                    fosCache.getFD().sync();
-                } catch (final IOException e) {
-                    // do nothing, we tried
-                }
-                try {
-                    outCache.close();
-                } catch (final IOException e) {
-                    // do nothing
-                }
-            }
-        }
-    }
+			outCache.write(classBytes);
+		} finally {
+			if (outCache != null) {
+				try {
+					outCache.flush();
+					fosCache.getFD().sync();
+				} catch (final IOException e) {
+					// do nothing, we tried
+				}
+				try {
+					outCache.close();
+				} catch (final IOException e) {
+					// do nothing
+				}
+			}
+		}
+	}
 
 }

--- a/bundles/org.eclipse.equinox.weaving.caching/src/org/eclipse/equinox/weaving/internal/caching/CachingServiceFactory.java
+++ b/bundles/org.eclipse.equinox.weaving.caching/src/org/eclipse/equinox/weaving/internal/caching/CachingServiceFactory.java
@@ -1,13 +1,13 @@
 /*******************************************************************************
  * Copyright (c) 2008, 2009 Heiko Seeberger and others.
  *
- * This program and the accompanying materials 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0.
- * 
+ *
  * Contributors:
  *     Heiko Seeberger - initial implementation
  *     Martin Lippert - further improvements and optimizations
@@ -32,119 +32,112 @@ import org.osgi.framework.Version;
 /**
  * {@link ICachingService} used as "singleton" OSGi service by
  * "org.aspectj.osgi".
- * 
+ *
  * @author Heiko Seeberger
  */
 public class CachingServiceFactory implements ICachingServiceFactory {
 
-    private final Map<String, ICachingService> bundleCachingServices = new HashMap<>();
+	private final Map<String, ICachingService> bundleCachingServices = new HashMap<>();
 
-    private final BundleContext bundleContext;
+	private final BundleContext bundleContext;
 
-    private final BlockingQueue<CacheItem> cacheQueue;
+	private final BlockingQueue<CacheItem> cacheQueue;
 
-    private final CacheWriter cacheWriter;
+	private final CacheWriter cacheWriter;
 
-    /**
-     * @param bundleContext Must not be null!
-     * @throws IllegalArgumentException if given bundleContext is null.
-     */
-    public CachingServiceFactory(final BundleContext bundleContext) {
-        if (bundleContext == null) {
-            throw new IllegalArgumentException(
-                    "Argument \"bundleContext\" must not be null!"); //$NON-NLS-1$
-        }
-        this.bundleContext = bundleContext;
-        this.cacheQueue = new ArrayBlockingQueue<>(5000);
-        this.cacheWriter = new CacheWriter(this.cacheQueue);
-        this.cacheWriter.start();
+	/**
+	 * @param bundleContext Must not be null!
+	 * @throws IllegalArgumentException if given bundleContext is null.
+	 */
+	public CachingServiceFactory(final BundleContext bundleContext) {
+		if (bundleContext == null) {
+			throw new IllegalArgumentException("Argument \"bundleContext\" must not be null!"); //$NON-NLS-1$
+		}
+		this.bundleContext = bundleContext;
+		this.cacheQueue = new ArrayBlockingQueue<>(5000);
+		this.cacheWriter = new CacheWriter(this.cacheQueue);
+		this.cacheWriter.start();
 
-        this.bundleContext.addBundleListener(new SynchronousBundleListener() {
+		this.bundleContext.addBundleListener(new SynchronousBundleListener() {
 
-            public void bundleChanged(final BundleEvent event) {
-                if (event.getType() == BundleEvent.UNINSTALLED) {
-                    stopBundleCachingService(event);
-                } else if (event.getType() == BundleEvent.UPDATED) {
-                    stopBundleCachingService(event);
-                }
-            }
-        });
-    }
+			public void bundleChanged(final BundleEvent event) {
+				if (event.getType() == BundleEvent.UNINSTALLED) {
+					stopBundleCachingService(event);
+				} else if (event.getType() == BundleEvent.UPDATED) {
+					stopBundleCachingService(event);
+				}
+			}
+		});
+	}
 
-    /**
-     * @see org.eclipse.equinox.service.weaving.ICachingServiceFactory#createCachingService(java.lang.ClassLoader,
-     *      org.osgi.framework.Bundle, java.lang.String)
-     */
-    public synchronized ICachingService createCachingService(
-            final ClassLoader classLoader, final Bundle bundle, final String key) {
+	/**
+	 * @see org.eclipse.equinox.service.weaving.ICachingServiceFactory#createCachingService(java.lang.ClassLoader,
+	 *      org.osgi.framework.Bundle, java.lang.String)
+	 */
+	public synchronized ICachingService createCachingService(final ClassLoader classLoader, final Bundle bundle,
+			final String key) {
 
-        if (bundle == null) {
-            throw new IllegalArgumentException(
-                    "Argument \"bundle\" must not be null!"); //$NON-NLS-1$
-        }
+		if (bundle == null) {
+			throw new IllegalArgumentException("Argument \"bundle\" must not be null!"); //$NON-NLS-1$
+		}
 
-        final String cacheId = getCacheId(bundle);
+		final String cacheId = getCacheId(bundle);
 
-        ICachingService bundleCachingService = bundleCachingServices
-                .get(cacheId);
+		ICachingService bundleCachingService = bundleCachingServices.get(cacheId);
 
-        if (bundleCachingService == null) {
+		if (bundleCachingService == null) {
 
-            if (key != null && key.length() > 0) {
-                bundleCachingService = new BundleCachingService(bundleContext,
-                        bundle, key, this.cacheQueue);
-            } else {
-                bundleCachingService = new UnchangedCachingService();
-            }
-            bundleCachingServices.put(cacheId, bundleCachingService);
+			if (key != null && key.length() > 0) {
+				bundleCachingService = new BundleCachingService(bundleContext, bundle, key, this.cacheQueue);
+			} else {
+				bundleCachingService = new UnchangedCachingService();
+			}
+			bundleCachingServices.put(cacheId, bundleCachingService);
 
-            if (Log.isDebugEnabled()) {
-                Log.debug(MessageFormat.format(
-                        "Created BundleCachingService for [{0}].", cacheId)); //$NON-NLS-1$
-            }
-        }
+			if (Log.isDebugEnabled()) {
+				Log.debug(MessageFormat.format("Created BundleCachingService for [{0}].", cacheId)); //$NON-NLS-1$
+			}
+		}
 
-        return bundleCachingService;
-    }
+		return bundleCachingService;
+	}
 
-    /**
-     * Generates the unique id for the cache of the given bundle (usually the
-     * symbolic name and the bundle version)
-     * 
-     * @param bundle The bundle for which a unique cache id should be calculated
-     * @return The unique id of the cache for the given bundle
-     */
-    public String getCacheId(final Bundle bundle) {
-        final Version v = bundle.getVersion();
-        return bundle.getSymbolicName() + "_" + v; //$NON-NLS-1$
-    }
+	/**
+	 * Generates the unique id for the cache of the given bundle (usually the
+	 * symbolic name and the bundle version)
+	 * 
+	 * @param bundle The bundle for which a unique cache id should be calculated
+	 * @return The unique id of the cache for the given bundle
+	 */
+	public String getCacheId(final Bundle bundle) {
+		final Version v = bundle.getVersion();
+		return bundle.getSymbolicName() + "_" + v; //$NON-NLS-1$
+	}
 
-    /**
-     * Stops all individual bundle services.
-     */
-    public synchronized void stop() {
-        for (final ICachingService bundleCachingService : bundleCachingServices
-                .values()) {
-            bundleCachingService.stop();
-        }
-        bundleCachingServices.clear();
-        this.cacheWriter.stop();
-    }
+	/**
+	 * Stops all individual bundle services.
+	 */
+	public synchronized void stop() {
+		for (final ICachingService bundleCachingService : bundleCachingServices.values()) {
+			bundleCachingService.stop();
+		}
+		bundleCachingServices.clear();
+		this.cacheWriter.stop();
+	}
 
-    /**
-     * Stops individual bundle caching service if the bundle is uninstalled
-     * 
-     * @param event The event contains the information for which bundle to stop
-     *            the caching service
-     */
-    protected void stopBundleCachingService(final BundleEvent event) {
-        final String cacheId = getCacheId(event.getBundle());
-        final ICachingService bundleCachingService = bundleCachingServices
-                .get(cacheId);
-        if (bundleCachingService != null) {
-            bundleCachingService.stop();
-            bundleCachingServices.remove(cacheId);
-        }
-    }
+	/**
+	 * Stops individual bundle caching service if the bundle is uninstalled
+	 * 
+	 * @param event The event contains the information for which bundle to stop the
+	 *              caching service
+	 */
+	protected void stopBundleCachingService(final BundleEvent event) {
+		final String cacheId = getCacheId(event.getBundle());
+		final ICachingService bundleCachingService = bundleCachingServices.get(cacheId);
+		if (bundleCachingService != null) {
+			bundleCachingService.stop();
+			bundleCachingServices.remove(cacheId);
+		}
+	}
 
 }

--- a/bundles/org.eclipse.equinox.weaving.caching/src/org/eclipse/equinox/weaving/internal/caching/ClassnameLockManager.java
+++ b/bundles/org.eclipse.equinox.weaving.caching/src/org/eclipse/equinox/weaving/internal/caching/ClassnameLockManager.java
@@ -1,0 +1,181 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Stefan Winkler and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0.
+ *
+ * Contributors:
+ *     Stefan Winkler - initial implementation
+ *******************************************************************************/
+
+package org.eclipse.equinox.weaving.internal.caching;
+
+import java.io.IOException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+/**
+ * A name-based locking facility that makes it possible to execute code in the
+ * scope of a given class name in read or write locked state (with respect to a
+ * ReadWriteLock).
+ *
+ * This makes it possible to read a woven class from the cache concurrently
+ * while preventing a write operation to the cache for the same class file.
+ */
+public class ClassnameLockManager {
+	/**
+	 * Helper class that combines a {@link ReadWriteLock} with a lock counter. By
+	 * using this counter, we can clean up any locks that are no longer used.
+	 */
+	private static class LockWithCount {
+		/**
+		 * The counter.
+		 */
+		final AtomicInteger count;
+		/**
+		 * The lock.
+		 */
+		final ReadWriteLock lock;
+
+		/**
+		 * Create a new lock instance with a counter initialized to zero.
+		 */
+		LockWithCount() {
+			this.lock = new ReentrantReadWriteLock();
+			this.count = new AtomicInteger(0);
+		}
+	}
+
+	/**
+	 * Functional interface for read operations. A cache read operation returns the
+	 * read byte[] array.
+	 */
+	@FunctionalInterface
+	public interface ReadOperation {
+		/**
+		 * The logic to read the array of class bytes from the cache.
+		 *
+		 * @return the bytes read from the cache
+		 */
+		byte[] read();
+	}
+
+	/**
+	 * Functional interface for write operations. Since we are writing to the file
+	 * system, IOExceptions can occor. Those can be propagated by declaring the
+	 * exception.
+	 */
+	@FunctionalInterface
+	public interface WriteOperation {
+		/**
+		 * The logic to write a class file to the cache.
+		 *
+		 * @throws IOException in case of a file system error in the logic, this can be
+		 *                     propagated to the caller.
+		 */
+		void write() throws IOException;
+	}
+
+	/**
+	 * The map of classnames to {@link LockWithCount} instances.
+	 */
+	private final ConcurrentHashMap<String, LockWithCount> classnameLocks = new ConcurrentHashMap<>(
+			IBundleConstants.QUEUE_CAPACITY);
+
+	/**
+	 * Acquire a read or write lock for the given classname.
+	 *
+	 * @param classname the classname
+	 * @param writeLock {@code true} if a write lock shall be acquired,
+	 *                  {@code false} for a read lock
+	 * @return the lock that has been acquired
+	 */
+	private Lock acquireLock(final String classname, final boolean writeLock) {
+		// we need to return the result from inside the closure, so wrap the value in an
+		// array.
+		final Lock[] lockWrapper = new Lock[1];
+
+		// we use compute(), so we can have the complete logic in a single atomic
+		// transaction.
+		// If there is not yet a lock, we create it and lock with it. If not, we lock
+		// with the one that exists.
+		classnameLocks.compute(classname, (key, existingEntry) -> {
+			// existingEntry == null means there is no lock for the given classname, so we
+			// create one.
+			final LockWithCount resultingEntry = existingEntry != null ? existingEntry : new LockWithCount();
+			// ge the lock that we need (read or write, depending on the parameter).
+			lockWrapper[0] = writeLock ? resultingEntry.lock.writeLock() : resultingEntry.lock.readLock();
+			// increment the lock counter
+			resultingEntry.count.incrementAndGet();
+			// return either the already existing lock (=leave the map unchanged) or, if
+			// there was none, the new one (adding it to the map)
+			return resultingEntry;
+		});
+
+		// return the acquired lock
+		return lockWrapper[0];
+	}
+
+	/**
+	 * Execute a read operation.
+	 *
+	 * @param classname     the classname defining the scope of the lock to acquire
+	 * @param readOperation the operation to execute
+	 *
+	 * @return the byte[] array read by the readOperation
+	 */
+	public byte[] executeRead(final String classname, final ReadOperation readOperation) {
+		final Lock lock = acquireLock(classname, false);
+		try {
+			return readOperation.read();
+		} finally {
+			releaseLock(classname, lock);
+		}
+	}
+
+	/**
+	 * Execute a write operation.
+	 *
+	 * @param classname      the classname defining the scope of the lock to acquire
+	 * @param writeOperation the operation to execute
+	 *
+	 * @throws IOException any exception thrown by the writeOperation will be
+	 *                     propagated to the caller
+	 */
+	public void executeWrite(final String classname, final WriteOperation writeOperation) throws IOException {
+		final Lock lock = acquireLock(classname, true);
+		try {
+			writeOperation.write();
+		} finally {
+			releaseLock(classname, lock);
+		}
+	}
+
+	/**
+	 * Release the acquired lock and perform cleanup actions.
+	 *
+	 * @param classname the classname to which lock applies
+	 * @param lock      the lock the was acquired before
+	 */
+	private void releaseLock(final String classname, final Lock lock) {
+		// We know that the lock is in the map, otherwise it could not have been
+		// acquired. So we use computeIfPresent() here.
+		classnameLocks.computeIfPresent(classname, (key, existingEntry) -> {
+			// we need to unlock inside the atomic compute operation, so that nothing can
+			// occur between the unlock operation and
+			// the counter decrement
+			lock.unlock();
+			// decrement the counter and if this was the last lock, remove it (by returning
+			// null), otherwise keep the
+			// existing entry as it was
+			return existingEntry.count.decrementAndGet() == 0 ? null : existingEntry;
+		});
+	}
+}

--- a/bundles/org.eclipse.equinox.weaving.caching/src/org/eclipse/equinox/weaving/internal/caching/IBundleConstants.java
+++ b/bundles/org.eclipse.equinox.weaving.caching/src/org/eclipse/equinox/weaving/internal/caching/IBundleConstants.java
@@ -1,13 +1,13 @@
 /*******************************************************************************
  * Copyright (c) 2008, 2009 Heiko Seeberger and others.
  *
- * This program and the accompanying materials 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0.
- * 
+ *
  * Contributors:
  *     Heiko Seeberger - initial implementation
  *******************************************************************************/
@@ -16,13 +16,13 @@ package org.eclipse.equinox.weaving.internal.caching;
 
 /**
  * Constants for org.aspectj.osgi.service.caching".
- * 
+ *
  * @author Heiko Seeberger
  */
 public interface IBundleConstants {
 
-    /**
-     * The symbolic name for this bundle: "org.aspectj.osgi.service.caching".
-     */
-    public static final String BUNDLE_SYMBOLIC_NAME = "org.eclipse.equinox.weaving.caching"; //$NON-NLS-1$
+	/**
+	 * The symbolic name for this bundle: "org.aspectj.osgi.service.caching".
+	 */
+	public static final String BUNDLE_SYMBOLIC_NAME = "org.eclipse.equinox.weaving.caching"; //$NON-NLS-1$
 }

--- a/bundles/org.eclipse.equinox.weaving.caching/src/org/eclipse/equinox/weaving/internal/caching/IBundleConstants.java
+++ b/bundles/org.eclipse.equinox.weaving.caching/src/org/eclipse/equinox/weaving/internal/caching/IBundleConstants.java
@@ -16,14 +16,14 @@
 package org.eclipse.equinox.weaving.internal.caching;
 
 /**
- * Constants for org.aspectj.osgi.service.caching".
+ * Constants for org.eclipse.equinox.weaving.caching.
  *
  * @author Heiko Seeberger
  */
 public interface IBundleConstants {
 
 	/**
-	 * The symbolic name for this bundle: "org.aspectj.osgi.service.caching".
+	 * The symbolic name for this bundle: "org.eclipse.equinox.weaving.caching".
 	 */
 	public static final String BUNDLE_SYMBOLIC_NAME = "org.eclipse.equinox.weaving.caching"; //$NON-NLS-1$
 

--- a/bundles/org.eclipse.equinox.weaving.caching/src/org/eclipse/equinox/weaving/internal/caching/IBundleConstants.java
+++ b/bundles/org.eclipse.equinox.weaving.caching/src/org/eclipse/equinox/weaving/internal/caching/IBundleConstants.java
@@ -10,6 +10,7 @@
  *
  * Contributors:
  *     Heiko Seeberger - initial implementation
+ *     Stefan Winkler - added capacity constant
  *******************************************************************************/
 
 package org.eclipse.equinox.weaving.internal.caching;
@@ -25,4 +26,9 @@ public interface IBundleConstants {
 	 * The symbolic name for this bundle: "org.aspectj.osgi.service.caching".
 	 */
 	public static final String BUNDLE_SYMBOLIC_NAME = "org.eclipse.equinox.weaving.caching"; //$NON-NLS-1$
+
+	/**
+	 * The capacity of the writer queue and lock map.
+	 */
+	public static final int QUEUE_CAPACITY = 5000;
 }

--- a/bundles/org.eclipse.equinox.weaving.caching/src/org/eclipse/equinox/weaving/internal/caching/Log.java
+++ b/bundles/org.eclipse.equinox.weaving.caching/src/org/eclipse/equinox/weaving/internal/caching/Log.java
@@ -1,13 +1,13 @@
 /*******************************************************************************
  * Copyright (c) 2008 Heiko Seeberger and others.
  *
- * This program and the accompanying materials 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0.
- * 
+ *
  * Contributors:
  *     Heiko Seeberger - initial implementation
  *******************************************************************************/
@@ -18,49 +18,49 @@ import static org.eclipse.equinox.weaving.internal.caching.IBundleConstants.BUND
 
 /**
  * Logging utility.
- * 
+ *
  * @author Heiko Seeberger
  */
 public class Log {
 
-    static boolean debugEnabled = false;
+	static boolean debugEnabled = false;
 
-    private static final String PREFIX = "[" + BUNDLE_SYMBOLIC_NAME + "] "; //$NON-NLS-1$ //$NON-NLS-2$
+	private static final String PREFIX = "[" + BUNDLE_SYMBOLIC_NAME + "] "; //$NON-NLS-1$ //$NON-NLS-2$
 
-    /**
-     * Logging debug information.
-     * 
-     * @param message The tracing message, optional.
-     */
-    public static void debug(final String message) {
-        if (debugEnabled) {
-            if (message != null) {
-                System.out.println(PREFIX + message);
-            }
-        }
-    }
+	/**
+	 * Logging debug information.
+	 * 
+	 * @param message The tracing message, optional.
+	 */
+	public static void debug(final String message) {
+		if (debugEnabled) {
+			if (message != null) {
+				System.out.println(PREFIX + message);
+			}
+		}
+	}
 
-    /**
-     * Logging an error.
-     * 
-     * @param message The error message, optional.
-     * @param t The Throwable for this error, optional.
-     */
-    public static void error(final String message, final Throwable t) {
-        if (message != null) {
-            System.err.println(PREFIX + message);
-        }
-        if (t != null) {
-            t.printStackTrace(System.err);
-        }
-    }
+	/**
+	 * Logging an error.
+	 * 
+	 * @param message The error message, optional.
+	 * @param t       The Throwable for this error, optional.
+	 */
+	public static void error(final String message, final Throwable t) {
+		if (message != null) {
+			System.err.println(PREFIX + message);
+		}
+		if (t != null) {
+			t.printStackTrace(System.err);
+		}
+	}
 
-    /**
-     * Shows debug toggle state.
-     * 
-     * @return true, if debug is enabled, else false.
-     */
-    public static boolean isDebugEnabled() {
-        return debugEnabled;
-    }
+	/**
+	 * Shows debug toggle state.
+	 * 
+	 * @return true, if debug is enabled, else false.
+	 */
+	public static boolean isDebugEnabled() {
+		return debugEnabled;
+	}
 }

--- a/bundles/org.eclipse.equinox.weaving.caching/src/org/eclipse/equinox/weaving/internal/caching/UnchangedCachingService.java
+++ b/bundles/org.eclipse.equinox.weaving.caching/src/org/eclipse/equinox/weaving/internal/caching/UnchangedCachingService.java
@@ -1,13 +1,13 @@
 /*******************************************************************************
  * Copyright (c) 2008, 2009 Martin Lippert and others.
  *
- * This program and the accompanying materials 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0.
- * 
+ *
  * Contributors:
  *     Martin Lippert - initial implementation
  *     Martin Lippert - caching of generated classes
@@ -25,53 +25,51 @@ import org.eclipse.equinox.service.weaving.ICachingService;
  * This implementation of the caching service is responsible for those bundles
  * that are not affected by the weaving. This is the case if no aspects are
  * being found for this bundle.
- * 
+ *
  * This caching service indicates for the runtime system that classes of the
  * bundle this caching service belongs to dont need to be passed to the weaving
  * service. Instead the original code from the bundle can be used.
- * 
+ *
  * @author Martin Lippert
  */
 public class UnchangedCachingService implements ICachingService {
 
-    /**
-     * @see org.eclipse.equinox.service.weaving.ICachingService#canCacheGeneratedClasses()
-     */
-    public boolean canCacheGeneratedClasses() {
-        return false;
-    }
+	/**
+	 * @see org.eclipse.equinox.service.weaving.ICachingService#canCacheGeneratedClasses()
+	 */
+	public boolean canCacheGeneratedClasses() {
+		return false;
+	}
 
-    /**
-     * @see org.eclipse.equinox.service.weaving.ICachingService#findStoredClass(java.lang.String,
-     *      java.net.URL, java.lang.String)
-     */
-    public CacheEntry findStoredClass(final String namespace,
-            final URL sourceFileURL, final String name) {
-        return new CacheEntry(true, null);
-    }
+	/**
+	 * @see org.eclipse.equinox.service.weaving.ICachingService#findStoredClass(java.lang.String,
+	 *      java.net.URL, java.lang.String)
+	 */
+	public CacheEntry findStoredClass(final String namespace, final URL sourceFileURL, final String name) {
+		return new CacheEntry(true, null);
+	}
 
-    /**
-     * @see org.eclipse.equinox.service.weaving.ICachingService#stop()
-     */
-    public void stop() {
-    }
+	/**
+	 * @see org.eclipse.equinox.service.weaving.ICachingService#stop()
+	 */
+	public void stop() {
+	}
 
-    /**
-     * @see org.eclipse.equinox.service.weaving.ICachingService#storeClass(java.lang.String,
-     *      java.net.URL, java.lang.Class, byte[])
-     */
-    public boolean storeClass(final String namespace, final URL sourceFileURL,
-            final Class<?> clazz, final byte[] classbytes) {
-        return false;
-    }
+	/**
+	 * @see org.eclipse.equinox.service.weaving.ICachingService#storeClass(java.lang.String,
+	 *      java.net.URL, java.lang.Class, byte[])
+	 */
+	public boolean storeClass(final String namespace, final URL sourceFileURL, final Class<?> clazz,
+			final byte[] classbytes) {
+		return false;
+	}
 
-    /**
-     * @see org.eclipse.equinox.service.weaving.ICachingService#storeClassAndGeneratedClasses(java.lang.String,
-     *      java.net.URL, java.lang.Class, byte[], java.util.Map)
-     */
-    public boolean storeClassAndGeneratedClasses(final String namespace,
-            final URL sourceFileUrl, final Class<?> clazz,
-            final byte[] classbytes, final Map<String, byte[]> generatedClasses) {
-        return false;
-    }
+	/**
+	 * @see org.eclipse.equinox.service.weaving.ICachingService#storeClassAndGeneratedClasses(java.lang.String,
+	 *      java.net.URL, java.lang.Class, byte[], java.util.Map)
+	 */
+	public boolean storeClassAndGeneratedClasses(final String namespace, final URL sourceFileUrl, final Class<?> clazz,
+			final byte[] classbytes, final Map<String, byte[]> generatedClasses) {
+		return false;
+	}
 }


### PR DESCRIPTION
This PR fixes issue #233 

I had a short discussion with @martinlippert a few weeks ago about how to fix this.

From that, I have tried to first implement a lookup map for classes that are currently in the writer queue. This solves the issue of weaving the same class multiple times, because even if the class is not yet written to disk, we have a cache hit and can already reuse that class in the writer queue.

This implementation made things a bit better, but still resulted in the same symptom; it only became rarer.

The problem is most likely that there is no synchronization between cache reads and writes, and it can be the case that the reader has a cache miss, and immediately at that point (before the reader checks the file system), the writer is given the same class to store and it directly starts to store it, which still can result in an incomplete file being present when the reader now checks the file system.

So, I implemented a synchronization mechanism in addition to the queue lookup. This synchronization uses one RWLock per class name, so that we still have optimal throughput as long as no conflicting access occurs.

With this implementation, the RCPTT tests are now rock-solid.