### PR TITLE
Define github action to build Windows launcher

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,40 @@ jobs:
         name: test-results
         if-no-files-found: error
         path: '**/target/*-reports/*.xml'
+  build-launcher-win64:
+    runs-on: windows-2019
+    env:
+      PROGRAM_OUTPUT: eclipse.exe
+      PROGRAM_LIBRARY: eclipse.dll
+      DEFAULT_OS: win32
+      DEFAULT_OS_ARCH: x86_64
+      DEFAULT_WS: win32
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 1
+    - name: Set up JDK 8
+      uses: actions/setup-java@v3
+      with:
+        java-version: '8'
+        distribution: 'temurin'
+    - name: Visual Studio shell
+      uses: egor-tensin/vs-shell@v2
+      with:
+        arch: x64
+    - name: Build
+      working-directory: features/org.eclipse.equinox.executable.feature/library/win32
+      run: nmake -f make_win64.mak
+      shell: pwsh
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v3
+      if: success()
+      with:
+        name: Windows launcher artifacts
+        path: |
+          features/org.eclipse.equinox.executable.feature/library/win32/eclipse*.exe
+          features/org.eclipse.equinox.executable.feature/library/win32/eclipse*.dll
+        if-no-files-found: error
   tck:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Currently, only equinox developers are allowed to launch the build jobs to produce the launcher artifacts.
As this greatly inhibits the community in helping develop these launchers, I propose to use github actions to provide the launcher artifact for at least Windows as the alternative is for the contributor to have a system available with the right version of Visual Studio and perhaps even buy a Visual Studio license just to help fix a bug.

I've been using this github action to validate the suggested change in #118 and it works.