### PR TITLE
Fix concurrency issue in Equinox Caching (errata)

### DIFF
--- a/bundles/org.eclipse.equinox.weaving.caching/src/org/eclipse/equinox/weaving/internal/caching/ClassnameLockManager.java
+++ b/bundles/org.eclipse.equinox.weaving.caching/src/org/eclipse/equinox/weaving/internal/caching/ClassnameLockManager.java
@@ -119,6 +119,11 @@ public class ClassnameLockManager {
 			return resultingEntry;
 		});
 
+		// now activate the lock - this must happen outside of the compute() because
+		// otherwise we would end up in a deadlock with the classnameLocks
+		// ConcurrentHashMap lock in releaseLock()
+		lockWrapper[0].lock();
+
 		// return the acquired lock
 		return lockWrapper[0];
 	}


### PR DESCRIPTION
This is an addition/fix to https://github.com/eclipse-equinox/equinox/pull/234 regarding https://github.com/eclipse-equinox/equinox/issues/233 

Sadly, it turned out that in the original code, I forgot to actually activate the lock that was obtained.
This was not detected in the original tests because of some other issues in RCPTT :-(

But actually, the previous PR is completely unusable without this fix...