### PR TITLE
replaced Require-Bundle with Import Packages

### DIFF
--- a/bundles/org.eclipse.equinox.common/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.common/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.common; singleton:=true
-Bundle-Version: 3.17.100.qualifier
+Bundle-Version: 3.17.200.qualifier
 Bundle-Localization: plugin
 Export-Package: org.eclipse.core.internal.boot;x-friends:="org.eclipse.core.resources,org.eclipse.pde.build",
  org.eclipse.core.internal.runtime;common=split;mandatory:=common;
@@ -19,7 +19,18 @@ Export-Package: org.eclipse.core.internal.boot;x-friends:="org.eclipse.core.reso
  org.eclipse.equinox.events;version="1.0.0"
 Bundle-Vendor: %providerName
 Bundle-Activator: org.eclipse.core.internal.runtime.Activator
-Require-Bundle: org.eclipse.osgi;bundle-version="[3.17.200,4.0.0)"
+Import-Package: org.eclipse.equinox.log;version="[1.0,2.0)",
+ org.eclipse.osgi.framework.log;version="[1.1, 2.0)",
+ org.eclipse.osgi.service.datalocation,
+ org.eclipse.osgi.service.debug,
+ org.eclipse.osgi.service.localization,
+ org.eclipse.osgi.service.urlconversion,
+ org.eclipse.osgi.util,
+ org.osgi.framework,
+ org.osgi.service.log;version="[1.3.0, 2.0)",
+ org.osgi.service.packageadmin,
+ org.osgi.service.url,
+ org.osgi.util.tracker
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Automatic-Module-Name: org.eclipse.equinox.common


### PR DESCRIPTION
For unclear reasons Require-Bundle was introduced, which makes it unnecessarily hard to work with bundles outside of equinox, that have some strong reliance on eclipse core runtime. The use of Import-Packages here allows to circumvent this strong requirement in some cases with creative repackaging.