### PR TITLE
Fix NPE when bundle is not started

### DIFF
--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/internal/runtime/Activator.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/internal/runtime/Activator.java
@@ -197,11 +197,13 @@ public class Activator implements BundleActivator {
 	 * in the given locale. Does not return null.
 	 * @throws MissingResourceException If the corresponding resource could not be found
 	 */
-	public ResourceBundle getLocalization(Bundle bundle, String locale) throws MissingResourceException {
-		if (localizationTracker == null) {
-			throw new MissingResourceException(CommonMessages.activator_resourceBundleNotStarted, bundle.getSymbolicName(), ""); //$NON-NLS-1$
+	public static ResourceBundle getLocalization(Bundle bundle, String locale) throws MissingResourceException {
+		Activator activator = Activator.getDefault();
+		if (activator == null) {
+			throw new MissingResourceException(CommonMessages.activator_resourceBundleNotStarted,
+					bundle.getSymbolicName(), ""); //$NON-NLS-1$
 		}
-		BundleLocalization location = localizationTracker.current().orElse(null);
+		BundleLocalization location = activator.localizationTracker.current().orElse(null);
 		ResourceBundle result = null;
 		if (location != null)
 			result = location.getLocalization(bundle, locale);

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/internal/runtime/ResourceTranslator.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/internal/runtime/ResourceTranslator.java
@@ -70,7 +70,7 @@ public class ResourceTranslator {
 			Locale locale = (language == null) ? Locale.getDefault() : new Locale(language);
 			return ResourceBundle.getBundle("plugin", locale, createTempClassloader(bundle)); //$NON-NLS-1$
 		}
-		return Activator.getDefault().getLocalization(bundle, language);
+		return Activator.getLocalization(bundle, language);
 	}
 
 	public static String[] getResourceString(Bundle bundle, String[] nonTranslated, String locale) {


### PR DESCRIPTION
Currently the code checks for 'localizationTracker == null' to see if bundle is started, but that field is actually never null (as it is a final field always initilized with a value) instead the Activator instance itself can be null.

This changes the method to replace the usless check with one that checks if the activator instance is null and additionally make the method static.