### PR TITLE
Use new static IPath factories

### DIFF
--- a/bundles/org.eclipse.equinox.common.tests/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.common.tests/META-INF/MANIFEST.MF
@@ -3,12 +3,12 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Common Eclipse Runtime Tests
 Bundle-Vendor: Eclipse.org - Equinox
 Bundle-SymbolicName: org.eclipse.equinox.common.tests;singleton:=true
-Bundle-Version: 3.16.0.qualifier
+Bundle-Version: 3.16.100.qualifier
 Automatic-Module-Name: org.eclipse.equinox.common.tests
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.junit,
- org.eclipse.equinox.common;bundle-version="3.17.0",
+ org.eclipse.equinox.common;bundle-version="3.18.0",
  org.eclipse.core.tests.harness;bundle-version="3.11.400",
  org.eclipse.equinox.registry;bundle-version="3.8.200"
 Import-Package: org.eclipse.osgi.service.localization,

--- a/bundles/org.eclipse.equinox.common.tests/src/org/eclipse/core/runtime/tests/FileLocatorTest.java
+++ b/bundles/org.eclipse.equinox.common.tests/src/org/eclipse/core/runtime/tests/FileLocatorTest.java
@@ -27,7 +27,6 @@ import java.util.Map;
 
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.tests.harness.BundleTestingHelper;
 import org.junit.Test;
 import org.osgi.framework.Bundle;
@@ -54,7 +53,7 @@ public class FileLocatorTest {
 				"Plugin_Testing/fileLocator/testFileLocator.nl");
 		BundleTestingHelper.refreshPackages(getContext(), new Bundle[] { fragment });
 
-		IPath path = new Path(searchLocation);
+		IPath path = IPath.fromOSString(searchLocation);
 		Map<String, String> map = new HashMap<>(1);
 		map.put("$nl$", nl);
 

--- a/bundles/org.eclipse.equinox.common.tests/src/org/eclipse/equinox/common/tests/URIUtilTest.java
+++ b/bundles/org.eclipse.equinox.common.tests/src/org/eclipse/equinox/common/tests/URIUtilTest.java
@@ -25,7 +25,6 @@ import java.net.URL;
 
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.URIUtil;
 import org.eclipse.core.tests.harness.CoreTest;
 import org.osgi.framework.FrameworkUtil;
@@ -59,12 +58,13 @@ public class URIUtilTest extends CoreTest {
 	 * Tests for {@link URIUtil#toJarURI(URI, IPath)}.
 	 */
 	public void testToJARURI() {
-		URL locationURL = FileLocator.find(FrameworkUtil.getBundle(getClass()), new Path("Plugin_Testing/uriutil/test.jar"), null);
+		URL locationURL = FileLocator.find(FrameworkUtil.getBundle(getClass()),
+				IPath.fromOSString("Plugin_Testing/uriutil/test.jar"), null);
 		try {
 			locationURL = FileLocator.resolve(locationURL);
 			URI location = URIUtil.toURI(locationURL);
 			final String suffix = "test/1029/test.txt";
-			URI jar = URIUtil.toJarURI(location, new Path(suffix));
+			URI jar = URIUtil.toJarURI(location, IPath.fromOSString(suffix));
 			InputStream is = jar.toURL().openStream();
 			is.close();
 
@@ -111,7 +111,7 @@ public class URIUtilTest extends CoreTest {
 		} else {
 			assertTrue("2.1", result.getAbsolutePath().startsWith("\\\\"));
 		}
-		assertTrue("2.2", new Path(result.toString()).isUNC());
+		assertTrue("2.2", IPath.fromOSString(result.toString()).isUNC());
 	}
 
 	/**

--- a/bundles/org.eclipse.equinox.preferences/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.preferences/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Version: 3.10.300.qualifier
 Bundle-Activator: org.eclipse.core.internal.preferences.Activator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
-Require-Bundle: org.eclipse.equinox.common;bundle-version="[3.2.0,4.0.0)",
+Require-Bundle: org.eclipse.equinox.common;bundle-version="[3.18.0,4.0.0)",
  org.eclipse.equinox.registry;bundle-version="[3.2.0,4.0.0)";resolution:=optional,
  org.osgi.service.prefs;bundle-version="[1.1.0,1.2.0)";visibility:=reexport
 Export-Package: org.eclipse.core.internal.preferences;x-friends:="org.eclipse.core.resources,org.eclipse.core.runtime,org.eclipse.equinox.p2.engine",

--- a/bundles/org.eclipse.equinox.preferences/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.preferences/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.preferences; singleton:=true
-Bundle-Version: 3.10.200.qualifier
+Bundle-Version: 3.10.300.qualifier
 Bundle-Activator: org.eclipse.core.internal.preferences.Activator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.equinox.preferences/src/org/eclipse/core/internal/preferences/BundleDefaultPreferences.java
+++ b/bundles/org.eclipse.equinox.preferences/src/org/eclipse/core/internal/preferences/BundleDefaultPreferences.java
@@ -15,7 +15,6 @@ package org.eclipse.core.internal.preferences;
 
 import java.util.*;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.preferences.*;
 
 /**
@@ -45,7 +44,7 @@ public class BundleDefaultPreferences extends EclipsePreferences {
 	private BundleDefaultPreferences(EclipsePreferences parent, String name) {
 		super(parent, name);
 		// cache the segment count
-		IPath path = new Path(absolutePath());
+		IPath path = IPath.fromOSString(absolutePath());
 		segmentCount = path.segmentCount();
 		if (segmentCount < 2)
 			return;

--- a/bundles/org.eclipse.equinox.preferences/src/org/eclipse/core/internal/preferences/ConfigurationPreferences.java
+++ b/bundles/org.eclipse.equinox.preferences/src/org/eclipse/core/internal/preferences/ConfigurationPreferences.java
@@ -16,7 +16,6 @@ package org.eclipse.core.internal.preferences;
 import java.net.URL;
 import java.util.*;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.osgi.service.datalocation.Location;
 
@@ -40,7 +39,7 @@ public class ConfigurationPreferences extends EclipsePreferences {
 		if (location != null) {
 			URL url = location.getURL();
 			if (url != null)
-				baseLocation = new Path(url.getFile());
+				baseLocation = IPath.fromOSString(url.getFile());
 		}
 	}
 

--- a/bundles/org.eclipse.equinox.preferences/src/org/eclipse/core/runtime/preferences/ConfigurationScope.java
+++ b/bundles/org.eclipse.equinox.preferences/src/org/eclipse/core/runtime/preferences/ConfigurationScope.java
@@ -17,7 +17,6 @@ import java.net.URL;
 import org.eclipse.core.internal.preferences.AbstractScope;
 import org.eclipse.core.internal.preferences.PreferencesOSGiUtils;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.osgi.service.datalocation.Location;
 
 /**
@@ -86,7 +85,7 @@ public final class ConfigurationScope extends AbstractScope {
 		if (!location.isReadOnly()) {
 			URL url = location.getURL();
 			if (url != null) {
-				result = new Path(url.getFile());
+				result = IPath.fromOSString(url.getFile());
 				if (result.isEmpty())
 					result = null;
 			}

--- a/bundles/org.eclipse.equinox.security.ui/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.security.ui/META-INF/MANIFEST.MF
@@ -18,7 +18,7 @@ Require-Bundle: org.eclipse.equinox.security;bundle-version="[1.0.0,2.0.0)",
  org.eclipse.equinox.preferences;bundle-version="[3.2.200,4.0.0)",
  org.eclipse.swt;bundle-version="[3.118.0,4.0.0)",
  org.eclipse.ui;bundle-version="[3.4.0,4.0.0)",
- org.eclipse.core.runtime; bundle-version="[3.4.0,4.0.0)"
+ org.eclipse.core.runtime;bundle-version="[3.27.0,4.0.0)"
 Bundle-Activator: org.eclipse.equinox.internal.security.ui.Activator
 Export-Package: org.eclipse.equinox.internal.provisional.security.ui;version="1.0.0";x-friends:="org.eclipse.equinox.p2.ui",
  org.eclipse.equinox.internal.security.ui;x-internal:=true,

--- a/bundles/org.eclipse.equinox.security.ui/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.security.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.security.ui;singleton:=true
-Bundle-Version: 1.3.500.qualifier
+Bundle-Version: 1.3.600.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Import-Package: javax.crypto.spec,

--- a/bundles/org.eclipse.equinox.security.ui/src/org/eclipse/equinox/internal/security/ui/storage/StorageLoginDialog.java
+++ b/bundles/org.eclipse.equinox.security.ui/src/org/eclipse/equinox/internal/security/ui/storage/StorageLoginDialog.java
@@ -16,8 +16,8 @@ package org.eclipse.equinox.internal.security.ui.storage;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import javax.crypto.spec.PBEKeySpec;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.equinox.internal.security.ui.Activator;
 import org.eclipse.equinox.internal.security.ui.nls.SecUIMessages;
 import org.eclipse.equinox.security.storage.EncodingUtils;
@@ -164,7 +164,7 @@ public class StorageLoginDialog extends TitleAreaDialog {
 			locationGroup.setLayout(new GridLayout());
 
 			Label locationLabel = new Label(locationGroup, SWT.WRAP);
-			locationLabel.setText(new Path(location).toOSString());
+			locationLabel.setText(IPath.fromOSString(location).toOSString());
 		}
 
 		composite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
@@ -213,7 +213,7 @@ public class StorageLoginDialog extends TitleAreaDialog {
 			internalPassword = EncodingUtils.encodeBase64(digested);
 		} catch (NoSuchAlgorithmException e) {
 			// just use the text as is
-			Activator.log(IStatus.WARNING, SecUIMessages.noDigestPassword, new Object[] {DIGEST_ALGORITHM}, e);
+			Activator.log(IStatus.WARNING, SecUIMessages.noDigestPassword, new Object[] { DIGEST_ALGORITHM }, e);
 			internalPassword = password.getText();
 		}
 		generatedPassword = new PBEKeySpec(internalPassword.toCharArray());

--- a/bundles/org.eclipse.equinox.security.ui/src/org/eclipse/equinox/internal/security/ui/storage/TabContents.java
+++ b/bundles/org.eclipse.equinox.security.ui/src/org/eclipse/equinox/internal/security/ui/storage/TabContents.java
@@ -15,8 +15,8 @@ package org.eclipse.equinox.internal.security.ui.storage;
 
 import java.io.*;
 import java.net.URL;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.equinox.internal.security.storage.friends.IDeleteListener;
 import org.eclipse.equinox.internal.security.storage.friends.InternalExchangeUtils;
 import org.eclipse.equinox.internal.security.ui.Activator;
@@ -114,10 +114,10 @@ public class TabContents implements ISecurePreferencesSelection, IDeleteListener
 		URL location = InternalExchangeUtils.defaultStorageLocation();
 		if (location != null) {
 			new Label(page, SWT.NONE).setText(SecUIMessages.locationButton);
-			new Text(page, SWT.READ_ONLY).setText(new Path(location.getFile()).toOSString());
+			new Text(page, SWT.READ_ONLY).setText(IPath.fromOSString(location.getFile()).toOSString());
 		}
 
-		sashForm.setWeights(new int[] {30, 70});
+		sashForm.setWeights(new int[] { 30, 70 });
 
 		nodesView = new NodesView(nodeTree, this);
 		valuesView = new ValuesView(tableOfValues, this, shell);


### PR DESCRIPTION
Use the new IPath factory methods introduced in https://github.com/eclipse-equinox/equinox/pull/228 in Equinox.

With this PR the `org.eclipse.core.runtime.Path` does not occur anymore in Equinox's entire code base, expect for the PathTests and of course `org.eclipse.core.runtime.Path` itself.