### PR TITLE
Fix broken init of Path constants

### DIFF
--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/IPath.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/IPath.java
@@ -61,7 +61,7 @@ public interface IPath extends Cloneable {
 	 * 
 	 * @since 3.18
 	 */
-	public static final IPath EMPTY = fromOSString(""); //$NON-NLS-1$
+	public static final IPath EMPTY = Path.Constants.empty();
 
 	/**
 	 * Constant value containing the root path with no device on the local file
@@ -69,7 +69,7 @@ public interface IPath extends Cloneable {
 	 * 
 	 * @since 3.18
 	 */
-	public static final IPath ROOT = fromOSString("/"); //$NON-NLS-1$
+	public static final IPath ROOT = Path.Constants.root();
 
 	/**
 	 * Constructs a new path from the given string path. The string path must


### PR DESCRIPTION
As long as IPath creates instances of Path in the IPath constants init code, Path can't back reference to same IPath constants that are not initialized yet - it will see null values and everyone who uses Path constants will be broken.

Fixes https://github.com/eclipse-equinox/equinox/issues/278