### PR TITLE
Remove 'Eclipse-LazyStart' headers in favor of 'Bundle-ActivationPolicy'

### DIFF
--- a/bundles/org.eclipse.equinox.compendium.tests/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.compendium.tests/META-INF/MANIFEST.MF
@@ -6,7 +6,6 @@ Bundle-Version: 1.2.300.qualifier
 Bundle-Activator: org.eclipse.equinox.compendium.tests.Activator
 Require-Bundle: org.eclipse.core.runtime,
  org.junit;bundle-version="4.12.0"
-Eclipse-LazyStart: true
 Import-Package: org.eclipse.equinox.metatype;version="1.2.0",
  org.eclipse.equinox.metatype.impl;version="1.2.0",
  org.eclipse.osgi.tests.bundles,
@@ -20,3 +19,4 @@ Bundle-RequiredExecutionEnvironment: J2SE-1.5
 Bundle-Localization: plugin
 Bundle-Vendor: %bundleVendor
 Automatic-Module-Name: org.eclipse.equinox.compendium.tests
+Bundle-ActivationPolicy: lazy

--- a/bundles/org.eclipse.equinox.launcher/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.launcher/META-INF/MANIFEST.MF
@@ -4,7 +4,6 @@ Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.launcher;singleton:=true
 Bundle-Version: 1.6.500.qualifier
 Main-Class: org.eclipse.equinox.launcher.Main
-Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Localization: launcher


### PR DESCRIPTION
... and remove unnecessary 'Bundle-ClassPath: .' entries.

Replace the use of the legacy and Eclipse-specific MANIFEST.MF header 'Eclipse-LazyStart: true' by the OSGi standard compliant header 'Bundle-ActivationPolicy: lazy' (which is already used in most cases.

The default value of 'Bundle-ClassPath' is the dot which is used when the header is not specified. Therefore there is no need to specify it with that value.