### PR TITLE
Add a standard osgi repository that includes all equinox bundles

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,7 +31,7 @@ pipeline {
 			}
 			post {
 				always {
-					archiveArtifacts artifacts: '**/*.log, **/*.jar', allowEmptyArchive: true
+					archiveArtifacts artifacts: '**/*.log, **/*.jar, **/repository/target/repository-deploy.zip', allowEmptyArchive: true
 					junit '**/target/surefire-reports/TEST-*.xml'
 					discoverGitReferenceBuild referenceJob: 'equinox/master'
 					recordIssues publishAllIssues: true, tools: [java(), mavenConsole(), javaDoc()]

--- a/pom.xml
+++ b/pom.xml
@@ -220,6 +220,7 @@
 		    <module>bundles/org.eclipse.equinox.launcher.win32.win32.x86_64</module>
 		
 		    <module>bundles/org.eclipse.osgi.tests</module>
+		    <module>repository</module>
         </modules>
     </profile>
   </profiles>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.eclipse.equinox</groupId>
+		<artifactId>parent</artifactId>
+		<version>4.29.0-SNAPSHOT</version>
+	</parent>
+	<artifactId>repository</artifactId>
+	<packaging>repository</packaging>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-repository-plugin</artifactId>
+				<version>${tycho.version}</version>
+				<extensions>true</extensions>
+				<executions>
+					<!-- Additionally we create another repository using the 'local' layout and place it in a deploy folder -->
+					<execution>
+						<id>local</id>
+						<phase>package</phase>
+						<goals>
+							<goal>package-repository</goal>
+						</goals>
+						<configuration>
+							<repositoryLayout>local</repositoryLayout>
+							<settings>
+								<repositoryFolderName>deploy</repositoryFolderName>
+							</settings>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>


### PR DESCRIPTION
Currently one has to wait until the next release or use the ibuilds composite p2 repository but there is currently no way to fetch latest equinox bundles in a more lightweight way.

This uses the new tycho-repositry-plugin to build a standard OSGi repository that could be deployed e.g. as part of the mater verification build.

WDYT @akurtakov @tjwatson? The idea would be that we can deploy a standard osgi repository with each master build and possibly even have an automated release build to publish equinox bundles independent from regular release cycles, at best such repository would then even be used as contribution to simrel some time....

But first goal would be to supply something standardized to the outside world without much effort.