### PR TITLE
JSP compilation depends on the org.eclipse.jdt.core.compiler package

### DIFF
--- a/features/org.eclipse.equinox.sdk/feature.xml
+++ b/features/org.eclipse.equinox.sdk/feature.xml
@@ -145,4 +145,17 @@
          version="0.0.0"
          unpack="false"/>
 
+   <plugin
+         id="org.eclipse.jdt.core.compiler.batch"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.jdt.core.compiler.batch.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
 </feature>


### PR DESCRIPTION
Add an include of the org.eclipse.jdt.core.compiler.batch plugin to the org.eclipse.equinox.sdk feature.

https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1251