### PR TITLE
Bump org.eclipse.equinox.security.ui and fix dependency version

### DIFF
--- a/bundles/org.eclipse.equinox.security.ui/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.security.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.security.ui;singleton:=true
-Bundle-Version: 1.4.0.qualifier
+Bundle-Version: 1.4.100.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Import-Package: javax.crypto.spec,
@@ -14,7 +14,7 @@ Import-Package: javax.crypto.spec,
  org.eclipse.osgi.util;version="[1.1.0,2.0.0)",
  org.osgi.framework,
  org.osgi.util.tracker;version="[1.3.3,2.0.0)"
-Require-Bundle: org.eclipse.equinox.security;bundle-version="[1.0.0,2.0.0)",
+Require-Bundle: org.eclipse.equinox.security;bundle-version="[1.4.100,2.0.0)",
  org.eclipse.equinox.preferences;bundle-version="[3.2.200,4.0.0)",
  org.eclipse.swt;bundle-version="[3.118.0,4.0.0)",
  org.eclipse.ui;bundle-version="[3.4.0,4.0.0)",


### PR DESCRIPTION
The https://github.com/eclipse-equinox/equinox/pull/285 changed IStorageConstants.DEFAULT_CIPHER that is inlined by TabAdvanced in org.eclipse.equinox.security.ui but which was not touched.

See https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1388