### PR TITLE
Force English locale for date tests

### DIFF
--- a/bundles/org.eclipse.equinox.http.servlet.tests/src/org/eclipse/equinox/http/servlet/tests/DispatchingTest.java
+++ b/bundles/org.eclipse.equinox.http.servlet.tests/src/org/eclipse/equinox/http/servlet/tests/DispatchingTest.java
@@ -1284,7 +1284,7 @@ public class DispatchingTest extends BaseTest {
 
 	@Test
 	public void test_headers_include() throws Exception {
-		SimpleDateFormat format = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz");
+		SimpleDateFormat format = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.ENGLISH);
 		format.setTimeZone(TimeZone.getTimeZone("GMT"));
 		final long date1 = System.currentTimeMillis() - (1000*60*60*24*365*30);
 		final long date2 = System.currentTimeMillis() - (1000*60*60*24*365*40);
@@ -1358,7 +1358,7 @@ public class DispatchingTest extends BaseTest {
 
 	@Test
 	public void test_headers_forward() throws Exception {
-		SimpleDateFormat format = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz");
+		SimpleDateFormat format = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.ENGLISH);
 		format.setTimeZone(TimeZone.getTimeZone("GMT"));
 		final long date1 = System.currentTimeMillis() - (1000*60*60*24*365*30);
 		final long date2 = System.currentTimeMillis() - (1000*60*60*24*365*40);


### PR DESCRIPTION
When using `java.text.SimpleDateFormat` without a locale, the system default locale will be considered and if that is not set to an English variant, the "EEE" part of the date string will be in a non-English language. To overcome this, ensure that the English locale is used for all tests where a `java.util.Date` is stringified.