### PR TITLE
Do not import o.e.jetty.servlet in server.jetty feature

### DIFF
--- a/features/org.eclipse.equinox.server.jetty/feature.xml
+++ b/features/org.eclipse.equinox.server.jetty/feature.xml
@@ -20,7 +20,6 @@
       <import plugin="org.eclipse.jetty.io"/>
       <import plugin="org.eclipse.jetty.security"/>
       <import plugin="org.eclipse.jetty.server"/>
-      <import plugin="org.eclipse.jetty.servlet"/>
       <import plugin="org.eclipse.jetty.util"/>
       <import plugin="org.eclipse.jetty.util.ajax"/>
    </requires>


### PR DESCRIPTION
Bundle changed id to o.e.jetty.ee8.servlet and import it not needed as it's a dependency of o.e.eqinox.http.jetty which is included in the feature and thus the servlet bundle will come as transitive dependency.