### PR TITLE
Remove imports of org.eclipse.jetty.* from server.jetty feature

### DIFF
--- a/features/org.eclipse.equinox.server.jetty/feature.xml
+++ b/features/org.eclipse.equinox.server.jetty/feature.xml
@@ -15,15 +15,6 @@
       %license
    </license>
 
-   <requires>
-      <import plugin="org.eclipse.jetty.http"/>
-      <import plugin="org.eclipse.jetty.io"/>
-      <import plugin="org.eclipse.jetty.security"/>
-      <import plugin="org.eclipse.jetty.server"/>
-      <import plugin="org.eclipse.jetty.util"/>
-      <import plugin="org.eclipse.jetty.util.ajax"/>
-   </requires>
-
    <plugin
          id="jakarta.servlet-api"
          download-size="0"


### PR DESCRIPTION
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1444