### PR TITLE
Remove jakarta.servlet-api, javax.servlet.jsp-api, javax.el-api

### DIFF
--- a/features/org.eclipse.equinox.sdk/feature.xml
+++ b/features/org.eclipse.equinox.sdk/feature.xml
@@ -48,34 +48,6 @@
          version="0.0.0"/>
 
    <plugin
-         id="javax.servlet.jsp-api"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="javax.servlet.jsp-api.source"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="javax.el-api"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="javax.el-api.source"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
          id="org.eclipse.equinox.http.servletbridge"
          download-size="0"
          install-size="0"
@@ -144,4 +116,5 @@
          install-size="0"
          version="0.0.0"
          unpack="false"/>
+
 </feature>

--- a/features/org.eclipse.equinox.server.jetty/feature.xml
+++ b/features/org.eclipse.equinox.server.jetty/feature.xml
@@ -16,13 +16,6 @@
    </license>
 
    <plugin
-         id="jakarta.servlet-api"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
          id="org.eclipse.equinox.http.jetty"
          download-size="0"
          install-size="0"


### PR DESCRIPTION
These bundles are included by features but are not actually needed at runtime.

https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1361