### PR TITLE
Update embedded org.osgi.util.tracker sources from 1.5.3 to 1.5.4

### DIFF
--- a/bundles/org.eclipse.osgi/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.osgi/META-INF/MANIFEST.MF
@@ -77,7 +77,7 @@ Export-Package: org.eclipse.core.runtime.adaptor;x-friends:="org.eclipse.core.ru
  org.osgi.service.resolver;version="1.1.1";uses:="org.osgi.resource",
  org.osgi.service.startlevel;version="1.1.1";uses:="org.osgi.framework",
  org.osgi.service.url;version="1.0.1",
- org.osgi.util.tracker;version="1.5.3";uses:="org.osgi.framework"
+ org.osgi.util.tracker;version="1.5.4";uses:="org.osgi.framework"
 Provide-Capability: osgi.service; objectClass:List<String>="org.osgi.service.log.LogReaderService,org.eclipse.equinox.log.ExtendedLogReaderService"; uses:="org.osgi.service.log",
  osgi.service; objectClass:List<String>="org.osgi.service.log.LoggerFactory,org.osgi.service.log.LogService,org.eclipse.equinox.log.ExtendedLogService"; uses:="org.osgi.service.log",
  osgi.service; objectClass:List<String>="org.osgi.service.log.admin.LoggerAdmin"; uses:="org.osgi.service.log.admin",

--- a/bundles/org.eclipse.osgi/osgi/src/org/osgi/util/tracker/AbstractTracked.java
+++ b/bundles/org.eclipse.osgi/osgi/src/org/osgi/util/tracker/AbstractTracked.java
@@ -1,18 +1,20 @@
-/*
- * Copyright (c) OSGi Alliance (2007, 2013). All Rights Reserved.
- * 
+/*******************************************************************************
+ * Copyright (c) Contributors to the Eclipse Foundation
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */
+ *
+ * SPDX-License-Identifier: Apache-2.0 
+ *******************************************************************************/
 
 package org.osgi.util.tracker;
 
@@ -34,7 +36,7 @@ import java.util.Map;
  * @param <T> The value mapped to the tracked item.
  * @param <R> The reason the tracked item is being tracked or untracked.
  * @ThreadSafe
- * @author $Id$
+ * @author $Id: 687685a4755f24def9382a8132fb0740323669fe $
  * @since 1.4
  */
 abstract class AbstractTracked<S, T, R> {

--- a/bundles/org.eclipse.osgi/osgi/src/org/osgi/util/tracker/BundleTracker.java
+++ b/bundles/org.eclipse.osgi/osgi/src/org/osgi/util/tracker/BundleTracker.java
@@ -1,18 +1,20 @@
-/*
- * Copyright (c) OSGi Alliance (2007, 2017). All Rights Reserved.
- * 
+/*******************************************************************************
+ * Copyright (c) Contributors to the Eclipse Foundation
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */
+ *
+ * SPDX-License-Identifier: Apache-2.0 
+ *******************************************************************************/
 
 package org.osgi.util.tracker;
 
@@ -46,7 +48,7 @@ import org.osgi.framework.SynchronousBundleListener;
  * 
  * @param <T> The type of the tracked object.
  * @ThreadSafe
- * @author $Id$
+ * @author $Id: 3682b0c1b257ec7c6760e9c4e5d62a3eda567451 $
  * @since 1.4
  */
 @ConsumerType

--- a/bundles/org.eclipse.osgi/osgi/src/org/osgi/util/tracker/BundleTrackerCustomizer.java
+++ b/bundles/org.eclipse.osgi/osgi/src/org/osgi/util/tracker/BundleTrackerCustomizer.java
@@ -1,18 +1,20 @@
-/*
- * Copyright (c) OSGi Alliance (2007, 2013). All Rights Reserved.
- * 
+/*******************************************************************************
+ * Copyright (c) Contributors to the Eclipse Foundation
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */
+ *
+ * SPDX-License-Identifier: Apache-2.0 
+ *******************************************************************************/
 
 package org.osgi.util.tracker;
 
@@ -43,7 +45,7 @@ import org.osgi.framework.BundleEvent;
  * 
  * @param <T> The type of the tracked object.
  * @ThreadSafe
- * @author $Id$
+ * @author $Id: f2733a974918984537676e30a7a96e7056244d98 $
  * @since 1.4
  */
 @ConsumerType

--- a/bundles/org.eclipse.osgi/osgi/src/org/osgi/util/tracker/ServiceTrackerCustomizer.java
+++ b/bundles/org.eclipse.osgi/osgi/src/org/osgi/util/tracker/ServiceTrackerCustomizer.java
@@ -1,18 +1,20 @@
-/*
- * Copyright (c) OSGi Alliance (2000, 2013). All Rights Reserved.
- * 
+/*******************************************************************************
+ * Copyright (c) Contributors to the Eclipse Foundation
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */
+ *
+ * SPDX-License-Identifier: Apache-2.0 
+ *******************************************************************************/
 
 package org.osgi.util.tracker;
 
@@ -46,7 +48,7 @@ import org.osgi.framework.ServiceReference;
  * @param <S> The type of the service being tracked.
  * @param <T> The type of the tracked object.
  * @ThreadSafe
- * @author $Id$
+ * @author $Id: 4617b2c5a0fba74a1a48db7188a3c946c672fefb $
  */
 @ConsumerType
 public interface ServiceTrackerCustomizer<S, T> {

--- a/bundles/org.eclipse.osgi/osgi/src/org/osgi/util/tracker/package-info.java
+++ b/bundles/org.eclipse.osgi/osgi/src/org/osgi/util/tracker/package-info.java
@@ -1,18 +1,20 @@
-/*
- * Copyright (c) OSGi Alliance (2010, 2020). All Rights Reserved.
- * 
+/*******************************************************************************
+ * Copyright (c) Contributors to the Eclipse Foundation
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */
+ *
+ * SPDX-License-Identifier: Apache-2.0 
+ *******************************************************************************/
 
 /**
  * Tracker Package Version 1.5.
@@ -26,10 +28,10 @@
  * <p>
  * {@code  Import-Package: org.osgi.util.tracker; version="[1.5,2.0)"}
  * 
- * @author $Id$
+ * @author $Id: 525c871316f48c75de552961b6e34b621bad047a $
  */
 
-@Version("1.5.3")
+@Version("1.5.4")
 package org.osgi.util.tracker;
 
 import org.osgi.annotation.versioning.Version;


### PR DESCRIPTION
As requested in https://github.com/eclipse-equinox/equinox/issues/18#issuecomment-1793367606 (altough this does not resolve the entire issue) update embedded org.osgi.util.tracker sources from 1.5.3 to 1.5.4.

@tjwatson I simply copied the java files from https://repo1.maven.org/maven2/org/osgi/org.osgi.util.tracker/1.5.4/org.osgi.util.tracker-1.5.4-sources.jar and replaced the existing sources with that.

But since this mainly changes license headers and SPDX-License-Identifier, I wonder if this is the right way?
Btw. to we need a CQ for this then (it is already Eclipse licensed and from another Eclipse project)?