### PR TITLE
Miscellaneous minor clean-ups in preference(-scope) implementations

### DIFF
--- a/bundles/org.eclipse.equinox.preferences/.settings/.api_filters
+++ b/bundles/org.eclipse.equinox.preferences/.settings/.api_filters
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<component id="org.eclipse.equinox.preferences" version="2">
+    <resource path="src/org/eclipse/core/runtime/preferences/BundleDefaultsScope.java" type="org.eclipse.core.runtime.preferences.BundleDefaultsScope">
+        <filter comment="Unncessary override deleted with same signature" id="338792546">
+            <message_arguments>
+                <message_argument value="org.eclipse.core.runtime.preferences.BundleDefaultsScope"/>
+                <message_argument value="getNode(String)"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="src/org/eclipse/core/runtime/preferences/ConfigurationScope.java" type="org.eclipse.core.runtime.preferences.ConfigurationScope">
+        <filter comment="Unncessary override deleted with same signature" id="338792546">
+            <message_arguments>
+                <message_argument value="org.eclipse.core.runtime.preferences.ConfigurationScope"/>
+                <message_argument value="getNode(String)"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="src/org/eclipse/core/runtime/preferences/DefaultScope.java" type="org.eclipse.core.runtime.preferences.DefaultScope">
+        <filter comment="Unncessary override deleted with same signature" id="338792546">
+            <message_arguments>
+                <message_argument value="org.eclipse.core.runtime.preferences.DefaultScope"/>
+                <message_argument value="getNode(String)"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="src/org/eclipse/core/runtime/preferences/InstanceScope.java" type="org.eclipse.core.runtime.preferences.InstanceScope">
+        <filter comment="Unncessary override deleted with same signature" id="338792546">
+            <message_arguments>
+                <message_argument value="org.eclipse.core.runtime.preferences.InstanceScope"/>
+                <message_argument value="getNode(String)"/>
+            </message_arguments>
+        </filter>
+    </resource>
+</component>

--- a/bundles/org.eclipse.equinox.preferences/src/org/eclipse/core/internal/preferences/AbstractScope.java
+++ b/bundles/org.eclipse.equinox.preferences/src/org/eclipse/core/internal/preferences/AbstractScope.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.core.internal.preferences;
 
-import org.eclipse.core.runtime.IPath;
+import java.util.Objects;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.core.runtime.preferences.IScopeContext;
 
@@ -24,9 +24,6 @@ import org.eclipse.core.runtime.preferences.IScopeContext;
  */
 public abstract class AbstractScope implements IScopeContext {
 
-	@Override
-	public abstract String getName();
-
 	/*
 	 * Default path hierarchy for nodes is /<scope>/<qualifier>.
 	 *
@@ -35,29 +32,24 @@ public abstract class AbstractScope implements IScopeContext {
 	 */
 	@Override
 	public IEclipsePreferences getNode(String qualifier) {
-		if (qualifier == null)
+		if (qualifier == null) {
 			throw new IllegalArgumentException();
+		}
 		return (IEclipsePreferences) PreferencesService.getDefault().getRootNode().node(getName()).node(qualifier);
 	}
 
 	@Override
-	public abstract IPath getLocation();
-
-	@Override
 	public boolean equals(Object obj) {
-		if (this == obj)
+		if (this == obj) {
 			return true;
-		if (!(obj instanceof IScopeContext))
-			return false;
-		IScopeContext other = (IScopeContext) obj;
-		if (!getName().equals(other.getName()))
-			return false;
-		IPath location = getLocation();
-		return location == null ? other.getLocation() == null : location.equals(other.getLocation());
+		}
+		return obj instanceof IScopeContext other //
+				&& getName().equals(other.getName()) //
+				&& Objects.equals(getLocation(), other.getLocation());
 	}
 
 	@Override
 	public int hashCode() {
-		return getName().hashCode();
+		return Objects.hash(getName(), getLocation());
 	}
 }

--- a/bundles/org.eclipse.equinox.preferences/src/org/eclipse/core/internal/preferences/RootPreferences.java
+++ b/bundles/org.eclipse.equinox.preferences/src/org/eclipse/core/internal/preferences/RootPreferences.java
@@ -13,7 +13,8 @@
  *******************************************************************************/
 package org.eclipse.core.internal.preferences;
 
-import org.eclipse.core.runtime.*;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.osgi.service.prefs.BackingStoreException;
 import org.osgi.service.prefs.Preferences;
@@ -55,8 +56,9 @@ public class RootPreferences extends EclipsePreferences {
 		Object value = children.get(key);
 		if (value == null)
 			return null;
-		if (value instanceof IEclipsePreferences)
-			return (IEclipsePreferences) value;
+		if (value instanceof IEclipsePreferences eclipsePreferences) {
+			return eclipsePreferences;
+		}
 		// lazy initialization
 		IEclipsePreferences child = PreferencesService.getDefault().createNode(key);
 		addChild(key, child);
@@ -65,11 +67,11 @@ public class RootPreferences extends EclipsePreferences {
 
 	protected synchronized IEclipsePreferences[] getChildren() {
 		// must perform lazy initialization of child nodes
-		String[] childNames = new String[0];
+		String[] childNames;
 		try {
 			childNames = childrenNames();
 		} catch (BackingStoreException e) {
-			log(new Status(IStatus.ERROR, Activator.PI_PREFERENCES, PrefsMessages.childrenNames, e));
+			log(Status.error(PrefsMessages.childrenNames, e));
 			return new IEclipsePreferences[0];
 		}
 		IEclipsePreferences[] childNodes = new IEclipsePreferences[childNames.length];

--- a/bundles/org.eclipse.equinox.preferences/src/org/eclipse/core/internal/preferences/ScopeDescriptor.java
+++ b/bundles/org.eclipse.equinox.preferences/src/org/eclipse/core/internal/preferences/ScopeDescriptor.java
@@ -137,18 +137,8 @@ public class ScopeDescriptor {
 	}
 
 	void removed(final String path) {
-		if (storage == null)
-			return;
-		SafeRunner.run(new ISafeRunnable() {
-			@Override
-			public void run() throws Exception {
-				storage.removed(path);
-			}
-
-			@Override
-			public void handleException(Throwable exception) {
-				// ignore here, error will be logged in saferunner
-			}
-		});
+		if (storage != null) {
+			SafeRunner.run(() -> storage.removed(path));
+		}
 	}
 }

--- a/bundles/org.eclipse.equinox.preferences/src/org/eclipse/core/runtime/preferences/BundleDefaultsScope.java
+++ b/bundles/org.eclipse.equinox.preferences/src/org/eclipse/core/runtime/preferences/BundleDefaultsScope.java
@@ -59,6 +59,7 @@ public final class BundleDefaultsScope extends AbstractScope {
 	 * 
 	 * @deprecated use <code>BundleDefaultsScope.INSTANCE</code> instead
 	 */
+	@Deprecated
 	public BundleDefaultsScope() {
 		super();
 	}
@@ -66,11 +67,6 @@ public final class BundleDefaultsScope extends AbstractScope {
 	@Override
 	public String getName() {
 		return SCOPE;
-	}
-
-	@Override
-	public IEclipsePreferences getNode(String qualifier) {
-		return super.getNode(qualifier);
 	}
 
 	@Override

--- a/bundles/org.eclipse.equinox.preferences/src/org/eclipse/core/runtime/preferences/ConfigurationScope.java
+++ b/bundles/org.eclipse.equinox.preferences/src/org/eclipse/core/runtime/preferences/ConfigurationScope.java
@@ -38,7 +38,7 @@ import org.eclipse.osgi.service.datalocation.Location;
  * <p>
  * This class is not intended to be subclassed. This class may be instantiated.
  * </p>
- * 
+ *
  * @see Location#CONFIGURATION_FILTER
  * @since 3.0
  */
@@ -60,9 +60,10 @@ public final class ConfigurationScope extends AbstractScope {
 
 	/**
 	 * Create and return a new configuration scope instance.
-	 * 
+	 *
 	 * @deprecated use <code>ConfigurationScope.INSTANCE</code> instead
 	 */
+	@Deprecated
 	public ConfigurationScope() {
 		super();
 	}
@@ -73,22 +74,17 @@ public final class ConfigurationScope extends AbstractScope {
 	}
 
 	@Override
-	public IEclipsePreferences getNode(String qualifier) {
-		return super.getNode(qualifier);
-	}
-
-	@Override
 	public IPath getLocation() {
-		IPath result = null;
 		Location location = PreferencesOSGiUtils.getDefault().getConfigurationLocation();
 		if (!location.isReadOnly()) {
 			URL url = location.getURL();
 			if (url != null) {
-				result = IPath.fromOSString(url.getFile());
-				if (result.isEmpty())
-					result = null;
+				IPath result = IPath.fromOSString(url.getFile());
+				if (!result.isEmpty()) {
+					return result;
+				}
 			}
 		}
-		return result;
+		return null;
 	}
 }

--- a/bundles/org.eclipse.equinox.preferences/src/org/eclipse/core/runtime/preferences/DefaultScope.java
+++ b/bundles/org.eclipse.equinox.preferences/src/org/eclipse/core/runtime/preferences/DefaultScope.java
@@ -63,6 +63,7 @@ public final class DefaultScope extends AbstractScope {
 	 * 
 	 * @deprecated use <code>DefaultScope.INSTANCE</code> instead
 	 */
+	@Deprecated
 	public DefaultScope() {
 		super();
 	}
@@ -70,11 +71,6 @@ public final class DefaultScope extends AbstractScope {
 	@Override
 	public String getName() {
 		return SCOPE;
-	}
-
-	@Override
-	public IEclipsePreferences getNode(String qualifier) {
-		return super.getNode(qualifier);
 	}
 
 	@Override

--- a/bundles/org.eclipse.equinox.preferences/src/org/eclipse/core/runtime/preferences/InstanceScope.java
+++ b/bundles/org.eclipse.equinox.preferences/src/org/eclipse/core/runtime/preferences/InstanceScope.java
@@ -34,7 +34,7 @@ import org.eclipse.osgi.service.datalocation.Location;
  * <p>
  * This class is not intended to be subclassed. This class may be instantiated.
  * </p>
- * 
+ *
  * @see Location#INSTANCE_FILTER
  * @since 3.0
  */
@@ -56,9 +56,10 @@ public final class InstanceScope extends AbstractScope {
 
 	/**
 	 * Create and return a new instance scope instance.
-	 * 
+	 *
 	 * @deprecated call <code>InstanceScope.INSTANCE</code> instead.
 	 */
+	@Deprecated
 	public InstanceScope() {
 		super();
 	}
@@ -73,10 +74,5 @@ public final class InstanceScope extends AbstractScope {
 	@Override
 	public String getName() {
 		return SCOPE;
-	}
-
-	@Override
-	public IEclipsePreferences getNode(String qualifier) {
-		return super.getNode(qualifier);
 	}
 }

--- a/bundles/org.eclipse.equinox.preferences/src/org/eclipse/core/runtime/preferences/OsgiPreferenceMetadataStore.java
+++ b/bundles/org.eclipse.equinox.preferences/src/org/eclipse/core/runtime/preferences/OsgiPreferenceMetadataStore.java
@@ -13,7 +13,8 @@
  *******************************************************************************/
 package org.eclipse.core.runtime.preferences;
 
-import java.util.*;
+import java.util.Objects;
+import java.util.Set;
 import org.eclipse.core.internal.preferences.PrefsMessages;
 import org.eclipse.osgi.util.NLS;
 
@@ -27,15 +28,14 @@ import org.eclipse.osgi.util.NLS;
  */
 public final class OsgiPreferenceMetadataStore implements IPreferenceMetadataStore {
 
-	private static final Set<Class<?>> CLASSES = Collections.unmodifiableSet(//
-			new HashSet<>(Arrays.asList(//
-					Boolean.class, //
-					byte[].class, //
-					Double.class, //
-					Float.class, //
-					Integer.class, //
-					Long.class, //
-					String.class)));
+	private static final Set<Class<?>> CLASSES = Set.of(//
+			Boolean.class, //
+			byte[].class, //
+			Double.class, //
+			Float.class, //
+			Integer.class, //
+			Long.class, //
+			String.class);
 
 	private final IEclipsePreferences preferences;
 
@@ -59,19 +59,19 @@ public final class OsgiPreferenceMetadataStore implements IPreferenceMetadataSto
 		String identifer = preference.identifer();
 		V defaultValue = preference.defaultValue();
 		if (String.class.equals(valueClass)) {
-			return valueClass.cast(preferences.get(identifer, String.class.cast(defaultValue)));
+			return valueClass.cast(preferences.get(identifer, (String) defaultValue));
 		} else if (Boolean.class.equals(valueClass)) {
-			return valueClass.cast(preferences.getBoolean(identifer, Boolean.class.cast(defaultValue)));
+			return valueClass.cast(preferences.getBoolean(identifer, (Boolean) defaultValue));
 		} else if (byte[].class.equals(valueClass)) {
-			return valueClass.cast(preferences.getByteArray(identifer, byte[].class.cast(defaultValue)));
+			return valueClass.cast(preferences.getByteArray(identifer, (byte[]) defaultValue));
 		} else if (Double.class.equals(valueClass)) {
-			return valueClass.cast(preferences.getDouble(identifer, Double.class.cast(defaultValue)));
+			return valueClass.cast(preferences.getDouble(identifer, (Double) defaultValue));
 		} else if (Float.class.equals(valueClass)) {
-			return valueClass.cast(preferences.getFloat(identifer, Float.class.cast(defaultValue)));
+			return valueClass.cast(preferences.getFloat(identifer, (Float) defaultValue));
 		} else if (Integer.class.equals(valueClass)) {
-			return valueClass.cast(preferences.getInt(identifer, Integer.class.cast(defaultValue)));
+			return valueClass.cast(preferences.getInt(identifer, (Integer) defaultValue));
 		} else if (Long.class.equals(valueClass)) {
-			return valueClass.cast(preferences.getLong(identifer, Long.class.cast(defaultValue)));
+			return valueClass.cast(preferences.getLong(identifer, (Long) defaultValue));
 		}
 		String message = PrefsMessages.PreferenceStorage_e_load_unsupported;
 		throw new UnsupportedOperationException(NLS.bind(message, preference, valueClass));
@@ -82,19 +82,19 @@ public final class OsgiPreferenceMetadataStore implements IPreferenceMetadataSto
 		Class<V> valueClass = preference.valueClass();
 		String identifer = preference.identifer();
 		if (String.class.equals(valueClass)) {
-			preferences.put(identifer, String.class.cast(value));
+			preferences.put(identifer, (String) value);
 		} else if (Boolean.class.equals(valueClass)) {
-			preferences.putBoolean(identifer, Boolean.class.cast(value));
+			preferences.putBoolean(identifer, (Boolean) value);
 		} else if (byte[].class.equals(valueClass)) {
-			preferences.putByteArray(identifer, byte[].class.cast(value));
+			preferences.putByteArray(identifer, (byte[]) value);
 		} else if (Double.class.equals(valueClass)) {
-			preferences.putDouble(identifer, Double.class.cast(value));
+			preferences.putDouble(identifer, (Double) value);
 		} else if (Float.class.equals(valueClass)) {
-			preferences.putFloat(identifer, Float.class.cast(value));
+			preferences.putFloat(identifer, (Float) value);
 		} else if (Integer.class.equals(valueClass)) {
-			preferences.putInt(identifer, Integer.class.cast(value));
+			preferences.putInt(identifer, (Integer) value);
 		} else if (Long.class.equals(valueClass)) {
-			preferences.putLong(identifer, Long.class.cast(value));
+			preferences.putLong(identifer, (Long) value);
 		} else {
 			String message = PrefsMessages.PreferenceStorage_e_save_unsupported;
 			throw new UnsupportedOperationException(NLS.bind(message, preference, valueClass));


### PR DESCRIPTION
- Make AbstractScope.hashCode() more efficient by also considering the location, which is also checked in equals().
- replace Collections.synchronizedMap(new HashMap<>()) by ConcurrentHashMap
- Use Status factories
- Leverage default implementation of ISafeRunnable.handleException()