### PR TITLE
Deprecate PluginVersionIdentifier for removal and start removal process

### DIFF
--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/PluginVersionIdentifier.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/PluginVersionIdentifier.java
@@ -60,7 +60,7 @@ import org.osgi.framework.Version;
  * @see java.lang.String#compareTo(java.lang.String)
  * @deprecated clients should use {@link org.osgi.framework.Version} instead
  */
-@Deprecated
+@Deprecated(forRemoval = true)
 public final class PluginVersionIdentifier {
 
 	private Version version;


### PR DESCRIPTION
Now that all references to `PluginVersionIdentifier` are removed in the Eclipse SDK (as far as I can tell) and `PluginVersionIdentifier` has been deprecated since 2015, I suggest to now deprecate it for removal so that we can remove it in two years.

@tjwatson if you and everyone else is fine with it I will also add a corresponding entry to the porting guide. 