### PR TITLE
SlicedProgressMonitor: fix canceled()

### DIFF
--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/SlicedProgressMonitor.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/SlicedProgressMonitor.java
@@ -86,6 +86,7 @@ public class SlicedProgressMonitor implements IProgressMonitor {
 
 	@Override
 	public void setCanceled(boolean value) {
+		monitor.setCanceled(value);
 		this.canceled = value;
 	}
 


### PR DESCRIPTION
as soon as is started using sliced() cancel test fails because cancel is not forwarded:

org.eclipse.ltk.core.refactoring.tests.participants.CancelingParticipantTests