### PR TITLE
Touch bundles affected by the changed ecj version

### DIFF
--- a/bundles/org.eclipse.equinox.app/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.app/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@
 Bug 403352 - Update all parent versions to match our build stream
 Bug 416896 - Some Equinox bundles need to be touched to get API descriptions back
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation #1139
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.equinox.bidi.tests/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.bidi.tests/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 # To force a version qualifier update add the bug here
 Bug 403352 - Update all parent versions to match our build stream
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation #1139
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.equinox.bidi/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.bidi/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 # To force a version qualifier update add the bug here
 Bug 403352 - Update all parent versions to match our build stream
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation #1139
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.equinox.cm/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.cm/forceQualifierUpdate.txt
@@ -1,4 +1,4 @@
 # To force a version qualifier update add the bug here
 Bug 403352 - Update all parent versions to match our build stream
 Bug 509973 - Comparator errors in I20170105-0320
-
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.equinox.common.tests/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.common.tests/forceQualifierUpdate.txt
@@ -1,1 +1,2 @@
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation #1139
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.equinox.common/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.common/forceQualifierUpdate.txt
@@ -4,3 +4,4 @@ Bug 462431 - New certificate conflict
 Bug 529356 - Build failure in I20180102-2215
 Bug 566471 - I20200828-0150 - Comparator Errors Found
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation #1139
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.equinox.console.ssh/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.console.ssh/forceQualifierUpdate.txt
@@ -3,3 +3,4 @@ Bug 403352 - Update all parent versions to match our build stream
 Bug 407707 - A number of .class files changed, after changing to M7 JDT compiler
 Bug 509973 - Comparator errors in I20170105-0320
 Bug 566471 - I20200828-0150 - Comparator Errors Found
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.equinox.ds.tests/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.ds.tests/forceQualifierUpdate.txt
@@ -1,2 +1,3 @@
 # To force a version qualifier update add the bug here
 Bug 403352 - Update all parent versions to match our build stream
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.equinox.event/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.event/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@
 Bug 403352 - Update all parent versions to match our build stream
 Bug 509973 - Comparator errors in I20170105-0320
 Force rebuild for proper capability metadata generated.
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.equinox.http.jetty/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.http.jetty/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %bundleName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.equinox.http.jetty
-Bundle-Version: 3.9.0.qualifier
+Bundle-Version: 3.9.100.qualifier
 Bundle-Activator: org.eclipse.equinox.http.jetty.internal.Activator
 Import-Package: javax.servlet;version="[3.1.0,5.0.0)",
  javax.servlet.http;version="[3.1.0,5.0.0)",

--- a/bundles/org.eclipse.equinox.http.jetty/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.http.jetty/forceQualifierUpdate.txt
@@ -1,1 +1,2 @@
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation #1139
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.equinox.http.registry/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.http.registry/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 # To force a version qualifier update add the bug here
 Bug 403352 - Update all parent versions to match our build stream
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation #1139
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.equinox.http.servlet.tests/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.http.servlet.tests/forceQualifierUpdate.txt
@@ -1,3 +1,3 @@
 # To force a version qualifier update add the bug here
 Bug 509973 - Comparator errors in I20170105-0320
-
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.equinox.http.servlet/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.http.servlet/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 # To force a version qualifier update add the bug here
 Bug 403352 - Update all parent versions to match our build stream
 Bug 509973 - Comparator errors in I20170105-0320
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.equinox.jsp.jasper/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.jsp.jasper/forceQualifierUpdate.txt
@@ -1,2 +1,3 @@
 # To force a version qualifier update add the bug here
 Bug 403352 - Update all parent versions to match our build stream
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.equinox.registry/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.registry/forceQualifierUpdate.txt
@@ -3,3 +3,4 @@ Bug 403352 - Update all parent versions to match our build stream
 Bug 462431 - New certificate conflict
 Bug 531640 - New certificate conflict
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation #1139
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.equinox.security.linux/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.security.linux/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %fragmentName
 Bundle-SymbolicName: org.eclipse.equinox.security.linux;singleton:=true
-Bundle-Version: 1.1.100.qualifier
+Bundle-Version: 1.1.200.qualifier
 Bundle-Vendor: %providerName
 Fragment-Host: org.eclipse.equinox.security;bundle-version="[1.0.0,2.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/bundles/org.eclipse.equinox.security.linux/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.security.linux/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 # To force a version qualifier update add the bug here
 
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation #1139
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.equinox.security.linux/pom.xml
+++ b/bundles/org.eclipse.equinox.security.linux/pom.xml
@@ -19,7 +19,7 @@
     <relativePath>../../</relativePath>
 </parent>
   <artifactId>org.eclipse.equinox.security.linux</artifactId>
-  <version>1.1.100-SNAPSHOT</version>
+  <version>1.1.200-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <build>

--- a/bundles/org.eclipse.equinox.security.tests/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.security.tests/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 # To force a version qualifier update add the bug here
 Bug 403352 - Update all parent versions to match our build stream
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation #1139
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.equinox.security.ui/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.security.ui/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@
 Bug 403352 - Update all parent versions to match our build stream
  -- Force update for luna
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation #1139
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.equinox.security/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.security/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 # To force a version qualifier update add the bug here
 Bug 403352 - Update all parent versions to match our build stream
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation #1139
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.equinox.servletbridge/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.servletbridge/forceQualifierUpdate.txt
@@ -1,2 +1,3 @@
 # To force a version qualifier update add the bug here
 Bug 403352 - Update all parent versions to match our build stream
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.equinox.transforms.hook/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.transforms.hook/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@
 Bug 403352 - Update all parent versions to match our build stream
  -- Force update for luna
 Bug 509973 - Comparator errors in I20170105-0320
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.equinox.transforms.xslt/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.transforms.xslt/forceQualifierUpdate.txt
@@ -1,2 +1,3 @@
 # To force a version qualifier update add the bug here
 Bug 403352 - Update all parent versions to match our build stream
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.equinox.useradmin/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.useradmin/forceQualifierUpdate.txt
@@ -1,2 +1,3 @@
 # To force a version qualifier update add the bug here
 Bug 403352 - Update all parent versions to match our build stream
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.equinox.weaving.caching.j9/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.weaving.caching.j9/forceQualifierUpdate.txt
@@ -1,2 +1,3 @@
 # To force a version qualifier update add the bug here
 Bug 403352 - Update all parent versions to match our build stream
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.equinox.weaving.caching/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.weaving.caching/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 # To force a version qualifier update add the bug here
 Bug 403352 - Update all parent versions to match our build stream
  -- Force update for luna
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.equinox.weaving.hook/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.weaving.hook/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 # To force a version qualifier update add the bug here
 Bug 403352 - Update all parent versions to match our build stream
  -- Force update for luna
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.osgi.tests/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.osgi.tests/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 # To force a version qualifier update add the bug here
 Bug 403352 - Update all parent versions to match our build stream
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation #1139
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659


### PR DESCRIPTION
See https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1394 
See https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659