### PR TITLE
Deprecate (and mark for removal) HttpContextExtensionService

### DIFF
--- a/bundles/org.eclipse.equinox.http.registry/src/org/eclipse/equinox/http/registry/HttpContextExtensionService.java
+++ b/bundles/org.eclipse.equinox.http.registry/src/org/eclipse/equinox/http/registry/HttpContextExtensionService.java
@@ -27,6 +27,7 @@ import org.osgi.service.http.HttpService;
  * @noimplement This interface is not intended to be implemented by clients.
  * @noextend This interface is not intended to be extended by clients.
  */
+@Deprecated(forRemoval = true)
 public interface HttpContextExtensionService {
 	/**
 	 * returns the HttpContext associated with the HttpService reference and http


### PR DESCRIPTION
The HttpContextExtensionService is effectively unused in platform and uses the abandoned HttpService it is API.

We therefore should deprecate and remove that so the org.eclipse.equinox.http.registry bundle becomes free from any API and only contains internal implementation what would make us free to change how it works,