### PR TITLE
Deprecate (and mark for removal) ExtendedHttpService

### DIFF
--- a/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/ExtendedHttpService.java
+++ b/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/ExtendedHttpService.java
@@ -25,6 +25,7 @@ import org.osgi.service.http.*;
  * @noimplement This interface is not intended to be implemented by clients.
  */
 @ProviderType
+@Deprecated(forRemoval = true)
 public interface ExtendedHttpService extends HttpService {
 
 	/**

--- a/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/HttpServiceMultipartServlet.java
+++ b/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/HttpServiceMultipartServlet.java
@@ -20,6 +20,7 @@ import javax.servlet.http.HttpServlet;
  * @deprecated No longer required.
  * @since 1.3
  */
+@Deprecated(forRemoval = true)
 public class HttpServiceMultipartServlet extends HttpServlet {
 	private static final long serialVersionUID = 2281118780429323631L;
 }


### PR DESCRIPTION
The ExtendedHttpService is effectively unused in platform and uses the abandoned HttpService it is API.

We therefore should deprecate and remove that to get rid of the dependency here a more modern replacement for the purpose of this extended form (registering filters) is today the [Http Whiteboard Specification](https://docs.osgi.org/specification/osgi.cmpn/7.0.0/service.http.whiteboard.html)