### PR TITLE
Fix the error that CoreExcepton is indirectly required

### DIFF
--- a/bundles/org.eclipse.equinox.region.tests/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.region.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Equinox Region Tests
 Bundle-SymbolicName: org.eclipse.equinox.region.tests
-Bundle-Version: 1.6.100.qualifier
+Bundle-Version: 1.6.200.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Import-Package: junit.framework;version="4.8.1",
  org.aspectj.internal.lang.annotation;version="[1.6.3,2.0.0)";resolution:=optional,
@@ -11,7 +11,8 @@ Import-Package: junit.framework;version="4.8.1",
  org.aspectj.lang.reflect;version="[1.6.3,2.0.0)";resolution:=optional,
  org.aspectj.runtime.internal;version="[1.6.3,2.0.0)";resolution:=optional,
  org.aspectj.runtime.reflect;version="[1.6.3,2.0.0)";resolution:=optional,
- org.eclipse.core.tests.harness;resolution:=optional,
+ org.eclipse.core.runtime;version="3.7.0",
+ org.eclipse.core.tests.harness,
  org.eclipse.equinox.region;version="1.1.0",
  org.eclipse.osgi.service.urlconversion;version="1.0.0",
  org.junit;version="4.8.1",


### PR DESCRIPTION
The org.eclipse.core.tests.harness.PerformanceTestRunner is not optional.