### PR TITLE
Migrate o.e.equinox.common.tests to JUnit 4

### DIFF
--- a/bundles/org.eclipse.equinox.common.tests/src/org/eclipse/equinox/common/tests/CoreExceptionTest.java
+++ b/bundles/org.eclipse.equinox.common.tests/src/org/eclipse/equinox/common/tests/CoreExceptionTest.java
@@ -13,25 +13,19 @@
  *******************************************************************************/
 package org.eclipse.equinox.common.tests;
 
-import org.eclipse.core.runtime.*;
-import org.eclipse.core.tests.harness.CoreTest;
+import static org.junit.Assert.assertEquals;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.junit.Test;
 
 /**
  * Test cases for the Path class.
  */
-public class CoreExceptionTest extends CoreTest {
-	/**
-	 * Need a zero argument constructor to satisfy the test harness. This
-	 * constructor should not do any real work nor should it be called by user code.
-	 */
-	public CoreExceptionTest() {
-		super(null);
-	}
+public class CoreExceptionTest {
 
-	public CoreExceptionTest(String name) {
-		super(name);
-	}
-
+	@Test
 	public void testCoreException() {
 		final String MESSAGE_STRING = "An exception has occurred";
 		IStatus status = new Status(IStatus.ERROR, "org.eclipse.core.tests.runtime", 31415, MESSAGE_STRING,

--- a/bundles/org.eclipse.equinox.common.tests/src/org/eclipse/equinox/common/tests/OperationCanceledExceptionTest.java
+++ b/bundles/org.eclipse.equinox.common.tests/src/org/eclipse/equinox/common/tests/OperationCanceledExceptionTest.java
@@ -13,25 +13,17 @@
  *******************************************************************************/
 package org.eclipse.equinox.common.tests;
 
+import static org.junit.Assert.assertEquals;
+
 import org.eclipse.core.runtime.OperationCanceledException;
-import org.eclipse.core.tests.harness.CoreTest;
+import org.junit.Test;
 
 /**
  * Test cases for the Path class.
  */
-public class OperationCanceledExceptionTest extends CoreTest {
-	/**
-	 * Need a zero argument constructor to satisfy the test harness. This
-	 * constructor should not do any real work nor should it be called by user code.
-	 */
-	public OperationCanceledExceptionTest() {
-		super(null);
-	}
+public class OperationCanceledExceptionTest {
 
-	public OperationCanceledExceptionTest(String name) {
-		super(name);
-	}
-
+	@Test
 	public void testCoreException() {
 		final String MESSAGE_STRING = "An exception has occurred";
 		OperationCanceledException e = new OperationCanceledException(MESSAGE_STRING);

--- a/bundles/org.eclipse.equinox.common.tests/src/org/eclipse/equinox/common/tests/PathTest.java
+++ b/bundles/org.eclipse.equinox.common.tests/src/org/eclipse/equinox/common/tests/PathTest.java
@@ -14,7 +14,13 @@
  *******************************************************************************/
 package org.eclipse.equinox.common.tests;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -22,24 +28,14 @@ import java.util.List;
 
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
-import org.eclipse.core.tests.harness.CoreTest;
+import org.junit.Test;
 
 /**
  * Test cases for the Path class.
  */
-public class PathTest extends CoreTest {
-	/**
-	 * Need a zero argument constructor to satisfy the test harness. This
-	 * constructor should not do any real work nor should it be called by user code.
-	 */
-	public PathTest() {
-		super(null);
-	}
+public class PathTest {
 
-	public PathTest(String name) {
-		super(name);
-	}
-
+	@Test
 	public void testAddTrailingSeparator() {
 
 		IPath with = new Path("/first/second/third/");
@@ -73,6 +69,7 @@ public class PathTest extends CoreTest {
 		assertEquals("6.1", IPath.ROOT, IPath.EMPTY.addTrailingSeparator());
 	}
 
+	@Test
 	public void testAppend() {
 
 		IPath fore = new Path("/first/second/third/");
@@ -237,6 +234,7 @@ public class PathTest extends CoreTest {
 		assertFalse("11.6.win", win4.isValidSegment(win4.segment(2)));
 	}
 
+	@Test
 	public void testSegmentCount() {
 
 		assertEquals("1.0", 0, IPath.ROOT.segmentCount());
@@ -255,6 +253,7 @@ public class PathTest extends CoreTest {
 		assertEquals("3.4", 2, new Path("//first/second/").segmentCount());
 	}
 
+	@Test
 	public void testCanonicalize() {
 		// Test collapsing multiple separators
 		// double slashes at the beginning of a path
@@ -281,6 +280,7 @@ public class PathTest extends CoreTest {
 		assertEquals("3.6", ".", new Path(".").toString());
 	}
 
+	@Test
 	public void testClone() {
 
 		IPath anyPath = new Path("/a/b/c");
@@ -293,6 +293,7 @@ public class PathTest extends CoreTest {
 		assertEquals("1.3", IPath.ROOT, IPath.ROOT.clone());
 	}
 
+	@Test
 	public void testConstructors() {
 
 		assertEquals("1.0", "", new Path("").toString());
@@ -319,6 +320,7 @@ public class PathTest extends CoreTest {
 		assertEquals("3.1.win", "D:/", IPath.forWindows("/D:/").toString());
 	}
 
+	@Test
 	public void testFactoryMethods() {
 
 		IPath win = IPath.forWindows("a:b\\c/d");
@@ -336,6 +338,7 @@ public class PathTest extends CoreTest {
 		assertNotEquals("3.1", win, posix);
 	}
 
+	@Test
 	public void testFirstSegment() {
 
 		assertNull("1.0", IPath.ROOT.segment(0));
@@ -355,6 +358,7 @@ public class PathTest extends CoreTest {
 
 	}
 
+	@Test
 	public void testFromOSString() {
 		List<String> segments = List.of("first", "first/second/third");
 		for (String segment : segments) {
@@ -370,6 +374,7 @@ public class PathTest extends CoreTest {
 		return new java.io.File(pathname).toString();
 	}
 
+	@Test
 	public void testFromPortableString() {
 		assertEquals("1.0", "", IPath.fromPortableString("").toString());
 		assertEquals("1.1", "/", IPath.fromPortableString("/").toString());
@@ -404,6 +409,7 @@ public class PathTest extends CoreTest {
 		assertEquals("3.12.posix", isLocalPosix, posix2.isValidSegment(":"));
 	}
 
+	@Test
 	public void testFromFile() {
 		List<String> segments = List.of("first", "first/second/third");
 		for (String segment : segments) {
@@ -418,6 +424,7 @@ public class PathTest extends CoreTest {
 		}
 	}
 
+	@Test
 	public void testFromPath() {
 		List<String> segments = List.of("first", "first/second/third");
 		for (String segment : segments) {
@@ -432,6 +439,7 @@ public class PathTest extends CoreTest {
 		}
 	}
 
+	@Test
 	public void testGetFileExtension() {
 
 		IPath anyPath = new Path("index.html");
@@ -450,6 +458,7 @@ public class PathTest extends CoreTest {
 
 	}
 
+	@Test
 	public void testHasTrailingSeparator() {
 
 		// positive
@@ -478,6 +487,7 @@ public class PathTest extends CoreTest {
 
 	}
 
+	@Test
 	public void testIsAbsolute() {
 
 		// positive
@@ -501,6 +511,7 @@ public class PathTest extends CoreTest {
 
 	}
 
+	@Test
 	public void testIsEmpty() {
 
 		// positive
@@ -518,6 +529,7 @@ public class PathTest extends CoreTest {
 		assertTrue("2.3", !new Path("c:/").isEmpty());
 	}
 
+	@Test
 	public void testIsPrefixOf() {
 
 		IPath prefix = new Path("/first/second");
@@ -536,6 +548,7 @@ public class PathTest extends CoreTest {
 		assertTrue("3.3", !path.isPrefixOf(IPath.EMPTY));
 	}
 
+	@Test
 	public void testIsRoot() {
 
 		// negative
@@ -551,6 +564,7 @@ public class PathTest extends CoreTest {
 		assertTrue("2.3.posix", IPath.forPosix("/").isRoot());
 	}
 
+	@Test
 	public void testIsUNC() {
 
 		// negative
@@ -581,6 +595,7 @@ public class PathTest extends CoreTest {
 		assertTrue("6.2.win", IPath.forWindows("c:\\\\").setDevice(null).isUNC());
 	}
 
+	@Test
 	public void testIsValidPath() {
 		IPath test = IPath.ROOT;
 		// positive
@@ -607,6 +622,7 @@ public class PathTest extends CoreTest {
 		assertTrue("3.4.posix", Path.isValidPosixPath("c:a/b:"));
 	}
 
+	@Test
 	public void testIsValidSegment() {
 		IPath test = IPath.ROOT;
 		// positive
@@ -635,6 +651,7 @@ public class PathTest extends CoreTest {
 		assertEquals("5.3", isLocalPosix, new Path("").isValidSegment(":"));
 	}
 
+	@Test
 	public void testLastSegment() {
 
 		assertEquals("1.0", "second", new Path("/first/second").lastSegment());
@@ -657,6 +674,7 @@ public class PathTest extends CoreTest {
 		assertEquals("5.1", "first", new Path("//first/").lastSegment());
 	}
 
+	@Test
 	public void testMakeAbsolute() {
 		IPath anyPath = new Path("first/second/third").makeAbsolute();
 		assertTrue("1.0", anyPath.isAbsolute());
@@ -667,6 +685,7 @@ public class PathTest extends CoreTest {
 		assertEquals("2.1", IPath.ROOT, anyPath);
 	}
 
+	@Test
 	public void testMakeRelative() {
 		IPath anyPath = new Path("/first/second/third").makeRelative();
 		assertTrue("1.0", !anyPath.isAbsolute());
@@ -680,6 +699,7 @@ public class PathTest extends CoreTest {
 	/**
 	 * Tests for {@link Path#makeRelativeTo(IPath)}.
 	 */
+	@Test
 	public void testMakeRelativeTo() {
 		// valid cases
 		IPath[] bases = new IPath[] { new Path("/a/"), new Path("/a/b") };
@@ -717,6 +737,7 @@ public class PathTest extends CoreTest {
 	/**
 	 * Tests for {@link Path#makeRelativeTo(IPath)}.
 	 */
+	@Test
 	public void testMakeRelativeToWindows() {
 		IPath[] bases = new IPath[] { IPath.forWindows("c:/a/"), IPath.forWindows("c:/a/b") };
 		IPath[] children = new IPath[] { IPath.forWindows("d:/a/"), IPath.forWindows("d:/a/b"),
@@ -733,6 +754,7 @@ public class PathTest extends CoreTest {
 
 	}
 
+	@Test
 	public void testMakeUNC() {
 		List<IPath> inputs = new ArrayList<>();
 		List<String> expected = new ArrayList<>();
@@ -815,6 +837,7 @@ public class PathTest extends CoreTest {
 	/**
 	 * This test is for bizarre cases that previously caused errors.
 	 */
+	@Test
 	public void testRegression() {
 		new Path("C:\\/eclipse");
 
@@ -824,6 +847,7 @@ public class PathTest extends CoreTest {
 		assertEquals("2.2.win", "ive", path.segment(0));
 	}
 
+	@Test
 	public void testRemoveFirstSegments() {
 		assertEquals("1.0", new Path("second"), new Path("/first/second").removeFirstSegments(1));
 		assertEquals("1.1", new Path("second/third/"), new Path("/first/second/third/").removeFirstSegments(1));
@@ -860,6 +884,7 @@ public class PathTest extends CoreTest {
 		assertEquals("3.6", new Path("third/fourth"), new Path("//first/second/third/fourth").removeFirstSegments(2));
 	}
 
+	@Test
 	public void testRemoveLastSegments() {
 
 		assertEquals("1.0", new Path("/first"), new Path("/first/second").removeLastSegments(1));
@@ -881,6 +906,7 @@ public class PathTest extends CoreTest {
 		assertEquals("4.2", new Path("//"), new Path("//").removeLastSegments(1));
 	}
 
+	@Test
 	public void testRemoveTrailingSeparator() {
 
 		IPath with = new Path("/first/second/third/");
@@ -914,6 +940,7 @@ public class PathTest extends CoreTest {
 		assertEquals("5.2", new Path("c:a/b"), new Path("c:a/b/").removeTrailingSeparator());
 	}
 
+	@Test
 	public void testSegments() {
 
 		IPath anyPath = null;
@@ -975,6 +1002,7 @@ public class PathTest extends CoreTest {
 		assertEquals("7.5", "c", segs[4]);
 	}
 
+	@Test
 	public void testToString() {
 
 		IPath anyPath = new Path("/first/second/third");
@@ -984,6 +1012,7 @@ public class PathTest extends CoreTest {
 		assertEquals("1.2", "", IPath.EMPTY.toString());
 	}
 
+	@Test
 	public void testHash() {
 		// actual hash codes may depend on JDK implementation of String.hashCode()
 
@@ -1008,6 +1037,7 @@ public class PathTest extends CoreTest {
 				new Path("p").addTrailingSeparator().hashCode());
 	}
 
+	@Test
 	public void testEquals() {
 		assertEquals("a", new Path("a"), new Path("a"));
 		assertEquals("b", new Path("a"), new Path("a"));
@@ -1031,6 +1061,7 @@ public class PathTest extends CoreTest {
 		assertNotEquals("leading\\ dependent", new Path("\\p"), new Path("p"));
 	}
 
+	@Test
 	public void testUptoSegment() {
 
 		// Case 1, absolute path with no trailing separator
@@ -1082,6 +1113,7 @@ public class PathTest extends CoreTest {
 		assertEquals("5.4", new Path("//"), anyPath.uptoSegment(0));
 	}
 
+	@Test
 	public void testToPath() {
 
 		// Case 1, absolute path with no trailing separator

--- a/bundles/org.eclipse.equinox.common.tests/src/org/eclipse/equinox/common/tests/PlatformLogWriterTest.java
+++ b/bundles/org.eclipse.equinox.common.tests/src/org/eclipse/equinox/common/tests/PlatformLogWriterTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.equinox.common.tests;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -23,14 +25,16 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.eclipse.core.internal.runtime.RuntimeLog;
 import org.eclipse.core.runtime.ILogListener;
 import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.tests.harness.CoreTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.service.log.LogService;
 import org.osgi.service.log.Logger;
 
-public class PlatformLogWriterTest extends CoreTest {
+public class PlatformLogWriterTest {
 
 	public static class TestILogListener implements ILogListener {
 		final AtomicReference<CountDownLatch> expected = new AtomicReference<>();
@@ -59,30 +63,23 @@ public class PlatformLogWriterTest extends CoreTest {
 		}
 	}
 
-	public PlatformLogWriterTest() {
-		super(null);
-	}
-
-	public PlatformLogWriterTest(String name) {
-		super(name);
-	}
-
 	LogService logService;
 	final TestILogListener listener = new TestILogListener();
 
-	@Override
-	protected void setUp() {
+	@Before
+	public void setUp() {
 		Bundle thisBundle = FrameworkUtil.getBundle(getClass());
 		BundleContext context = thisBundle.getBundleContext();
 		logService = context.getService(context.getServiceReference(LogService.class));
 		RuntimeLog.addLogListener(listener);
 	}
 
-	@Override
-	protected void tearDown() throws Exception {
+	@After
+	public void tearDown() throws Exception {
 		RuntimeLog.removeLogListener(listener);
 	}
 
+	@Test
 	public void testLogServiceLevels() throws InterruptedException {
 		listener.setExpected(6);
 		Logger logger = logService.getLogger("org.eclipse.equinox.logger");
@@ -100,7 +97,6 @@ public class PlatformLogWriterTest extends CoreTest {
 		assertStatus(allStatus.get(3), "info", IStatus.INFO);
 		assertStatus(allStatus.get(4), "debug", IStatus.OK);
 		assertStatus(allStatus.get(5), "trace", IStatus.OK);
-
 	}
 
 	private void assertStatus(IStatus status, String message, int severity) {

--- a/bundles/org.eclipse.equinox.common.tests/src/org/eclipse/equinox/common/tests/PluginVersionIdentifierTest.java
+++ b/bundles/org.eclipse.equinox.common.tests/src/org/eclipse/equinox/common/tests/PluginVersionIdentifierTest.java
@@ -13,20 +13,16 @@
  *******************************************************************************/
 package org.eclipse.equinox.common.tests;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import org.eclipse.core.runtime.PluginVersionIdentifier;
-import org.eclipse.core.tests.harness.CoreTest;
+import org.junit.Test;
 
 @Deprecated
-public class PluginVersionIdentifierTest extends CoreTest {
+public class PluginVersionIdentifierTest {
 
-	public PluginVersionIdentifierTest() {
-		super(null);
-	}
-
-	public PluginVersionIdentifierTest(String name) {
-		super(name);
-	}
-
+	@Test
 	public void testConstructor() {
 
 		assertEquals("1.0", "123.456.789", new PluginVersionIdentifier(123, 456, 789).toString());
@@ -49,6 +45,7 @@ public class PluginVersionIdentifierTest extends CoreTest {
 	}
 
 	// should test the hashcode() method that is currently missing.
+	@Test
 	public void testEqual() {
 
 		assertTrue("1.0",
@@ -57,6 +54,7 @@ public class PluginVersionIdentifierTest extends CoreTest {
 
 	}
 
+	@Test
 	public void testComparisons() {
 
 		PluginVersionIdentifier plugin1 = new PluginVersionIdentifier("1.896.456");
@@ -77,6 +75,7 @@ public class PluginVersionIdentifierTest extends CoreTest {
 
 	}
 
+	@Test
 	public void testValidate() {
 		// success cases
 		assertTrue("1.0", PluginVersionIdentifier.validateVersion("1").isOK());

--- a/bundles/org.eclipse.equinox.common.tests/src/org/eclipse/equinox/common/tests/ProgressMonitorWrapperTest.java
+++ b/bundles/org.eclipse.equinox.common.tests/src/org/eclipse/equinox/common/tests/ProgressMonitorWrapperTest.java
@@ -13,29 +13,24 @@
  *******************************************************************************/
 package org.eclipse.equinox.common.tests;
 
-import org.eclipse.core.runtime.*;
-import org.eclipse.core.tests.harness.CoreTest;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.ProgressMonitorWrapper;
+import org.eclipse.core.runtime.SubProgressMonitor;
+import org.junit.Test;
 
 /**
  * Test cases for the Path class.
  */
-public class ProgressMonitorWrapperTest extends CoreTest {
-	/**
-	 * Need a zero argument constructor to satisfy the test harness. This
-	 * constructor should not do any real work nor should it be called by user code.
-	 */
-	public ProgressMonitorWrapperTest() {
-		super(null);
-	}
-
-	public ProgressMonitorWrapperTest(String name) {
-		super(name);
-	}
+public class ProgressMonitorWrapperTest {
 
 	/**
 	 * @deprecated to suppress deprecation warnings
 	 */
 	@Deprecated
+	@Test
 	public void testProgressMonitorWrapper() {
 		NullProgressMonitor nullMonitor = new NullProgressMonitor();
 		SubProgressMonitor wrapped = new SubProgressMonitor(nullMonitor, 10);

--- a/bundles/org.eclipse.equinox.common.tests/src/org/eclipse/equinox/common/tests/QualifiedNameTest.java
+++ b/bundles/org.eclipse.equinox.common.tests/src/org/eclipse/equinox/common/tests/QualifiedNameTest.java
@@ -13,32 +13,21 @@
  *******************************************************************************/
 package org.eclipse.equinox.common.tests;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import org.eclipse.core.runtime.QualifiedName;
-import org.eclipse.core.tests.harness.CoreTest;
+import org.junit.Test;
 
 /**
  * Test cases for the QualifiedName class.
  */
 
-public class QualifiedNameTest extends CoreTest {
+public class QualifiedNameTest {
 
-	/**
-	 * Need a zero argument constructor to satisfy the test harness. This
-	 * constructor should not do any real work nor should it be called by user code.
-	 */
-	public QualifiedNameTest() {
-		super(null);
-	}
-
-	/**
-	 * Constructor for QualifiedNameTest
-	 */
-	public QualifiedNameTest(String name) {
-		super(name);
-	}
-
+	@Test
 	public void testQualifiers() {
 
 		try {
@@ -67,6 +56,7 @@ public class QualifiedNameTest extends CoreTest {
 
 	}
 
+	@Test
 	public void testLocalNames() {
 
 		try {
@@ -97,6 +87,7 @@ public class QualifiedNameTest extends CoreTest {
 
 	}
 
+	@Test
 	public void testEqualsAndHashcode() {
 
 		QualifiedName qN1 = new QualifiedName("org.eclipse.runtime", "myClass");

--- a/bundles/org.eclipse.equinox.common.tests/src/org/eclipse/equinox/common/tests/ServiceCallerTest.java
+++ b/bundles/org.eclipse.equinox.common.tests/src/org/eclipse/equinox/common/tests/ServiceCallerTest.java
@@ -14,7 +14,15 @@
 package org.eclipse.equinox.common.tests;
 
 import static java.util.Collections.singletonMap;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 import static org.osgi.framework.FrameworkUtil.asDictionary;
 
 import java.io.IOException;
@@ -27,7 +35,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.eclipse.core.runtime.ServiceCaller;
-import org.eclipse.core.tests.harness.CoreTest;
+import org.junit.Test;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.BundleException;
@@ -37,7 +45,7 @@ import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.framework.ServiceFactory;
 import org.osgi.framework.ServiceRegistration;
 
-public class ServiceCallerTest extends CoreTest {
+public class ServiceCallerTest {
 	static class ServiceExampleFactory implements ServiceFactory<IServiceExample> {
 		final Map<Bundle, AtomicInteger> createCount = new ConcurrentHashMap<>();
 		volatile ServiceExample lastCreated;
@@ -60,18 +68,7 @@ public class ServiceCallerTest extends CoreTest {
 		}
 	}
 
-	/**
-	 * Need a zero argument constructor to satisfy the test harness. This
-	 * constructor should not do any real work nor should it be called by user code.
-	 */
-	public ServiceCallerTest() {
-		super(null);
-	}
-
-	public ServiceCallerTest(String name) {
-		super(name);
-	}
-
+	@Test
 	public void testCallOnce() {
 		Bundle bundle = FrameworkUtil.getBundle(ServiceCallerTest.class);
 		assertNotNull("Test only works under an OSGi runtime", bundle);
@@ -106,6 +103,7 @@ public class ServiceCallerTest extends CoreTest {
 		}
 	}
 
+	@Test
 	public void testCall() throws IOException, BundleException, ClassNotFoundException {
 		Bundle bundle = FrameworkUtil.getBundle(ServiceCallerTest.class);
 		assertNotNull("Test only works under an OSGi runtime", bundle);
@@ -209,22 +207,20 @@ public class ServiceCallerTest extends CoreTest {
 		}
 	}
 
+	@Test
 	public void testInvalidFilter() {
-		try {
-			new ServiceCaller<>(getClass(), IServiceExample.class, "invalid filter");
-			fail("Expected an exception on invalid filter.");
-		} catch (IllegalArgumentException e) {
-			assertTrue("Unexpected cause.", e.getCause() instanceof InvalidSyntaxException);
-		}
-		try {
+		IllegalArgumentException exceptionOnConstructor = assertThrows(IllegalArgumentException.class,
+				() -> new ServiceCaller<>(getClass(), IServiceExample.class, "invalid filter"));
+		assertThat("Unexpected cause.", exceptionOnConstructor.getCause(), instanceOf(InvalidSyntaxException.class));
+
+		IllegalArgumentException exceptionOnCall = assertThrows(IllegalArgumentException.class, () -> {
 			ServiceCaller.callOnce(getClass(), IServiceExample.class, "invalid filter", (example) -> {
 			});
-			fail("Expected an exception on invalid filter.");
-		} catch (IllegalArgumentException e) {
-			assertTrue("Unexpected cause.", e.getCause() instanceof InvalidSyntaxException);
-		}
+		});
+		assertThat("Unexpected cause.", exceptionOnCall.getCause(), instanceOf(InvalidSyntaxException.class));
 	}
 
+	@Test
 	public void testRank() {
 		Bundle bundle = FrameworkUtil.getBundle(ServiceCallerTest.class);
 		assertNotNull("Test only works under an OSGi runtime", bundle);

--- a/bundles/org.eclipse.equinox.common.tests/src/org/eclipse/equinox/common/tests/StatusTest.java
+++ b/bundles/org.eclipse.equinox.common.tests/src/org/eclipse/equinox/common/tests/StatusTest.java
@@ -15,6 +15,9 @@
 package org.eclipse.equinox.common.tests;
 
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -31,13 +34,14 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.MultiStatus;
 import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.Status;
-import org.eclipse.core.tests.harness.CoreTest;
+import org.junit.Before;
+import org.junit.Test;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.BundleException;
 import org.osgi.framework.FrameworkUtil;
 
-public class StatusTest extends CoreTest {
+public class StatusTest {
 
 	private int status1Severity = IStatus.OK;
 	private String status1PluginId = "org.eclipse.core.tests.runtime";
@@ -62,16 +66,8 @@ public class StatusTest extends CoreTest {
 
 	private MultiStatus multistatus2;
 
-	public StatusTest() {
-		super(null);
-	}
-
-	public StatusTest(String name) {
-		super(name);
-	}
-
-	@Override
-	protected void setUp() {
+	@Before
+	public void setUp() {
 		status1 = new Status(status1Severity, status1PluginId, status1Code, status1Message, status1Exception);
 		status2 = new Status(status2Severity, status2PluginId, status2Code, status2Message, status2Exception);
 
@@ -82,6 +78,7 @@ public class StatusTest extends CoreTest {
 		multistatus2.add(status1);
 	}
 
+	@Test
 	public void testMultiStatusReturnValues() {
 		assertEquals("1.1", multistatus1PluginId, multistatus1.getPlugin());
 		assertEquals("1.2", multistatus1Code, multistatus1.getCode());
@@ -94,6 +91,7 @@ public class StatusTest extends CoreTest {
 		assertEquals("1.9", false, status1.matches(IStatus.ERROR | IStatus.WARNING | IStatus.INFO));
 	}
 
+	@Test
 	public void testSingleStatusReturnValues() {
 		assertEquals("1.0", status1Severity, status1.getSeverity());
 		assertEquals("1.1", status1PluginId, status1.getPlugin());
@@ -116,6 +114,7 @@ public class StatusTest extends CoreTest {
 		assertEquals("2.8", status2.matches(IStatus.ERROR), !status2.isOK());
 	}
 
+	@Test
 	public void testAdd() {
 
 		multistatus1.add(status1);
@@ -129,6 +128,7 @@ public class StatusTest extends CoreTest {
 
 	}
 
+	@Test
 	public void testSingleFromClass() throws ClassNotFoundException, IOException, BundleException {
 		assertEquals("org.eclipse.equinox.common.tests", new Status(IStatus.WARNING, StatusTest.class, "").getPlugin());
 		assertEquals("org.eclipse.equinox.common", new Status(IStatus.ERROR, IStatus.class, "", null).getPlugin());
@@ -138,6 +138,7 @@ public class StatusTest extends CoreTest {
 				new Status(IStatus.WARNING, installNoBSNBundle().loadClass(TestClass.class.getName()), "").getPlugin());
 	}
 
+	@Test
 	public void testMultiFromClass() throws ClassNotFoundException, IOException, BundleException {
 		assertEquals("org.eclipse.equinox.common", new MultiStatus(IStatus.class, 0, "").getPlugin());
 		assertEquals("org.eclipse.equinox.common.tests", new MultiStatus(StatusTest.class, 0, "").getPlugin());
@@ -170,6 +171,7 @@ public class StatusTest extends CoreTest {
 		return bc.installBundle(noNameBSNFile.toURI().toASCIIString());
 	}
 
+	@Test
 	public void testAddAll() {
 
 		multistatus1.add(status2);
@@ -199,6 +201,7 @@ public class StatusTest extends CoreTest {
 
 	}
 
+	@Test
 	public void testIsOK() {
 
 		assertTrue("1.0", multistatus2.isOK());
@@ -209,6 +212,7 @@ public class StatusTest extends CoreTest {
 
 	}
 
+	@Test
 	public void testMerge() {
 
 		multistatus1.merge(status2);
@@ -240,6 +244,7 @@ public class StatusTest extends CoreTest {
 
 	}
 
+	@Test
 	public void testInfo() {
 		IStatus info = Status.info("message");
 		assertEquals(IStatus.INFO, info.getSeverity());
@@ -250,6 +255,7 @@ public class StatusTest extends CoreTest {
 		assertArrayEquals(new IStatus[] {}, info.getChildren());
 	}
 
+	@Test
 	public void testWarning() {
 		IStatus warning = Status.warning("message");
 		assertEquals(IStatus.WARNING, warning.getSeverity());
@@ -260,6 +266,7 @@ public class StatusTest extends CoreTest {
 		assertArrayEquals(new IStatus[] {}, warning.getChildren());
 	}
 
+	@Test
 	public void testWarningWithException() {
 
 		Status warningWithException = Status.warning("message", new Exception("exception"));
@@ -271,6 +278,7 @@ public class StatusTest extends CoreTest {
 		assertArrayEquals(new IStatus[] {}, warningWithException.getChildren());
 	}
 
+	@Test
 	public void testError() {
 		IStatus error = Status.error("message");
 		assertEquals(IStatus.ERROR, error.getSeverity());
@@ -281,6 +289,7 @@ public class StatusTest extends CoreTest {
 		assertArrayEquals(new IStatus[] {}, error.getChildren());
 	}
 
+	@Test
 	public void testErrorWithException() {
 		IStatus errorWithException = Status.error("message", new Exception("exception"));
 		assertEquals(IStatus.ERROR, errorWithException.getSeverity());

--- a/bundles/org.eclipse.equinox.common.tests/src/org/eclipse/equinox/common/tests/URIUtilTest.java
+++ b/bundles/org.eclipse.equinox.common.tests/src/org/eclipse/equinox/common/tests/URIUtilTest.java
@@ -13,10 +13,14 @@
  *******************************************************************************/
 package org.eclipse.equinox.common.tests;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.File;
-import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -26,19 +30,20 @@ import java.net.URL;
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.URIUtil;
-import org.eclipse.core.tests.harness.CoreTest;
+import org.junit.Test;
 import org.osgi.framework.FrameworkUtil;
 
 /**
  * Tests for the {@link URIUtil} class.
  */
-public class URIUtilTest extends CoreTest {
+public class URIUtilTest {
 	/** Constant value indicating if the current platform is Windows */
 	private static final boolean WINDOWS = java.io.File.separatorChar == '\\';
 
 	private static final String[] testPaths = new String[] { "abc", "with spaces", "with%percent" };
 
 	// re-enable once bug 331314 is fixed
+	@Test
 	public void testBug331314() {
 		doTestBug331314("File with spaces");
 		doTestBug331314("FileWithBrackets[]");
@@ -57,34 +62,27 @@ public class URIUtilTest extends CoreTest {
 	/**
 	 * Tests for {@link URIUtil#toJarURI(URI, IPath)}.
 	 */
-	public void testToJARURI() {
+	@Test
+	public void testToJARURI() throws Exception {
 		URL locationURL = FileLocator.find(FrameworkUtil.getBundle(getClass()),
 				IPath.fromOSString("Plugin_Testing/uriutil/test.jar"), null);
-		try {
-			locationURL = FileLocator.resolve(locationURL);
-			URI location = URIUtil.toURI(locationURL);
-			final String suffix = "test/1029/test.txt";
-			URI jar = URIUtil.toJarURI(location, IPath.fromOSString(suffix));
-			InputStream is = jar.toURL().openStream();
-			is.close();
+		locationURL = FileLocator.resolve(locationURL);
+		URI location = URIUtil.toURI(locationURL);
+		final String suffix = "test/1029/test.txt";
+		URI jar = URIUtil.toJarURI(location, IPath.fromOSString(suffix));
+		InputStream is = jar.toURL().openStream();
+		is.close();
 
-			// null entry path
-			URI jar2 = URIUtil.toJarURI(location, null);
-			assertEquals("2.0", jar.toString(), jar2.toString() + suffix);
-
-		} catch (MalformedURLException e) {
-			fail("1.0", e);
-		} catch (IOException e) {
-			fail("1.1", e);
-		} catch (URISyntaxException e) {
-			fail("1.2", e);
-		}
+		// null entry path
+		URI jar2 = URIUtil.toJarURI(location, null);
+		assertEquals("2.0", jar.toString(), jar2.toString() + suffix);
 	}
 
 	/**
 	 * Tests for {@link URIUtil#toFile(URI)}.
 	 */
-	public void testToFile() throws URISyntaxException {
+	@Test
+	public void testToFile() {
 		File base = new File(System.getProperty("java.io.tmpdir"));
 		for (int i = 0; i < testPaths.length; i++) {
 			File original = new File(base, testPaths[i]);
@@ -97,6 +95,7 @@ public class URIUtilTest extends CoreTest {
 	/**
 	 * Tests for {@link URIUtil#toFile(URI)} involving UNC paths.
 	 */
+	@Test
 	public void testToFileUNC() throws URISyntaxException {
 		if (!WINDOWS) {
 			return;
@@ -115,6 +114,7 @@ public class URIUtilTest extends CoreTest {
 	/**
 	 * Tests for {@link URIUtil#toUnencodedString(URI)}.
 	 */
+	@Test
 	public void testToUnencodedString() throws URISyntaxException {
 		assertEquals("1.0", "http://foo.bar", URIUtil.toUnencodedString(new URI("http://foo.bar")));
 		assertEquals("1.1", "http://foo.bar#fragment", URIUtil.toUnencodedString(new URI("http://foo.bar#fragment")));
@@ -131,6 +131,7 @@ public class URIUtilTest extends CoreTest {
 	/**
 	 * Tests for {@link URIUtil#fromString(String)}.
 	 */
+	@Test
 	public void testFromString() throws URISyntaxException {
 		// spaces
 		assertEquals("1.1", new URI("http://foo.bar/a%20b"), URIUtil.fromString("http://foo.bar/a b"));
@@ -172,6 +173,7 @@ public class URIUtilTest extends CoreTest {
 	/**
 	 * Tests for {@link URIUtil#toURI(java.net.URL)}.
 	 */
+	@Test
 	public void testURLtoURI() throws MalformedURLException, URISyntaxException {
 		// spaces
 		assertEquals("1.1", new URI("http://foo.bar/a%20b"), URIUtil.toURI(new URL("http://foo.bar/a b")));
@@ -188,6 +190,7 @@ public class URIUtilTest extends CoreTest {
 	/**
 	 * Tests for {@link URIUtil#toURL(java.net.URI)}.
 	 */
+	@Test
 	public void testURItoURL() throws MalformedURLException, URISyntaxException {
 		// spaces
 		assertEquals("1.1", new URL("http://foo.bar/a%20b"), URIUtil.toURL(new URI("http://foo.bar/a%20b")));
@@ -205,6 +208,7 @@ public class URIUtilTest extends CoreTest {
 	 * Tests handling of Absolute file system paths on Windows incorrectly encoded
 	 * as relative URIs (file:c:/tmp).
 	 */
+	@Test
 	public void testWindowsPathsFromURI() throws MalformedURLException, URISyntaxException {
 		if (!WINDOWS) {
 			return;
@@ -217,6 +221,7 @@ public class URIUtilTest extends CoreTest {
 	 * Tests handling of Absolute file system paths on Windows incorrectly encoded
 	 * as relative URIs (file:c:/tmp).
 	 */
+	@Test
 	public void testWindowsPathsFromString() throws URISyntaxException {
 		if (!WINDOWS) {
 			return;
@@ -229,6 +234,7 @@ public class URIUtilTest extends CoreTest {
 	 * Tests handling of conversion from a File with spaces to URL and File to URI
 	 * and equivalence of the resulting URI
 	 */
+	@Test
 	public void testFileWithSpaces() throws MalformedURLException, URISyntaxException {
 		File fileWithSpaces = new File("/c:/with spaces/goo");
 		URI correctURI = fileWithSpaces.toURI();
@@ -255,6 +261,7 @@ public class URIUtilTest extends CoreTest {
 	 * Tests handling of conversion from a File with spaces to URL and File to URI
 	 * and equivalence of the resulting URI
 	 */
+	@Test
 	public void testFileWithBrackets() throws MalformedURLException, URISyntaxException {
 		File fileWithSpaces = new File("/c:/with[brackets]/goo");
 		URI correctURI = fileWithSpaces.toURI();
@@ -280,6 +287,7 @@ public class URIUtilTest extends CoreTest {
 	/**
 	 * Tests for {@link URIUtil#append(URI, String)}.
 	 */
+	@Test
 	public void testAppend() throws URISyntaxException {
 		URI base = new URI("http://a.b.c/a%20b/");
 		URI result = URIUtil.append(base, "file.txt");
@@ -296,6 +304,7 @@ public class URIUtilTest extends CoreTest {
 	/**
 	 * Tests for {@link URIUtil#append(URI, String)} when dealing with UNC paths.
 	 */
+	@Test
 	public void testAppendUNC() throws URISyntaxException {
 		// UNC paths
 		URI base = new URI("file:////SERVER/some/path/");
@@ -309,6 +318,7 @@ public class URIUtilTest extends CoreTest {
 	 * Tests for {@link URIUtil#append(URI, String)} when dealing with paths
 	 * containing brackets.
 	 */
+	@Test
 	public void testAppendWithBrackets() throws URISyntaxException {
 		// append a simple string
 		URI base = new URI("http://example.com/base/");
@@ -341,6 +351,7 @@ public class URIUtilTest extends CoreTest {
 		// assertEquals("5.1", null, result.getPath());
 	}
 
+	@Test
 	public void testBug286339() throws URISyntaxException {
 
 		// single letter server path
@@ -352,6 +363,7 @@ public class URIUtilTest extends CoreTest {
 
 	}
 
+	@Test
 	public void testAppendWindows() throws URISyntaxException {
 		if (!WINDOWS) {
 			return;
@@ -374,6 +386,7 @@ public class URIUtilTest extends CoreTest {
 	 * Tests handling of conversion from a File with %20 to URL and File to URI and
 	 * equivalence of the resulting URI
 	 */
+	@Test
 	public void testFileWithPercent20() throws MalformedURLException, URISyntaxException {
 		File fileWithPercent20 = new File("/c:/with%20spaces/goo");
 		URI correctURI = fileWithPercent20.toURI();
@@ -387,27 +400,24 @@ public class URIUtilTest extends CoreTest {
 		assertNotSame("1.4", correctURI, URIUtil.fromString(fileURL.toString()));
 	}
 
-	public void testRemoveExtension() {
-		try {
-			URI uri1 = new URI("file:/foo/bar/zoo.txt");
-			assertEquals(new URI("file:/foo/bar/zoo"), URIUtil.removeFileExtension(uri1));
+	@Test
+	public void testRemoveExtension() throws URISyntaxException {
+		URI uri1 = new URI("file:/foo/bar/zoo.txt");
+		assertEquals(new URI("file:/foo/bar/zoo"), URIUtil.removeFileExtension(uri1));
 
-			URI uri2 = new URI("file:/foo/bar.zoo/foo.txt");
-			assertEquals(new URI("file:/foo/bar.zoo/foo"), URIUtil.removeFileExtension(uri2));
+		URI uri2 = new URI("file:/foo/bar.zoo/foo.txt");
+		assertEquals(new URI("file:/foo/bar.zoo/foo"), URIUtil.removeFileExtension(uri2));
 
-			URI uri3 = new URI("file:/foo/bar.zoo/foo");
-			assertEquals(new URI("file:/foo/bar.zoo/foo"), URIUtil.removeFileExtension(uri3));
+		URI uri3 = new URI("file:/foo/bar.zoo/foo");
+		assertEquals(new URI("file:/foo/bar.zoo/foo"), URIUtil.removeFileExtension(uri3));
 
-			URI uri4 = new URI(
-					"file:/C:/DOCUME~1/ADMINI~1/LOCALS~1/Temp/testRepo/plugins/org.junit_3.8.2.v200706111738.jar");
-			assertEquals(
-					new URI("file:/C:/DOCUME~1/ADMINI~1/LOCALS~1/Temp/testRepo/plugins/org.junit_3.8.2.v200706111738"),
-					URIUtil.removeFileExtension(uri4));
-		} catch (URISyntaxException e) {
-			fail("URI syntax exception", e);
-		}
+		URI uri4 = new URI(
+				"file:/C:/DOCUME~1/ADMINI~1/LOCALS~1/Temp/testRepo/plugins/org.junit_3.8.2.v200706111738.jar");
+		assertEquals(new URI("file:/C:/DOCUME~1/ADMINI~1/LOCALS~1/Temp/testRepo/plugins/org.junit_3.8.2.v200706111738"),
+				URIUtil.removeFileExtension(uri4));
 	}
 
+	@Test
 	public void testRemoveFileExtensionFromFile() {
 		String fileName = "/c:/some.dir/afile";
 		File testFileWithExtension = new File(fileName + ".extension");
@@ -418,6 +428,7 @@ public class URIUtilTest extends CoreTest {
 		assertEquals(correctURI, URIUtil.removeFileExtension(testFileWithOutExtension.toURI()));
 	}
 
+	@Test
 	public void testSameURI() throws URISyntaxException {
 		assertFalse("1.0", URIUtil.sameURI(new File("a").toURI(), URIUtil.fromString("file:a")));
 		assertFalse("1.1", URIUtil.sameURI(new URI("file:/a"), URIUtil.fromString("file:a")));
@@ -427,6 +438,7 @@ public class URIUtilTest extends CoreTest {
 		assertTrue("2.1", URIUtil.sameURI(new URI("file:/a%2Cb"), new URI("file:/a,b")));
 	}
 
+	@Test
 	public void testSameURIWindows() throws URISyntaxException {
 		if (!WINDOWS) {
 			return;
@@ -442,6 +454,7 @@ public class URIUtilTest extends CoreTest {
 		assertFalse("2.0", URIUtil.sameURI(new URI("file:/a/b"), new URI("file:/c:/a/b")));
 	}
 
+	@Test
 	public void testMakeAbsolute() throws URISyntaxException {
 		URI[][] data = new URI[][] {
 				// simple path
@@ -522,6 +535,7 @@ public class URIUtilTest extends CoreTest {
 	/**
 	 * Tests for {@link URIUtil#makeAbsolute(URI, URI)} involving UNC paths.
 	 */
+	@Test
 	public void testMakeAbsoluteUNC() throws URISyntaxException {
 		URI base = new URI("file:////SERVER/some/path/");
 		URI relative = new URI("plugins/javax.servlet_2.4.0.v200806031604.jar");
@@ -535,6 +549,7 @@ public class URIUtilTest extends CoreTest {
 
 	}
 
+	@Test
 	public void testMakeRelative() throws URISyntaxException {
 		URI[][] data = new URI[][] {
 				// simple path
@@ -591,6 +606,7 @@ public class URIUtilTest extends CoreTest {
 	/**
 	 * Test UNC-Paths containing a $.
 	 */
+	@Test
 	public void testDollar() throws URISyntaxException {
 		final var relative = "SomePath";
 		final String[] uris = {

--- a/bundles/org.eclipse.equinox.common.tests/src/org/eclipse/equinox/common/tests/URLTest.java
+++ b/bundles/org.eclipse.equinox.common.tests/src/org/eclipse/equinox/common/tests/URLTest.java
@@ -17,14 +17,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 
-import org.eclipse.core.tests.harness.CoreTest;
+import org.junit.Test;
 
-public class URLTest extends CoreTest {
+public class URLTest {
 
-	public URLTest(String name) {
-		super(name);
-	}
-
+	@Test
 	public void testPlatformPlugin() throws IOException {
 		URL url = new URL("platform:/plugin/org.eclipse.equinox.common.tests/test.xml");
 		InputStream is = url.openStream();


### PR DESCRIPTION
* Apply JUnit 4 annotations `@Test`, `@Before , `@After`
* Remove inheritance of `TestCase` and `CoreTest`
* Remove unnecessarily try-catch blocks by letting test method throw the exception or by applying `assertThrows()`

This makes `org.eclipse.equinox.common.tests` completely independent from JUnit 3 and particularly removes the dependency to `CoreTest` in that bundle (see eclipse-platform/eclipse.platform.releng.aggregator#1684)