### PR TITLE
Migrate debugoptions, hooks and resources in o.e.osgi.tests to JUnit 4

### DIFF
--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/debugoptions/DebugOptionsTestCase.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/debugoptions/DebugOptionsTestCase.java
@@ -14,6 +14,14 @@
 
 package org.eclipse.osgi.tests.debugoptions;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
@@ -35,17 +43,25 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.atomic.AtomicReference;
-import org.eclipse.core.tests.harness.CoreTest;
+import junit.framework.AssertionFailedError;
 import org.eclipse.osgi.internal.debug.FrameworkDebugOptions;
 import org.eclipse.osgi.internal.debug.FrameworkDebugTraceEntry;
 import org.eclipse.osgi.service.debug.DebugOptions;
 import org.eclipse.osgi.service.debug.DebugOptionsListener;
 import org.eclipse.osgi.service.debug.DebugTrace;
 import org.eclipse.osgi.tests.OSGiTestsActivator;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
 import org.osgi.framework.ServiceReference;
 import org.osgi.framework.ServiceRegistration;
 
-public class DebugOptionsTestCase extends CoreTest {
+public class DebugOptionsTestCase {
+
+	@Rule
+	public TestName testName = new TestName();
 
 	DebugOptions debugOptions;
 	ServiceReference ref;
@@ -63,7 +79,8 @@ public class DebugOptionsTestCase extends CoreTest {
 	}
 	private final static String TAB_CHARACTER = "\t"; //$NON-NLS-1$
 
-	protected void setUp() throws Exception {
+	@Before
+	public void setUp() throws Exception {
 		ref = OSGiTestsActivator.getContext().getServiceReference(DebugOptions.class.getName());
 		assertNotNull("DebugOptions service is not available", ref); //$NON-NLS-1$
 		debugOptions = (DebugOptions) OSGiTestsActivator.getContext().getService(ref);
@@ -74,7 +91,8 @@ public class DebugOptionsTestCase extends CoreTest {
 		reg = OSGiTestsActivator.getContext().registerService(DebugOptionsListener.class.getName(), listener, props);
 	}
 
-	protected void tearDown() throws Exception {
+	@After
+	public void tearDown() throws Exception {
 		if (debugOptions == null)
 			return;
 		debugOptions.setDebugEnabled(false);
@@ -84,6 +102,11 @@ public class DebugOptionsTestCase extends CoreTest {
 			reg.unregister();
 	}
 
+	private String getName() {
+		return testName.getMethodName();
+	}
+
+	@Test
 	public void testRegistration01() {
 		assertTrue("Listener did not get called", listener.gotCalled()); //$NON-NLS-1$
 	}
@@ -96,6 +119,7 @@ public class DebugOptionsTestCase extends CoreTest {
 	 * This test mimics the tracing framework to ensure that the correct class name and method name
 	 * are returned and written to the trace file.
 	 */
+	@Test
 	public void testTracingEntry01() {
 
 		String bundleName = OSGiTestsActivator.getBundle().getSymbolicName();
@@ -116,6 +140,7 @@ public class DebugOptionsTestCase extends CoreTest {
 	 * This test mimics the tracing framework to ensure that the correct class name and method name
 	 * are returned and written to the trace file.
 	 */
+	@Test
 	public void testTracingEntry02() {
 
 		String correctClassName = Runner1.class.getName();
@@ -141,6 +166,7 @@ public class DebugOptionsTestCase extends CoreTest {
 		}
 	}
 
+	@Test
 	public void testDyanmicEnablement01() {
 		if (debugOptions.isDebugEnabled())
 			return; // cannot test
@@ -155,6 +181,7 @@ public class DebugOptionsTestCase extends CoreTest {
 		assertNull("Found bad value: " + listener.getIncorrectValue(), listener.getIncorrectValue()); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testDyanmicEnablement02() {
 		if (debugOptions.isDebugEnabled())
 			return; // cannot test
@@ -169,6 +196,7 @@ public class DebugOptionsTestCase extends CoreTest {
 		assertNotNull("Should find bad value: " + listener.getIncorrectValue(), listener.getIncorrectValue()); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testDyanmicEnablement03() {
 		listener.clear();
 		if (debugOptions.isDebugEnabled())
@@ -209,6 +237,7 @@ public class DebugOptionsTestCase extends CoreTest {
 		anotherReg.unregister();
 	}
 
+	@Test
 	public void testDyanmicEnablement04() {
 		if (debugOptions.isDebugEnabled())
 			return; // cannot test
@@ -240,6 +269,7 @@ public class DebugOptionsTestCase extends CoreTest {
 
 	}
 
+	@Test
 	public void testBatchSetOptionsWhenEnabled() {
 
 		if (!debugOptions.isDebugEnabled()) {
@@ -305,6 +335,7 @@ public class DebugOptionsTestCase extends CoreTest {
 		assertEquals("The new option for key6 does not match the retrieved option when tracing is enabled", "ok6", actualValue);
 	}
 
+	@Test
 	public void testSetNullOptions() {
 
 		// make sure setOptions() doesn't like an empty Map
@@ -332,6 +363,7 @@ public class DebugOptionsTestCase extends CoreTest {
 		assertTrue("An exception was not thrown when calling setOption() with a null key", exceptionThrown);
 	}
 
+	@Test
 	public void testBatchSetOptionsWhenDisabled() {
 
 		// enable tracing initially.
@@ -406,6 +438,7 @@ public class DebugOptionsTestCase extends CoreTest {
 		// testing of options when tracing is re-enabled is done in testSetOptionsWhenDisabled so it is not needed here
 	}
 
+	@Test
 	public void testSetOptionsWhenDisabled() {
 
 		// enable tracing initially.
@@ -437,6 +470,7 @@ public class DebugOptionsTestCase extends CoreTest {
 		assertEquals("The value after re-enabling tracing is invalid.", "ok", actualValue);
 	}
 
+	@Test
 	public void testStringValues() {
 
 		if (!debugOptions.isDebugEnabled()) {
@@ -455,6 +489,7 @@ public class DebugOptionsTestCase extends CoreTest {
 		assertEquals("The 'default' value supplied was not returned when the key does not exist in the DebugOptions.", "default", actualValue);
 	}
 
+	@Test
 	public void testIntegerValues() {
 
 		if (!debugOptions.isDebugEnabled()) {
@@ -477,6 +512,7 @@ public class DebugOptionsTestCase extends CoreTest {
 		assertEquals("The 'default' value supplied was not returned when the key does not exist in the DebugOptions.", 0, actualValue);
 	}
 
+	@Test
 	public void testBooleanValues() {
 		if (!debugOptions.isDebugEnabled()) {
 			debugOptions.setDebugEnabled(true);
@@ -513,7 +549,8 @@ public class DebugOptionsTestCase extends CoreTest {
 	/**
 	 * Test all DebugTrace.trace*() API when verbose debugging is disabled
 	 */
-	public void testVerboseDebugging() {
+	@Test
+	public void testVerboseDebugging() throws IOException {
 
 		// TODO: Convert this back to {@link DebugOptions} once is/setVerbose becomes API
 		FrameworkDebugOptions fwDebugOptions = (FrameworkDebugOptions) debugOptions;
@@ -539,7 +576,7 @@ public class DebugOptionsTestCase extends CoreTest {
 			debugTrace.traceExit("/debug", "returnValue"); //$NON-NLS-1$ //$NON-NLS-2$
 			traceOutput = readTraceFile(traceFile); // Note: this call will also delete the trace file
 		} catch (InvalidTraceEntry invalidEx) {
-			fail("Failed 'DebugTrace.trace(option, message)' test as an invalid trace entry was found.  Actual Value: '" + invalidEx.getActualValue() + "'.", invalidEx); //$NON-NLS-1$ //$NON-NLS-2$
+			failWithInvalidTrace("DebugTrace.trace(option, message)", invalidEx);
 		}
 		// make sure all 3 entries exist
 		assertEquals("Wrong number of trace entries", 8, traceOutput.length); //$NON-NLS-1$
@@ -607,8 +644,9 @@ public class DebugOptionsTestCase extends CoreTest {
 
 	/**
 	 * test DebugTrace.trace(option, message);
-	*/
-	public void testTraceFile01() {
+	 */
+	@Test
+	public void testTraceFile01() throws IOException {
 
 		final File traceFile = OSGiTestsActivator.getContext().getDataFile(getName() + ".trace"); //$NON-NLS-1$
 		TestDebugTrace debugTrace = this.createDebugTrace(traceFile);
@@ -619,7 +657,7 @@ public class DebugOptionsTestCase extends CoreTest {
 			debugTrace.trace("/debug", "testing 3"); //$NON-NLS-1$ //$NON-NLS-2$
 			traceOutput = readTraceFile(traceFile); // Note: this call will also delete the trace file
 		} catch (InvalidTraceEntry invalidEx) {
-			fail("Failed 'DebugTrace.trace(option, message)' test as an invalid trace entry was found.  Actual Value: '" + invalidEx.getActualValue() + "'.", invalidEx); //$NON-NLS-1$ //$NON-NLS-2$
+			failWithInvalidTrace("DebugTrace.trace(option, message)", invalidEx);
 		}
 		assertEquals("Wrong number of trace entries", 2, traceOutput.length); //$NON-NLS-1$
 		assertEquals("Thread name is incorrect", Thread.currentThread().getName(), traceOutput[0].getThreadName()); //$NON-NLS-1$
@@ -644,7 +682,8 @@ public class DebugOptionsTestCase extends CoreTest {
 	/**
 	 * test DebugTrace.trace(option, message, Throwable)
 	 */
-	public void testTraceFile02() {
+	@Test
+	public void testTraceFile02() throws IOException {
 
 		final File traceFile = OSGiTestsActivator.getContext().getDataFile(getName() + ".trace"); //$NON-NLS-1$
 		TestDebugTrace debugTrace = this.createDebugTrace(traceFile);
@@ -658,7 +697,7 @@ public class DebugOptionsTestCase extends CoreTest {
 			debugTrace.trace("/debug", "testing 3", new Exception(exceptionMessage3)); //$NON-NLS-1$ //$NON-NLS-2$
 			traceOutput = readTraceFile(traceFile); // Note: this call will also delete the trace file
 		} catch (InvalidTraceEntry invalidEx) {
-			fail("Failed 'DebugTrace.trace(option, message, Throwable)' test as an invalid trace entry was found.  Actual Value: '" + invalidEx.getActualValue() + "'.", invalidEx); //$NON-NLS-1$ //$NON-NLS-2$
+			failWithInvalidTrace("DebugTrace.trace(option, message, Throwable)", invalidEx);
 		}
 
 		final StringBuilder expectedThrowableText1 = new StringBuilder("java.lang.Exception: "); //$NON-NLS-1$
@@ -734,8 +773,9 @@ public class DebugOptionsTestCase extends CoreTest {
 
 	/**
 	 * test DebugTrace.traceDumpStack(option)
-	*/
-	public void testTraceFile03() {
+	 */
+	@Test
+	public void testTraceFile03() throws IOException {
 
 		final File traceFile = OSGiTestsActivator.getContext().getDataFile(getName() + ".trace"); //$NON-NLS-1$
 		TestDebugTrace debugTrace = this.createDebugTrace(traceFile);
@@ -746,7 +786,7 @@ public class DebugOptionsTestCase extends CoreTest {
 			debugTrace.traceDumpStack("/debug"); //$NON-NLS-1$
 			traceOutput = readTraceFile(traceFile); // Note: this call will also delete the trace file
 		} catch (InvalidTraceEntry invalidEx) {
-			fail("Failed 'DebugTrace.traceDumpStack(option)' test as an invalid trace entry was found.  Actual Value: '" + invalidEx.getActualValue() + "'.", invalidEx); //$NON-NLS-1$ //$NON-NLS-2$
+			failWithInvalidTrace("DebugTrace.traceDumpStack(option)", invalidEx);
 		}
 		assertEquals("Wrong number of trace entries", 2, traceOutput.length); //$NON-NLS-1$
 		assertEquals("Thread name is incorrect", Thread.currentThread().getName(), traceOutput[0].getThreadName()); //$NON-NLS-1$
@@ -770,8 +810,9 @@ public class DebugOptionsTestCase extends CoreTest {
 
 	/**
 	 * test DebugTrace.traceEntry(option)
-	*/
-	public void testTraceFile04() {
+	 */
+	@Test
+	public void testTraceFile04() throws IOException {
 
 		final File traceFile = OSGiTestsActivator.getContext().getDataFile(getName() + ".trace"); //$NON-NLS-1$
 		TestDebugTrace debugTrace = this.createDebugTrace(traceFile);
@@ -782,7 +823,7 @@ public class DebugOptionsTestCase extends CoreTest {
 			debugTrace.traceEntry("/debug"); //$NON-NLS-1$
 			traceOutput = readTraceFile(traceFile); // Note: this call will also delete the trace file
 		} catch (InvalidTraceEntry invalidEx) {
-			fail("Failed 'DebugTrace.traceEntry(option)' test as an invalid trace entry was found.  Actual Value: '" + invalidEx.getActualValue() + "'.", invalidEx); //$NON-NLS-1$ //$NON-NLS-2$
+			failWithInvalidTrace("DebugTrace.traceEntry(option)", invalidEx);
 		}
 		assertEquals("Wrong number of trace entries", 2, traceOutput.length); //$NON-NLS-1$
 		assertEquals("Thread name is incorrect", Thread.currentThread().getName(), traceOutput[0].getThreadName()); //$NON-NLS-1$
@@ -807,7 +848,8 @@ public class DebugOptionsTestCase extends CoreTest {
 	/**
 	 * test DebugTrace.traceEntry(option, methodArgument)
 	 */
-	public void testTraceFile05() {
+	@Test
+	public void testTraceFile05() throws IOException {
 
 		final File traceFile = OSGiTestsActivator.getContext().getDataFile(getName() + ".trace"); //$NON-NLS-1$
 		TestDebugTrace debugTrace = this.createDebugTrace(traceFile);
@@ -818,7 +860,7 @@ public class DebugOptionsTestCase extends CoreTest {
 			debugTrace.traceEntry("/debug", new String("arg3")); //$NON-NLS-1$ //$NON-NLS-2$
 			traceOutput = readTraceFile(traceFile); // Note: this call will also delete the trace file
 		} catch (InvalidTraceEntry invalidEx) {
-			fail("Failed 'DebugTrace.traceEntry(option, methodArgument)' test as an invalid trace entry was found.  Actual Value: '" + invalidEx.getActualValue() + "'.", invalidEx); //$NON-NLS-1$ //$NON-NLS-2$
+			failWithInvalidTrace("DebugTrace.traceEntry(option, methodArgument)", invalidEx);
 		}
 		assertEquals("Wrong number of trace entries", 2, traceOutput.length); //$NON-NLS-1$
 		assertEquals("Thread name is incorrect", Thread.currentThread().getName(), traceOutput[0].getThreadName()); //$NON-NLS-1$
@@ -843,7 +885,8 @@ public class DebugOptionsTestCase extends CoreTest {
 	/**
 	 * test DebugTrace.traceEntry(option, methodArgument[])
 	 */
-	public void testTraceFile06() {
+	@Test
+	public void testTraceFile06() throws IOException {
 
 		final File traceFile = OSGiTestsActivator.getContext().getDataFile(getName() + ".trace"); //$NON-NLS-1$
 		TestDebugTrace debugTrace = this.createDebugTrace(traceFile);
@@ -854,7 +897,7 @@ public class DebugOptionsTestCase extends CoreTest {
 			debugTrace.traceEntry("/debug", new String[] {"arg5", "arg6"}); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 			traceOutput = readTraceFile(traceFile); // Note: this call will also delete the trace file
 		} catch (InvalidTraceEntry invalidEx) {
-			fail("Failed 'DebugTrace.traceEntry(option, methodArgument[])' test as an invalid trace entry was found.  Actual Value: '" + invalidEx.getActualValue() + "'.", invalidEx); //$NON-NLS-1$ //$NON-NLS-2$
+			failWithInvalidTrace("DebugTrace.traceEntry(option, methodArgument[])", invalidEx);
 		}
 		assertEquals("Wrong number of trace entries", 2, traceOutput.length); //$NON-NLS-1$
 		assertEquals("Thread name is incorrect", Thread.currentThread().getName(), traceOutput[0].getThreadName()); //$NON-NLS-1$
@@ -876,7 +919,8 @@ public class DebugOptionsTestCase extends CoreTest {
 		traceFile.delete();
 	}
 
-	public void testEntryExitWithBracesInArgs() throws InvalidTraceEntry {
+	@Test
+	public void testEntryExitWithBracesInArgs() throws InvalidTraceEntry, IOException {
 		FrameworkDebugOptions fwDebugOptions = (FrameworkDebugOptions) debugOptions;
 		final File traceFile = OSGiTestsActivator.getContext().getDataFile(getName() + ".trace"); //$NON-NLS-1$
 		TestDebugTrace debugTrace = this.createDebugTrace(traceFile);
@@ -918,8 +962,9 @@ public class DebugOptionsTestCase extends CoreTest {
 
 	/**
 	 * test DebugTrace.traceExit(option)
-	*/
-	public void testTraceFile07() {
+	 */
+	@Test
+	public void testTraceFile07() throws IOException {
 
 		final File traceFile = OSGiTestsActivator.getContext().getDataFile(getName() + ".trace"); //$NON-NLS-1$
 		TestDebugTrace debugTrace = this.createDebugTrace(traceFile);
@@ -930,7 +975,7 @@ public class DebugOptionsTestCase extends CoreTest {
 			debugTrace.traceExit("/debug"); //$NON-NLS-1$
 			traceOutput = readTraceFile(traceFile); // Note: this call will also delete the trace file
 		} catch (InvalidTraceEntry invalidEx) {
-			fail("Failed 'DebugTrace.traceExit(option)' test as an invalid trace entry was found.  Actual Value: '" + invalidEx.getActualValue() + "'.", invalidEx); //$NON-NLS-1$ //$NON-NLS-2$
+			failWithInvalidTrace("DebugTrace.traceExit(option)", invalidEx);
 		}
 		assertEquals("Wrong number of trace entries", 2, traceOutput.length); //$NON-NLS-1$
 		assertEquals("Thread name is incorrect", Thread.currentThread().getName(), traceOutput[0].getThreadName()); //$NON-NLS-1$
@@ -954,8 +999,9 @@ public class DebugOptionsTestCase extends CoreTest {
 
 	/**
 	 * test DebugTrace.traceExit(option, result)
-	*/
-	public void testTraceFile08() {
+	 */
+	@Test
+	public void testTraceFile08() throws IOException {
 
 		final File traceFile = OSGiTestsActivator.getContext().getDataFile(getName() + ".trace"); //$NON-NLS-1$
 		TestDebugTrace debugTrace = this.createDebugTrace(traceFile);
@@ -966,7 +1012,7 @@ public class DebugOptionsTestCase extends CoreTest {
 			debugTrace.traceExit("/debug", new String("returnValue3")); //$NON-NLS-1$ //$NON-NLS-2$
 			traceOutput = readTraceFile(traceFile); // Note: this call will also delete the trace file
 		} catch (InvalidTraceEntry invalidEx) {
-			fail("Failed 'DebugTrace.traceExit(option, result)' test as an invalid trace entry was found.  Actual Value: '" + invalidEx.getActualValue() + "'.", invalidEx); //$NON-NLS-1$ //$NON-NLS-2$
+			failWithInvalidTrace("DebugTrace.traceExit(option, result)", invalidEx);
 		}
 		assertEquals("Wrong number of trace entries", 2, traceOutput.length); //$NON-NLS-1$
 		assertEquals("Thread name is incorrect", Thread.currentThread().getName(), traceOutput[0].getThreadName()); //$NON-NLS-1$
@@ -989,9 +1035,11 @@ public class DebugOptionsTestCase extends CoreTest {
 	}
 
 	/**
-	 * tests DebugTrace.trace(option, message) where the 'option' and 'message contain a '|' character (the delimiter).
-	*/
-	public void testTraceFile09() {
+	 * tests DebugTrace.trace(option, message) where the 'option' and 'message
+	 * contain a '|' character (the delimiter).
+	 */
+	@Test
+	public void testTraceFile09() throws IOException {
 
 		final File traceFile = OSGiTestsActivator.getContext().getDataFile(getName() + ".trace"); //$NON-NLS-1$
 		TestDebugTrace debugTrace = this.createDebugTrace(traceFile);
@@ -1002,7 +1050,7 @@ public class DebugOptionsTestCase extends CoreTest {
 			debugTrace.trace("/debug|path", "|A message with | multiple || characters.|");
 			traceOutput = readTraceFile(traceFile); // Note: this call will also delete the trace file
 		} catch (InvalidTraceEntry invalidEx) {
-			fail("Failed 'DebugTrace.trace(option, message)' test as an invalid trace entry was found.  Actual Value: '" + invalidEx.getActualValue() + "'.", invalidEx); //$NON-NLS-1$ //$NON-NLS-2$
+			failWithInvalidTrace("DebugTrace.trace(option, message)", invalidEx);
 		}
 		assertEquals("Wrong number of entries", 2, traceOutput.length);
 		String optionPath = decodeString(traceOutput[0].getOptionPath());
@@ -1017,6 +1065,7 @@ public class DebugOptionsTestCase extends CoreTest {
 		traceFile.delete();
 	}
 
+	@Test
 	public void testTraceSystemOut() throws IOException {
 		PrintStream old = System.out;
 		File traceFile = OSGiTestsActivator.getContext().getDataFile(getName() + ".trace"); //$NON-NLS-1$
@@ -1046,7 +1095,7 @@ public class DebugOptionsTestCase extends CoreTest {
 		try {
 			traceOutput = readTraceFile(traceFile);
 		} catch (InvalidTraceEntry e) {
-			fail("Failed 'DebugTrace.trace(option, message)' test as an invalid trace entry was found.  Actual Value: '" + e.getActualValue() + "'.", e); //$NON-NLS-1$ //$NON-NLS-2$
+			failWithInvalidTrace("DebugTrace.trace(option, message)", e);
 		}
 		assertEquals("Wrong number of entries", 2, traceOutput.length);
 		String optionPath = decodeString(traceOutput[0].getOptionPath());
@@ -1073,7 +1122,7 @@ public class DebugOptionsTestCase extends CoreTest {
 		return tempBuffer.toString();
 	}
 
-	private TraceEntry[] readTraceFile(File traceFile) throws InvalidTraceEntry {
+	private TraceEntry[] readTraceFile(File traceFile) throws InvalidTraceEntry, IOException {
 
 		BufferedReader traceReader = null;
 		List traceEntries = new ArrayList();
@@ -1084,8 +1133,6 @@ public class DebugOptionsTestCase extends CoreTest {
 			while ((entry = this.readMessage(traceReader)) != null) {
 				traceEntries.add(entry);
 			}
-		} catch (IOException ex) {
-			fail("Failed to read trace file", ex); //$NON-NLS-1$
 		} finally {
 			if (traceReader != null) {
 				try {
@@ -1200,6 +1247,13 @@ public class DebugOptionsTestCase extends CoreTest {
 			}
 		}
 		return buffer.toString().trim();
+	}
+
+	private void failWithInvalidTrace(String methodSignature, InvalidTraceEntry invalidEx) {
+		AssertionFailedError error = new AssertionFailedError("Failed '" + methodSignature
+				+ "' test as an invalid trace entry was found.  Actual Value: '" + invalidEx.getActualValue() + "'.");
+		error.initCause(invalidEx);
+		throw error;
 	}
 
 	static public class TraceEntry {

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/hooks/framework/AbstractFrameworkHookTests.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/hooks/framework/AbstractFrameworkHookTests.java
@@ -14,6 +14,8 @@
 package org.eclipse.osgi.tests.hooks.framework;
 
 import static org.eclipse.osgi.tests.bundles.AbstractBundleTests.stop;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -24,17 +26,24 @@ import java.net.URLClassLoader;
 import java.util.Enumeration;
 import java.util.Map;
 import org.eclipse.core.runtime.adaptor.EclipseStarter;
-import org.eclipse.core.tests.harness.CoreTest;
 import org.eclipse.osgi.internal.hookregistry.HookRegistry;
 import org.eclipse.osgi.launch.EquinoxFactory;
 import org.eclipse.osgi.tests.OSGiTestsActivator;
 import org.eclipse.osgi.tests.bundles.BundleInstaller;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.TestName;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.connect.FrameworkUtilHelper;
 import org.osgi.framework.launch.Framework;
 import org.osgi.framework.launch.FrameworkFactory;
 
-public abstract class AbstractFrameworkHookTests extends CoreTest {
+public abstract class AbstractFrameworkHookTests {
+
+	@Rule
+	public TestName testName = new TestName();
+
 	protected static class BasicURLClassLoader extends URLClassLoader {
 		private volatile String testURL;
 
@@ -124,12 +133,14 @@ public abstract class AbstractFrameworkHookTests extends CoreTest {
 		return framework;
 	}
 
-	protected void setUp() throws Exception {
+	@Before
+	public void setUp() throws Exception {
 		setUpBundleInstaller();
 		setUpClassLoader();
 	}
 
-	protected void tearDown() throws Exception {
+	@After
+	public void tearDown() throws Exception {
 		bundleInstaller.shutdown();
 	}
 

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/hooks/framework/ActivatorOrderTest.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/hooks/framework/ActivatorOrderTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.osgi.tests.hooks.framework;
 
 import static org.eclipse.osgi.tests.bundles.AbstractBundleTests.stop;
+import static org.junit.Assert.assertEquals;
 
 import java.io.File;
 import java.net.URL;
@@ -23,6 +24,7 @@ import java.util.HashMap;
 import java.util.List;
 import org.eclipse.osgi.internal.hookregistry.HookRegistry;
 import org.eclipse.osgi.tests.OSGiTestsActivator;
+import org.junit.Test;
 import org.osgi.framework.Constants;
 import org.osgi.framework.launch.Framework;
 
@@ -35,12 +37,12 @@ public class ActivatorOrderTest extends AbstractFrameworkHookTests {
 	private static final String HOOK_CONFIGURATOR_CLASS3 = "org.eclipse.osgi.tests.hooks.framework.activator.a.TestHookConfigurator3";
 
 	@Override
-	protected void setUp() throws Exception {
+	public void setUp() throws Exception {
 		super.setUp();
 		String loc = bundleInstaller.getBundleLocation(HOOK_CONFIGURATOR_BUNDLE);
 		loc = loc.substring(loc.indexOf("file:"));
 		classLoader.addURL(new URL(loc));
-		File file = OSGiTestsActivator.getContext().getDataFile(getName());
+		File file = OSGiTestsActivator.getContext().getDataFile(testName.getMethodName());
 		HashMap<String, String> configuration = new HashMap<>();
 		configuration.put(Constants.FRAMEWORK_STORAGE, file.getAbsolutePath());
 		configuration.put(HookRegistry.PROP_HOOK_CONFIGURATORS, HOOK_CONFIGURATOR_CLASS1 + "," + HOOK_CONFIGURATOR_CLASS2 + "," + HOOK_CONFIGURATOR_CLASS3);
@@ -48,6 +50,7 @@ public class ActivatorOrderTest extends AbstractFrameworkHookTests {
 		framework = createFramework(configuration);
 	}
 
+	@Test
 	public void testActivatorOrder() throws Exception {
 		List<String> actualEvents = new ArrayList<>();
 		Class<?> clazz1 = classLoader.loadClass(HOOK_CONFIGURATOR_CLASS1);

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/hooks/framework/BundleFileWrapperFactoryHookTests.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/hooks/framework/BundleFileWrapperFactoryHookTests.java
@@ -14,6 +14,7 @@
 package org.eclipse.osgi.tests.hooks.framework;
 
 import static org.eclipse.osgi.tests.bundles.AbstractBundleTests.stopQuietly;
+import static org.junit.Assert.assertEquals;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -24,6 +25,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.eclipse.osgi.internal.hookregistry.HookRegistry;
 import org.eclipse.osgi.tests.OSGiTestsActivator;
+import org.junit.Test;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.Constants;
 import org.osgi.framework.launch.Framework;
@@ -38,13 +40,13 @@ public class BundleFileWrapperFactoryHookTests extends AbstractFrameworkHookTest
 	private String location;
 
 	@Override
-	protected void setUp() throws Exception {
+	public void setUp() throws Exception {
 		super.setUp();
 		String loc = bundleInstaller.getBundleLocation(HOOK_CONFIGURATOR_BUNDLE);
 		loc = loc.substring(loc.indexOf("file:"));
 		classLoader.addURL(new URL(loc));
 		location = bundleInstaller.getBundleLocation(TEST_BUNDLE);
-		File file = OSGiTestsActivator.getContext().getDataFile(getName());
+		File file = OSGiTestsActivator.getContext().getDataFile(testName.getMethodName());
 		configuration = new HashMap<>();
 		configuration.put(Constants.FRAMEWORK_STORAGE, file.getAbsolutePath());
 		configuration.put(HookRegistry.PROP_HOOK_CONFIGURATORS_INCLUDE, HOOK_CONFIGURATOR_CLASS);
@@ -52,7 +54,7 @@ public class BundleFileWrapperFactoryHookTests extends AbstractFrameworkHookTest
 	}
 
 	@Override
-	protected void tearDown() throws Exception {
+	public void tearDown() throws Exception {
 		stopQuietly(framework);
 		super.tearDown();
 	}
@@ -65,6 +67,7 @@ public class BundleFileWrapperFactoryHookTests extends AbstractFrameworkHookTest
 		return framework.getBundleContext().installBundle(location);
 	}
 
+	@Test
 	public void testGetResourceURL() throws Exception {
 		initAndStartFramework();
 
@@ -74,19 +77,15 @@ public class BundleFileWrapperFactoryHookTests extends AbstractFrameworkHookTest
 		assertEquals("Wrong content found.", "CUSTOM_CONTENT", readURL(url1));
 	}
 
-	private String readURL(URL url) {
+	private String readURL(URL url) throws IOException {
 		StringBuilder sb = new StringBuilder();
-		try {
-			try (BufferedReader reader = new BufferedReader(new InputStreamReader(url.openStream()))) {
-				for (String line = reader.readLine(); line != null;) {
-					sb.append(line);
-					line = reader.readLine();
-					if (line != null)
-						sb.append('\n');
-				}
+		try (BufferedReader reader = new BufferedReader(new InputStreamReader(url.openStream()))) {
+			for (String line = reader.readLine(); line != null;) {
+				sb.append(line);
+				line = reader.readLine();
+				if (line != null)
+					sb.append('\n');
 			}
-		} catch (IOException e) {
-			fail("Unexpected exception reading url: " + url.toExternalForm(), e); //$NON-NLS-1$
 		}
 		return sb.toString();
 	}

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/hooks/framework/ClassLoaderHookTests.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/hooks/framework/ClassLoaderHookTests.java
@@ -14,6 +14,10 @@
 package org.eclipse.osgi.tests.hooks.framework;
 
 import static org.eclipse.osgi.tests.bundles.AbstractBundleTests.stopQuietly;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.net.URL;
@@ -25,6 +29,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import org.eclipse.osgi.internal.hookregistry.HookRegistry;
 import org.eclipse.osgi.tests.OSGiTestsActivator;
+import org.junit.Test;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.Constants;
 import org.osgi.framework.FrameworkEvent;
@@ -53,7 +58,7 @@ public class ClassLoaderHookTests extends AbstractFrameworkHookTests {
 	private String location;
 
 	@Override
-	protected void setUp() throws Exception {
+	public void setUp() throws Exception {
 		super.setUp();
 		setRejectTransformation(false);
 		setBadTransform(false);
@@ -66,7 +71,7 @@ public class ClassLoaderHookTests extends AbstractFrameworkHookTests {
 		loc = loc.substring(loc.indexOf("file:"));
 		classLoader.addURL(new URL(loc));
 		location = bundleInstaller.getBundleLocation(TEST_BUNDLE);
-		File file = OSGiTestsActivator.getContext().getDataFile(getName());
+		File file = OSGiTestsActivator.getContext().getDataFile(testName.getMethodName());
 		configuration = new HashMap<>();
 		configuration.put(Constants.FRAMEWORK_STORAGE, file.getAbsolutePath());
 		configuration.put(HookRegistry.PROP_HOOK_CONFIGURATORS_INCLUDE, HOOK_CONFIGURATOR_CLASS);
@@ -74,7 +79,7 @@ public class ClassLoaderHookTests extends AbstractFrameworkHookTests {
 	}
 
 	@Override
-	protected void tearDown() throws Exception {
+	public void tearDown() throws Exception {
 		stopQuietly(framework);
 		super.tearDown();
 	}
@@ -115,6 +120,7 @@ public class ClassLoaderHookTests extends AbstractFrameworkHookTests {
 		System.setProperty(PREVENT_RESOURCE_LOAD_POST, Boolean.toString(value));
 	}
 
+	@Test
 	public void testRejectTransformationFromWeavingHook() throws Exception {
 		setRejectTransformation(true);
 		initAndStartFramework();
@@ -142,6 +148,7 @@ public class ClassLoaderHookTests extends AbstractFrameworkHookTests {
 		assertEquals("Found some imports.", 1, b.adapt(BundleRevision.class).getWiring().getRequirements(PackageNamespace.PACKAGE_NAMESPACE).size());
 	}
 
+	@Test
 	public void testRejectTransformationFromClassLoadingHook() throws Exception {
 		setRejectTransformation(true);
 		setBadTransform(true);
@@ -160,6 +167,7 @@ public class ClassLoaderHookTests extends AbstractFrameworkHookTests {
 		}
 	}
 
+	@Test
 	public void testRecursionFromClassLoadingHookNotSupported() throws Exception {
 		setRecursionLoad(true);
 		initAndStartFramework();
@@ -167,6 +175,7 @@ public class ClassLoaderHookTests extends AbstractFrameworkHookTests {
 		b.loadClass(TEST_CLASSNAME);
 	}
 
+	@Test
 	public void testRecursionFromClassLoadingHookIsSupported() throws Exception {
 		setRecursionLoad(true);
 		setRecursionLoadSupported(true);
@@ -185,6 +194,7 @@ public class ClassLoaderHookTests extends AbstractFrameworkHookTests {
 		refreshSignal.await(30, TimeUnit.SECONDS);
 	}
 
+	@Test
 	public void testFilterClassPaths() throws Exception {
 		setFilterClassPaths(false);
 		initAndStartFramework();
@@ -201,6 +211,7 @@ public class ClassLoaderHookTests extends AbstractFrameworkHookTests {
 		}
 	}
 
+	@Test
 	public void testPreventResourceLoadFromClassLoadingHook() throws Exception {
 		setPreventResourceLoadPre(false);
 		setPreventResourceLoadPost(false);

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/hooks/framework/ContextFinderTests.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/hooks/framework/ContextFinderTests.java
@@ -14,6 +14,8 @@
 package org.eclipse.osgi.tests.hooks.framework;
 
 import static org.eclipse.osgi.tests.bundles.AbstractBundleTests.stopQuietly;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 
 import java.io.File;
 import java.io.IOException;
@@ -22,6 +24,7 @@ import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
 import org.eclipse.osgi.tests.OSGiTestsActivator;
+import org.junit.Test;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.Constants;
 import org.osgi.framework.InvalidSyntaxException;
@@ -33,9 +36,9 @@ public class ContextFinderTests extends AbstractFrameworkHookTests {
 	private Framework framework;
 
 	@Override
-	protected void setUp() throws Exception {
+	public void setUp() throws Exception {
 		super.setUp();
-		File file = OSGiTestsActivator.getContext().getDataFile(getName());
+		File file = OSGiTestsActivator.getContext().getDataFile(testName.getMethodName());
 		configuration = new HashMap<>();
 		configuration.put(Constants.FRAMEWORK_STORAGE, file.getAbsolutePath());
 		framework = createFramework(configuration);
@@ -43,11 +46,12 @@ public class ContextFinderTests extends AbstractFrameworkHookTests {
 	}
 
 	@Override
-	protected void tearDown() throws Exception {
+	public void tearDown() throws Exception {
 		stopQuietly(framework);
 		super.tearDown();
 	}
 
+	@Test
 	public void testContextClassLoaderNullLocal() throws InvalidSyntaxException, IOException {
 		BundleContext bc = framework.getBundleContext();
 		ClassLoader contextFinder = bc.getService(bc.getServiceReferences(ClassLoader.class, "(equinox.classloader.type=contextClassLoader)").iterator().next());

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/hooks/framework/DevClassPathDuplicateTests.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/hooks/framework/DevClassPathDuplicateTests.java
@@ -14,6 +14,8 @@
 package org.eclipse.osgi.tests.hooks.framework;
 
 import static org.eclipse.osgi.tests.bundles.AbstractBundleTests.stopQuietly;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 import java.io.File;
 import java.net.URL;
@@ -23,6 +25,7 @@ import java.util.Map;
 import org.eclipse.osgi.internal.framework.EquinoxConfiguration;
 import org.eclipse.osgi.tests.OSGiTestsActivator;
 import org.eclipse.osgi.tests.bundles.SystemBundleTests;
+import org.junit.Test;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.Constants;
 import org.osgi.framework.launch.Framework;
@@ -33,9 +36,9 @@ public class DevClassPathDuplicateTests extends AbstractFrameworkHookTests {
 	private String location;
 
 	@Override
-	protected void setUp() throws Exception {
+	public void setUp() throws Exception {
 		super.setUp();
-		File store = OSGiTestsActivator.getContext().getDataFile(getName());
+		File store = OSGiTestsActivator.getContext().getDataFile(testName.getMethodName());
 		configuration = new HashMap<>();
 		configuration.put(Constants.FRAMEWORK_STORAGE, store.getAbsolutePath());
 		configuration.put(EquinoxConfiguration.PROP_DEV, "duplicate/");
@@ -53,7 +56,7 @@ public class DevClassPathDuplicateTests extends AbstractFrameworkHookTests {
 	}
 
 	@Override
-	protected void tearDown() throws Exception {
+	public void tearDown() throws Exception {
 		stopQuietly(framework);
 		super.tearDown();
 	}
@@ -66,6 +69,7 @@ public class DevClassPathDuplicateTests extends AbstractFrameworkHookTests {
 		return framework.getBundleContext().installBundle(location);
 	}
 
+	@Test
 	public void testDevClassPathWithExtension() throws Exception {
 		initAndStartFramework();
 

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/hooks/framework/DevClassPathWithExtensionTests.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/hooks/framework/DevClassPathWithExtensionTests.java
@@ -15,6 +15,7 @@ package org.eclipse.osgi.tests.hooks.framework;
 
 import static org.eclipse.osgi.tests.bundles.AbstractBundleTests.stop;
 import static org.eclipse.osgi.tests.bundles.AbstractBundleTests.stopQuietly;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.util.Collection;
@@ -23,6 +24,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.eclipse.osgi.internal.framework.EquinoxConfiguration;
 import org.eclipse.osgi.tests.OSGiTestsActivator;
+import org.junit.Test;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.Constants;
 import org.osgi.framework.launch.Framework;
@@ -36,10 +38,10 @@ public class DevClassPathWithExtensionTests extends AbstractFrameworkHookTests {
 	private String location;
 
 	@Override
-	protected void setUp() throws Exception {
+	public void setUp() throws Exception {
 		super.setUp();
 		location = bundleInstaller.getBundleLocation(TEST_BUNDLE);
-		File file = OSGiTestsActivator.getContext().getDataFile(getName());
+		File file = OSGiTestsActivator.getContext().getDataFile(testName.getMethodName());
 		configuration = new HashMap<>();
 		configuration.put(Constants.FRAMEWORK_STORAGE, file.getAbsolutePath());
 		configuration.put(EquinoxConfiguration.PROP_DEV, "bin/");
@@ -47,7 +49,7 @@ public class DevClassPathWithExtensionTests extends AbstractFrameworkHookTests {
 	}
 
 	@Override
-	protected void tearDown() throws Exception {
+	public void tearDown() throws Exception {
 		stopQuietly(framework);
 		super.tearDown();
 	}
@@ -60,6 +62,7 @@ public class DevClassPathWithExtensionTests extends AbstractFrameworkHookTests {
 		return framework.getBundleContext().installBundle(location);
 	}
 
+	@Test
 	public void testDevClassPathWithExtension() throws Exception {
 		initAndStartFramework();
 

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/hooks/framework/EmbeddedEquinoxWithURLInClassLoadTests.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/hooks/framework/EmbeddedEquinoxWithURLInClassLoadTests.java
@@ -14,6 +14,7 @@
 package org.eclipse.osgi.tests.hooks.framework;
 
 import static org.eclipse.osgi.tests.bundles.AbstractBundleTests.stopQuietly;
+import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.net.MalformedURLException;
@@ -21,6 +22,7 @@ import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 import org.eclipse.osgi.tests.OSGiTestsActivator;
+import org.junit.Test;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.Constants;
 import org.osgi.framework.launch.Framework;
@@ -30,18 +32,18 @@ public class EmbeddedEquinoxWithURLInClassLoadTests extends AbstractFrameworkHoo
 	private Framework framework;
 
 	@Override
-	protected void setUp() throws Exception {
+	public void setUp() throws Exception {
 		URL myManifest = getClass().getResource("/META-INF/MANIFEST.MF");
 		testURL = myManifest.toExternalForm();
 		super.setUp();
-		File file = OSGiTestsActivator.getContext().getDataFile(getName());
+		File file = OSGiTestsActivator.getContext().getDataFile(testName.getMethodName());
 		Map<String, String> configuration = new HashMap<>();
 		configuration.put(Constants.FRAMEWORK_STORAGE, file.getAbsolutePath());
 		framework = createFramework(configuration);
 	}
 
 	@Override
-	protected void tearDown() throws Exception {
+	public void tearDown() throws Exception {
 		stopQuietly(framework);
 		super.tearDown();
 	}
@@ -50,10 +52,12 @@ public class EmbeddedEquinoxWithURLInClassLoadTests extends AbstractFrameworkHoo
 		initAndStart(framework);
 	}
 
+	@Test
 	public void testFrameworkClassLoaderWithNewURI() throws Exception {
 		initAndStartFramework();
 	}
 
+	@Test
 	public void testEmbeddedURLHandler() throws Exception {
 		initAndStart(framework);
 		Bundle testHandler = framework.getBundleContext().installBundle(bundleInstaller.getBundleLocation("test.protocol.handler"));

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/hooks/framework/StorageHookTests.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/hooks/framework/StorageHookTests.java
@@ -15,7 +15,11 @@ package org.eclipse.osgi.tests.hooks.framework;
 
 import static org.eclipse.osgi.tests.bundles.AbstractBundleTests.stop;
 import static org.eclipse.osgi.tests.bundles.AbstractBundleTests.stopQuietly;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -27,6 +31,7 @@ import org.eclipse.osgi.container.ModuleContainerAdaptor.ModuleEvent;
 import org.eclipse.osgi.internal.hookregistry.HookRegistry;
 import org.eclipse.osgi.tests.OSGiTestsActivator;
 import org.eclipse.osgi.tests.bundles.SystemBundleTests;
+import org.junit.Test;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleException;
 import org.osgi.framework.Constants;
@@ -61,6 +66,7 @@ public class StorageHookTests extends AbstractFrameworkHookTests {
 	 * Bundles must be discarded if a storage hook throws an
 	 * IllegalStateException during validation.
 	 */
+	@Test
 	public void testBundleDiscardedWhenClasspathStorageHookInvalidates() throws Exception {
 		initAndStartFramework();
 		installBundle();
@@ -73,6 +79,7 @@ public class StorageHookTests extends AbstractFrameworkHookTests {
 	/*
 	 * Bundles must not be discarded when a storage hook says they are valid.
 	 */
+	@Test
 	public void testBundleNotDiscardedWhenClasspathStorageHookValidates() throws Exception {
 		initAndStartFramework();
 		installBundle();
@@ -86,6 +93,7 @@ public class StorageHookTests extends AbstractFrameworkHookTests {
 	 * A storage hook with the wrong factory class should cause bundle
 	 * installation to fail.
 	 */
+	@Test
 	public void testWrongStorageHookFactoryClassOnBundleInstall() throws Exception {
 		setFactoryClassInvalid(true);
 		initAndStartFramework();
@@ -102,6 +110,7 @@ public class StorageHookTests extends AbstractFrameworkHookTests {
 	 * A storage hook with the wrong factory class should cause bundle update
 	 * to fail.
 	 */
+	@Test
 	public void testWrongStorageHookFactoryClassOnBundleUpdate() throws Exception {
 		initAndStartFramework();
 		installBundle();
@@ -119,6 +128,7 @@ public class StorageHookTests extends AbstractFrameworkHookTests {
 	 * A storage hook with the wrong factory class should cause a framework
 	 * restart with persisted bundles to fail.
 	 */
+	@Test
 	public void testWrongStorageHookFactoryClassOnFrameworkRestart() throws Exception {
 		initAndStartFramework();
 		installBundle();
@@ -132,6 +142,7 @@ public class StorageHookTests extends AbstractFrameworkHookTests {
 		assertCreateStorageHookCalled();
 	}
 
+	@Test
 	public void testCleanOnFailLoad() throws Exception {
 		initAndStartFramework();
 		installBundle();
@@ -139,11 +150,13 @@ public class StorageHookTests extends AbstractFrameworkHookTests {
 		restartFramework();
 		assertBundleDiscarded();
 		// install a bundle without reference to test that the staging area is created correctly after clean
-		File bundlesBase = new File(OSGiTestsActivator.getContext().getDataFile(getName()), "bundles");
+		File bundlesBase = new File(OSGiTestsActivator.getContext().getDataFile(testName.getMethodName()), "bundles");
 		bundlesBase.mkdirs();
-		framework.getBundleContext().installBundle(SystemBundleTests.createBundle(bundlesBase, getName(), false, false).toURI().toString());
+		framework.getBundleContext().installBundle(
+				SystemBundleTests.createBundle(bundlesBase, testName.getMethodName(), false, false).toURI().toString());
 	}
 
+	@Test
 	public void testDeletingGenerationCalledOnDiscard() throws Exception {
 		initAndStartFramework();
 		installBundle();
@@ -153,6 +166,7 @@ public class StorageHookTests extends AbstractFrameworkHookTests {
 		assertBundleDiscarded();
 	}
 
+	@Test
 	public void testDeletingGenerationCalledUninstall() throws Exception {
 		initAndStartFramework();
 		installBundle();
@@ -162,6 +176,7 @@ public class StorageHookTests extends AbstractFrameworkHookTests {
 		assertStorageHookDeletingGenerationCalled();
 	}
 
+	@Test
 	public void testDeletingGenerationCalledUpdate() throws Exception {
 		initAndStartFramework();
 		installBundle();
@@ -171,6 +186,7 @@ public class StorageHookTests extends AbstractFrameworkHookTests {
 		assertStorageHookDeletingGenerationCalled();
 	}
 
+	@Test
 	public void testAdaptModuleRevisionBuilder() throws Exception {
 		setFactoryClassAdaptManifest(true);
 		initAndStartFramework();
@@ -238,6 +254,7 @@ public class StorageHookTests extends AbstractFrameworkHookTests {
 		assertEquals("Wrong attribute value", "testDirective", bundleCap.getDirectives().get("matching.directive"));
 	}
 
+	@Test
 	@SuppressWarnings("deprecation")
 	public void testFrameworkUtilHelper() throws Exception {
 		initAndStartFramework();
@@ -249,6 +266,7 @@ public class StorageHookTests extends AbstractFrameworkHookTests {
 		assertEquals("Wrong bundle found.", framework.getBundleContext().getBundle(Constants.SYSTEM_BUNDLE_LOCATION), b);
 	}
 
+	@Test
 	public void testHandleContent() throws Exception {
 		initAndStartFramework();
 
@@ -284,12 +302,14 @@ public class StorageHookTests extends AbstractFrameworkHookTests {
 		assertEquals("Wrong symbolicName", "testHandleContentConnection", b.getSymbolicName());
 	}
 
+	@Test
 	public void testNullStorageHook() throws Exception {
 
 		initAndStartFramework();
-		File bundlesBase = new File(OSGiTestsActivator.getContext().getDataFile(getName()), "bundles");
+		File bundlesBase = new File(OSGiTestsActivator.getContext().getDataFile(testName.getMethodName()), "bundles");
 		bundlesBase.mkdirs();
-		String initialBundleLoc = SystemBundleTests.createBundle(bundlesBase, getName(), false, false).toURI().toString();
+		String initialBundleLoc = SystemBundleTests.createBundle(bundlesBase, testName.getMethodName(), false, false)
+				.toURI().toString();
 		Bundle initialBundle = framework.getBundleContext().installBundle(initialBundleLoc);
 		assertNotNull("Expected to have an initial bundle.", initialBundle);
 
@@ -310,13 +330,13 @@ public class StorageHookTests extends AbstractFrameworkHookTests {
 	}
 
 	@Override
-	protected void setUp() throws Exception {
+	public void setUp() throws Exception {
 		super.setUp();
 		String loc = bundleInstaller.getBundleLocation(HOOK_CONFIGURATOR_BUNDLE);
 		loc = loc.substring(loc.indexOf("file:"));
 		classLoader.addURL(new URL(loc));
 		location = bundleInstaller.getBundleLocation(TEST_BUNDLE);
-		File file = OSGiTestsActivator.getContext().getDataFile(getName());
+		File file = OSGiTestsActivator.getContext().getDataFile(testName.getMethodName());
 		configuration = new HashMap<>();
 		configuration.put(Constants.FRAMEWORK_STORAGE, file.getAbsolutePath());
 		configuration.put(HookRegistry.PROP_HOOK_CONFIGURATORS_INCLUDE, HOOK_CONFIGURATOR_CLASS);
@@ -325,7 +345,7 @@ public class StorageHookTests extends AbstractFrameworkHookTests {
 	}
 
 	@Override
-	protected void tearDown() throws Exception {
+	public void tearDown() throws Exception {
 		stopQuietly(framework);
 		super.tearDown();
 	}

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resource/AbstractResourceTest.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resource/AbstractResourceTest.java
@@ -13,33 +13,21 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.resource;
 
-import org.eclipse.osgi.tests.OSGiTest;
 import org.eclipse.osgi.tests.OSGiTestsActivator;
 import org.eclipse.osgi.tests.bundles.BundleInstaller;
-import org.osgi.framework.InvalidSyntaxException;
+import org.junit.After;
+import org.junit.Before;
 
-public abstract class AbstractResourceTest extends OSGiTest {
+public abstract class AbstractResourceTest {
 	protected BundleInstaller installer;
 
-	public AbstractResourceTest() {
-		super();
+	@Before
+	public void setUp() throws Exception {
+		installer = new BundleInstaller(OSGiTestsActivator.TEST_FILES_ROOT + "wiringTests/bundles", OSGiTestsActivator.getContext()); //$NON-NLS-1$
 	}
 
-	public AbstractResourceTest(String name) {
-		super(name);
-	}
-
-	protected void setUp() throws Exception {
-		super.setUp();
-		try {
-			installer = new BundleInstaller(OSGiTestsActivator.TEST_FILES_ROOT + "wiringTests/bundles", OSGiTestsActivator.getContext()); //$NON-NLS-1$
-		} catch (InvalidSyntaxException e) {
-			fail("Failed to create bundle installer", e); //$NON-NLS-1$
-		}
-	}
-
-	protected void tearDown() throws Exception {
+	@After
+	public void tearDown() throws Exception {
 		installer.shutdown();
-		super.tearDown();
 	}
 }

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resource/BasicTest.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resource/BasicTest.java
@@ -13,12 +13,17 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.resource;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import org.junit.Assert;
+import org.junit.Test;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.Version;
 import org.osgi.framework.namespace.IdentityNamespace;
@@ -80,10 +85,8 @@ public class BasicTest extends AbstractResourceTest {
 	private Bundle tf1;
 	private Bundle tf2;
 
-	public BasicTest(String name) {
-		super(name);
-	}
 
+	@Test
 	public void testRequirementMatches() throws Exception {
 		Bundle tb5 = installer.installBundle("resource.tb5");
 		Resource requirer = tb5.adapt(BundleRevision.class);
@@ -123,6 +126,7 @@ public class BasicTest extends AbstractResourceTest {
 		assertRequirementMatches(requirement5, capability2);
 	}
 
+	@Test
 	public void testIdentity() throws Exception {
 		tb1 = installer.installBundle("resource.tb1");
 		tb2 = installer.installBundle("resource.tb2");
@@ -455,14 +459,6 @@ public class BasicTest extends AbstractResourceTest {
 		if (!(requirement instanceof BundleRequirement) || !(capability instanceof BundleCapability))
 			return;
 		assertFalse("Requirement matches capability", ((BundleRequirement) requirement).matches((BundleCapability) capability));
-	}
-
-	private void assertNotNull(Capability capability) {
-		Assert.assertNotNull("Null capability", capability);
-	}
-
-	private void assertNotNull(Requirement requirement) {
-		Assert.assertNotNull("Null requirement", requirement);
 	}
 
 	private void assertRequirementMatches(Requirement requirement, Capability capability) {

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resource/ResolverHookTests.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resource/ResolverHookTests.java
@@ -13,8 +13,14 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.resource;
 
+import static org.eclipse.osgi.tests.OSGiTestsActivator.getContext;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import java.util.Arrays;
 import java.util.Collection;
+import org.junit.Test;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.framework.hooks.resolver.ResolverHook;
@@ -26,10 +32,7 @@ import org.osgi.framework.wiring.FrameworkWiring;
 
 public class ResolverHookTests extends AbstractResourceTest {
 
-	public ResolverHookTests(String name) {
-		super(name);
-	}
-
+	@Test
 	public void testSingletonIdentity() throws Exception {
 		final RuntimeException error[] = {null};
 		final boolean called[] = {false};


### PR DESCRIPTION
This migrates all tests in `org.eclipse.osgi.tests.debugoptions`, `org.eclipse.osgi.tests.hooks.framework` and
`org.eclipse.osgi.tests.resource` to JUnit 4

* Add JUnit 4 annotations `@Test`, `@Before`,  @After`
* Remove inheritance of JUnit 3 TestCase and CoreTest
* Replace try-catch for actual errors with making the test method throw the exception