### PR TITLE
Migrate resolver tests in o.e.osgi.tests to JUnit 4

### DIFF
--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/perf/BasePerformanceTest.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/perf/BasePerformanceTest.java
@@ -28,10 +28,6 @@ import org.osgi.framework.Version;
 public class BasePerformanceTest extends AbstractStateTest {
 	private Random random;
 
-	public BasePerformanceTest(String name) {
-		super(name);
-	}
-
 	protected State buildRandomState(int size) {
 		State state = buildEmptyState();
 		StateObjectFactory stateFactory = state.getFactory();
@@ -77,7 +73,7 @@ public class BasePerformanceTest extends AbstractStateTest {
 	}
 
 	@Override
-	protected void setUp() throws Exception {
+	public void setUp() throws Exception {
 		super.setUp();
 		// uses a constant seed to prevent variation on results
 		this.random = new Random(0);

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/perf/StatePerformanceTest.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/perf/StatePerformanceTest.java
@@ -16,15 +16,16 @@ package org.eclipse.osgi.tests.perf;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import org.eclipse.core.tests.harness.CoreTest;
 import org.eclipse.core.tests.harness.PerformanceTestRunner;
 import org.eclipse.osgi.service.resolver.State;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
 
 public class StatePerformanceTest extends BasePerformanceTest {
 
-	public StatePerformanceTest(String name) {
-		super(name);
-	}
+	@Rule
+	public TestName testName = new TestName();
 
 	State storeAndRetrieve(State toStore) throws IOException {
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -33,16 +34,17 @@ public class StatePerformanceTest extends BasePerformanceTest {
 		return toStore.getFactory().readState(bais);
 	}
 
-	public void testCreation() {
+	@Test
+	public void testCreation() throws Exception {
 		final int stateSize = 5000;
 		new PerformanceTestRunner() {
 			protected void test() {
 				buildRandomState(stateSize);
 			}
-		}.run(this, 10, 10);
+		}.run(getClass(), testName.getMethodName(), 10, 10);
 	}
 
-	private void testResolution(int stateSize, int repetitions, String localName, String degradation) {
+	private void testResolution(int stateSize, int repetitions, String degradation) throws Exception {
 		final State originalState = buildRandomState(stateSize);
 		PerformanceTestRunner runner = new PerformanceTestRunner() {
 			protected void test() {
@@ -50,40 +52,41 @@ public class StatePerformanceTest extends BasePerformanceTest {
 			}
 		};
 		runner.setRegressionReason(degradation);
-		runner.run(this, localName, 10, repetitions);
+		runner.run(getClass(), testName.getMethodName(), 10, repetitions);
 	}
 
-	public void testResolution100() {
-		testResolution(100, 500, null, AllTests.DEGRADATION_RESOLUTION);
+	@Test
+	public void testResolution100() throws Exception {
+		testResolution(100, 500, AllTests.DEGRADATION_RESOLUTION);
 	}
 
-	public void testResolution1000() {
-		testResolution(1000, 15, "State Resolution", null);
+	@Test
+	public void testResolution1000() throws Exception {
+		testResolution(1000, 15, null);
 	}
 
-	public void testResolution500() {
-		testResolution(500, 50, null, AllTests.DEGRADATION_RESOLUTION);
+	@Test
+	public void testResolution500() throws Exception {
+		testResolution(500, 50, AllTests.DEGRADATION_RESOLUTION);
 	}
 
-	public void testResolution5000() {
-		testResolution(5000, 1, null, AllTests.DEGRADATION_RESOLUTION);
+	@Test
+	public void testResolution5000() throws Exception {
+		testResolution(5000, 1, AllTests.DEGRADATION_RESOLUTION);
 	}
 
 	private static final String DEGREDATION_STORE_RETRIEVE = "Performance decrease caused by additional fuctionality required for generic capabilities/requirements in OSGi R4.3 specification. See https://bugs.eclipse.org/bugs/show_bug.cgi?id=324753 for details.";
 
-	public void testStoreAndRetrieve() {
+	@Test
+	public void testStoreAndRetrieve() throws Exception {
 		int stateSize = 5000;
 		final State originalState = buildRandomState(stateSize);
 		PerformanceTestRunner runner = new PerformanceTestRunner() {
-			protected void test() {
-				try {
-					storeAndRetrieve(originalState);
-				} catch (IOException e) {
-					CoreTest.fail("", e);
-				}
+			protected void test() throws IOException {
+				storeAndRetrieve(originalState);
 			}
 		};
 		runner.setRegressionReason(DEGREDATION_STORE_RETRIEVE);
-		runner.run(this, 10, 10);
+		runner.run(getClass(), testName.getMethodName(), 10, 10);
 	}
 }

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/perf/StateUsesPerformanceTest.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/perf/StateUsesPerformanceTest.java
@@ -16,16 +16,18 @@ package org.eclipse.osgi.tests.perf;
 import java.util.Hashtable;
 import org.eclipse.core.tests.harness.PerformanceTestRunner;
 import org.eclipse.osgi.service.resolver.State;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
 import org.osgi.framework.BundleException;
 import org.osgi.framework.Constants;
 
 public class StateUsesPerformanceTest extends BasePerformanceTest {
 
-	public StateUsesPerformanceTest(String name) {
-		super(name);
-	}
+	@Rule
+	public TestName testName = new TestName();
 
-	private void doUsesResolution(int stateSize, int repetitions, String localName, String degradation) throws BundleException {
+	private void doUsesResolution(int stateSize, int repetitions, String degradation) throws Exception {
 		final State originalState = buildRandomState(stateSize);
 		addUsesBundles(originalState);
 		PerformanceTestRunner runner = new PerformanceTestRunner() {
@@ -34,24 +36,28 @@ public class StateUsesPerformanceTest extends BasePerformanceTest {
 			}
 		};
 		runner.setRegressionReason(degradation);
-		runner.run(this, localName, 10, repetitions);
+		runner.run(getClass(), testName.getMethodName(), 10, repetitions);
 
 	}
 
-	public void testUsesResolution00100() throws BundleException {
-		doUsesResolution(100, 100, null, AllTests.DEGRADATION_RESOLUTION);
+	@Test
+	public void testUsesResolution00100() throws Exception {
+		doUsesResolution(100, 100, AllTests.DEGRADATION_RESOLUTION);
 	}
 
-	public void testUsesResolution00500() throws BundleException {
-		doUsesResolution(500, 10, null, AllTests.DEGRADATION_RESOLUTION);
+	@Test
+	public void testUsesResolution00500() throws Exception {
+		doUsesResolution(500, 10, AllTests.DEGRADATION_RESOLUTION);
 	}
 
-	public void testUsesResolution01000() throws BundleException {
-		doUsesResolution(1000, 10, null, AllTests.DEGRADATION_RESOLUTION);
+	@Test
+	public void testUsesResolution01000() throws Exception {
+		doUsesResolution(1000, 10, AllTests.DEGRADATION_RESOLUTION);
 	}
 
-	public void testUsesResolution05000() throws BundleException {
-		doUsesResolution(5000, 1, null, AllTests.DEGRADATION_RESOLUTION);
+	@Test
+	public void testUsesResolution05000() throws Exception {
+		doUsesResolution(5000, 1, AllTests.DEGRADATION_RESOLUTION);
 	}
 
 	private void addUsesBundles(State state) throws BundleException {

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resolver/TestAttributes_001.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resolver/TestAttributes_001.java
@@ -13,14 +13,19 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.resolver;
 
-import org.eclipse.osgi.service.resolver.*;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.eclipse.osgi.service.resolver.BundleDescription;
+import org.eclipse.osgi.service.resolver.ExportPackageDescription;
+import org.eclipse.osgi.service.resolver.State;
+import org.eclipse.osgi.service.resolver.StateObjectFactory;
 import org.eclipse.osgi.tests.services.resolver.AbstractStateTest;
+import org.junit.Test;
 import org.osgi.framework.BundleException;
 
 public class TestAttributes_001 extends AbstractStateTest {
-	public TestAttributes_001(String testName) {
-		super(testName);
-	}
 
 	BundleDescription bundle_1 = null;
 	BundleDescription bundle_2 = null;
@@ -28,6 +33,7 @@ public class TestAttributes_001 extends AbstractStateTest {
 	BundleDescription bundle_4 = null;
 	BundleDescription bundle_5 = null;
 
+	@Test
 	public void testTest_001() {
 		State state = buildEmptyState();
 		StateObjectFactory sof = StateObjectFactory.defaultFactory;

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resolver/TestBSN_001.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resolver/TestBSN_001.java
@@ -13,19 +13,25 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.resolver;
 
-import org.eclipse.osgi.service.resolver.*;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.eclipse.osgi.service.resolver.BundleDescription;
+import org.eclipse.osgi.service.resolver.ExportPackageDescription;
+import org.eclipse.osgi.service.resolver.State;
+import org.eclipse.osgi.service.resolver.StateObjectFactory;
 import org.eclipse.osgi.tests.services.resolver.AbstractStateTest;
+import org.junit.Test;
 import org.osgi.framework.BundleException;
 
 public class TestBSN_001 extends AbstractStateTest {
-	public TestBSN_001(String testName) {
-		super(testName);
-	}
 
 	BundleDescription bundle_1 = null;
 	BundleDescription bundle_2 = null;
 	BundleDescription bundle_3 = null;
 
+	@Test
 	public void testTest_001() {
 		State state = buildEmptyState();
 		StateObjectFactory sof = StateObjectFactory.defaultFactory;

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resolver/TestCycle_001.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resolver/TestCycle_001.java
@@ -13,18 +13,23 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.resolver;
 
-import org.eclipse.osgi.service.resolver.*;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.eclipse.osgi.service.resolver.BundleDescription;
+import org.eclipse.osgi.service.resolver.State;
+import org.eclipse.osgi.service.resolver.StateObjectFactory;
 import org.eclipse.osgi.tests.services.resolver.AbstractStateTest;
+import org.junit.Test;
 import org.osgi.framework.BundleException;
 
 public class TestCycle_001 extends AbstractStateTest {
-	public TestCycle_001(String testName) {
-		super(testName);
-	}
 
 	BundleDescription bundle_1 = null;
 	BundleDescription bundle_2 = null;
 
+	@Test
 	public void testTest_001() {
 		State state = buildEmptyState();
 		StateObjectFactory sof = StateObjectFactory.defaultFactory;

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resolver/TestCycle_002.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resolver/TestCycle_002.java
@@ -13,19 +13,24 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.resolver;
 
-import org.eclipse.osgi.service.resolver.*;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.eclipse.osgi.service.resolver.BundleDescription;
+import org.eclipse.osgi.service.resolver.State;
+import org.eclipse.osgi.service.resolver.StateObjectFactory;
 import org.eclipse.osgi.tests.services.resolver.AbstractStateTest;
+import org.junit.Test;
 import org.osgi.framework.BundleException;
 
 public class TestCycle_002 extends AbstractStateTest {
-	public TestCycle_002(String testName) {
-		super(testName);
-	}
 
 	BundleDescription bundle_1 = null;
 	BundleDescription bundle_2 = null;
 	BundleDescription bundle_3 = null;
 
+	@Test
 	public void testTest_002() {
 		State state = buildEmptyState();
 		StateObjectFactory sof = StateObjectFactory.defaultFactory;

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resolver/TestCycle_003.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resolver/TestCycle_003.java
@@ -13,19 +13,23 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.resolver;
 
-import org.eclipse.osgi.service.resolver.*;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.eclipse.osgi.service.resolver.BundleDescription;
+import org.eclipse.osgi.service.resolver.State;
+import org.eclipse.osgi.service.resolver.StateObjectFactory;
 import org.eclipse.osgi.tests.services.resolver.AbstractStateTest;
+import org.junit.Test;
 import org.osgi.framework.BundleException;
 
 public class TestCycle_003 extends AbstractStateTest {
-	public TestCycle_003(String testName) {
-		super(testName);
-	}
 
 	BundleDescription bundle_1 = null;
 	BundleDescription bundle_2 = null;
 	BundleDescription bundle_3 = null;
 
+	@Test
 	public void testTest_003() {
 		State state = buildEmptyState();
 		StateObjectFactory sof = StateObjectFactory.defaultFactory;

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resolver/TestCycle_004.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resolver/TestCycle_004.java
@@ -13,18 +13,24 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.resolver;
 
-import org.eclipse.osgi.service.resolver.*;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.eclipse.osgi.service.resolver.BundleDescription;
+import org.eclipse.osgi.service.resolver.ExportPackageDescription;
+import org.eclipse.osgi.service.resolver.State;
+import org.eclipse.osgi.service.resolver.StateObjectFactory;
 import org.eclipse.osgi.tests.services.resolver.AbstractStateTest;
+import org.junit.Test;
 import org.osgi.framework.BundleException;
 
 public class TestCycle_004 extends AbstractStateTest {
-	public TestCycle_004(String testName) {
-		super(testName);
-	}
 
 	BundleDescription bundle_1 = null;
 	BundleDescription bundle_2 = null;
 
+	@Test
 	public void testTest_001() {
 		State state = buildEmptyState();
 		StateObjectFactory sof = StateObjectFactory.defaultFactory;

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resolver/TestCycle_005.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resolver/TestCycle_005.java
@@ -13,19 +13,25 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.resolver;
 
-import org.eclipse.osgi.service.resolver.*;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.eclipse.osgi.service.resolver.BundleDescription;
+import org.eclipse.osgi.service.resolver.ExportPackageDescription;
+import org.eclipse.osgi.service.resolver.State;
+import org.eclipse.osgi.service.resolver.StateObjectFactory;
 import org.eclipse.osgi.tests.services.resolver.AbstractStateTest;
+import org.junit.Test;
 import org.osgi.framework.BundleException;
 
 public class TestCycle_005 extends AbstractStateTest {
-	public TestCycle_005(String testName) {
-		super(testName);
-	}
 
 	BundleDescription bundle_1 = null;
 	BundleDescription bundle_2 = null;
 	BundleDescription bundle_3 = null;
 
+	@Test
 	public void testTest_002() {
 		State state = buildEmptyState();
 		StateObjectFactory sof = StateObjectFactory.defaultFactory;

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resolver/TestCycle_006.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resolver/TestCycle_006.java
@@ -13,23 +13,23 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.resolver;
 
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import org.eclipse.osgi.service.resolver.BundleDescription;
 import org.eclipse.osgi.service.resolver.State;
 import org.eclipse.osgi.service.resolver.StateObjectFactory;
 import org.eclipse.osgi.tests.services.resolver.AbstractStateTest;
+import org.junit.Test;
 import org.osgi.framework.BundleException;
 
-
 public class TestCycle_006 extends AbstractStateTest {
-	public TestCycle_006(String testName) {
-		super(testName);
-	}
 
 	BundleDescription bundle_1 = null;
 	BundleDescription bundle_2 = null;
 	BundleDescription bundle_3 = null;
 
-
+	@Test
 	public void testTest_003() {
 		State state = buildEmptyState();
 		StateObjectFactory sof = StateObjectFactory.defaultFactory;

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resolver/TestDynamic_001.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resolver/TestDynamic_001.java
@@ -13,23 +13,24 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.resolver;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import org.eclipse.osgi.service.resolver.BundleDescription;
 import org.eclipse.osgi.service.resolver.ExportPackageDescription;
 import org.eclipse.osgi.service.resolver.State;
 import org.eclipse.osgi.service.resolver.StateObjectFactory;
 import org.eclipse.osgi.tests.services.resolver.AbstractStateTest;
+import org.junit.Test;
 import org.osgi.framework.BundleException;
 
-
 public class TestDynamic_001 extends AbstractStateTest {
-	public TestDynamic_001(String testName) {
-		super(testName);
-	}
 
 	BundleDescription bundle_1 = null;
 	BundleDescription bundle_2 = null;
 
-
+	@Test
 	public void testTest_001() {
 		State state = buildEmptyState();
 		StateObjectFactory sof = StateObjectFactory.defaultFactory;

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resolver/TestDynamic_002.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resolver/TestDynamic_002.java
@@ -13,24 +13,26 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.resolver;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import org.eclipse.osgi.service.resolver.BundleDescription;
 import org.eclipse.osgi.service.resolver.ExportPackageDescription;
 import org.eclipse.osgi.service.resolver.State;
 import org.eclipse.osgi.service.resolver.StateObjectFactory;
 import org.eclipse.osgi.tests.services.resolver.AbstractStateTest;
+import org.junit.Test;
 import org.osgi.framework.BundleException;
 
-
 public class TestDynamic_002 extends AbstractStateTest {
-	public TestDynamic_002(String testName) {
-		super(testName);
-	}
 
 	BundleDescription bundle_1 = null;
 	BundleDescription bundle_2 = null;
 	BundleDescription bundle_3 = null;
 
-
+	@Test
 	public void testTest_002() {
 		State state = buildEmptyState();
 		StateObjectFactory sof = StateObjectFactory.defaultFactory;

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resolver/TestDynamic_003.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resolver/TestDynamic_003.java
@@ -13,24 +13,25 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.resolver;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import org.eclipse.osgi.service.resolver.BundleDescription;
 import org.eclipse.osgi.service.resolver.ExportPackageDescription;
 import org.eclipse.osgi.service.resolver.State;
 import org.eclipse.osgi.service.resolver.StateObjectFactory;
 import org.eclipse.osgi.tests.services.resolver.AbstractStateTest;
+import org.junit.Test;
 import org.osgi.framework.BundleException;
 
-
 public class TestDynamic_003 extends AbstractStateTest {
-	public TestDynamic_003(String testName) {
-		super(testName);
-	}
 
 	BundleDescription bundle_1 = null;
 	BundleDescription bundle_2 = null;
 	BundleDescription bundle_3 = null;
 
-
+	@Test
 	public void testTest_003() {
 		State state = buildEmptyState();
 		StateObjectFactory sof = StateObjectFactory.defaultFactory;

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resolver/TestDynamic_004.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resolver/TestDynamic_004.java
@@ -13,25 +13,26 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.resolver;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import org.eclipse.osgi.service.resolver.BundleDescription;
 import org.eclipse.osgi.service.resolver.ExportPackageDescription;
 import org.eclipse.osgi.service.resolver.State;
 import org.eclipse.osgi.service.resolver.StateObjectFactory;
 import org.eclipse.osgi.tests.services.resolver.AbstractStateTest;
+import org.junit.Test;
 import org.osgi.framework.BundleException;
 
-
 public class TestDynamic_004 extends AbstractStateTest {
-	public TestDynamic_004(String testName) {
-		super(testName);
-	}
 
 	BundleDescription bundle_1 = null;
 	BundleDescription bundle_2 = null;
 	BundleDescription bundle_3 = null;
 	BundleDescription bundle_4 = null;
 
-
+	@Test
 	public void testTest_003() {
 		State state = buildEmptyState();
 		StateObjectFactory sof = StateObjectFactory.defaultFactory;

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resolver/TestDynamic_005.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resolver/TestDynamic_005.java
@@ -13,24 +13,25 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.resolver;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import org.eclipse.osgi.service.resolver.BundleDescription;
 import org.eclipse.osgi.service.resolver.ExportPackageDescription;
 import org.eclipse.osgi.service.resolver.State;
 import org.eclipse.osgi.service.resolver.StateObjectFactory;
 import org.eclipse.osgi.tests.services.resolver.AbstractStateTest;
+import org.junit.Test;
 import org.osgi.framework.BundleException;
 
-
 public class TestDynamic_005 extends AbstractStateTest {
-	public TestDynamic_005(String testName) {
-		super(testName);
-	}
 
 	BundleDescription bundle_1 = null;
 	BundleDescription bundle_2 = null;
 	BundleDescription bundle_3 = null;
 
-
+	@Test
 	public void testTest_005() {
 		State state = buildEmptyState();
 		StateObjectFactory sof = StateObjectFactory.defaultFactory;

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resolver/TestDynamic_006.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resolver/TestDynamic_006.java
@@ -13,24 +13,25 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.resolver;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import org.eclipse.osgi.service.resolver.BundleDescription;
 import org.eclipse.osgi.service.resolver.ExportPackageDescription;
 import org.eclipse.osgi.service.resolver.State;
 import org.eclipse.osgi.service.resolver.StateObjectFactory;
 import org.eclipse.osgi.tests.services.resolver.AbstractStateTest;
+import org.junit.Test;
 import org.osgi.framework.BundleException;
 
-
 public class TestDynamic_006 extends AbstractStateTest {
-	public TestDynamic_006(String testName) {
-		super(testName);
-	}
 
 	BundleDescription bundle_1 = null;
 	BundleDescription bundle_2 = null;
 	BundleDescription bundle_3 = null;
 
-
+	@Test
 	public void testTest_005() {
 		State state = buildEmptyState();
 		StateObjectFactory sof = StateObjectFactory.defaultFactory;

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resolver/TestGenerated_001.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resolver/TestGenerated_001.java
@@ -13,19 +13,19 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.resolver;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import org.eclipse.osgi.service.resolver.BundleDescription;
 import org.eclipse.osgi.service.resolver.ExportPackageDescription;
 import org.eclipse.osgi.service.resolver.State;
 import org.eclipse.osgi.service.resolver.StateObjectFactory;
 import org.eclipse.osgi.tests.services.resolver.AbstractStateTest;
+import org.junit.Test;
 import org.osgi.framework.BundleException;
 
-
-
 public class TestGenerated_001 extends AbstractStateTest {
-	public TestGenerated_001(String testName) {
-		super(testName);
-	}
 
 	BundleDescription bundle_1 = null;
 	BundleDescription bundle_2 = null;
@@ -38,6 +38,7 @@ public class TestGenerated_001 extends AbstractStateTest {
 	BundleDescription bundle_9 = null;
 	BundleDescription bundle_10 = null;
 
+	@Test
 	public void testTest_001() {
 		State state = buildEmptyState();
 		StateObjectFactory sof = StateObjectFactory.defaultFactory;

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resolver/TestGrouping_001.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resolver/TestGrouping_001.java
@@ -13,24 +13,25 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.resolver;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import org.eclipse.osgi.service.resolver.BundleDescription;
 import org.eclipse.osgi.service.resolver.ExportPackageDescription;
 import org.eclipse.osgi.service.resolver.State;
 import org.eclipse.osgi.service.resolver.StateObjectFactory;
 import org.eclipse.osgi.tests.services.resolver.AbstractStateTest;
+import org.junit.Test;
 import org.osgi.framework.BundleException;
 
-
 public class TestGrouping_001 extends AbstractStateTest {
-	public TestGrouping_001(String testName) {
-		super(testName);
-	}
 
 	BundleDescription bundle_1 = null;
 	BundleDescription bundle_2 = null;
 	BundleDescription bundle_3 = null;
 
-
+	@Test
 	public void testTest_001() {
 		State state = buildEmptyState();
 		StateObjectFactory sof = StateObjectFactory.defaultFactory;

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resolver/TestGrouping_002.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resolver/TestGrouping_002.java
@@ -13,23 +13,23 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.resolver;
 
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import org.eclipse.osgi.service.resolver.BundleDescription;
 import org.eclipse.osgi.service.resolver.State;
 import org.eclipse.osgi.service.resolver.StateObjectFactory;
 import org.eclipse.osgi.tests.services.resolver.AbstractStateTest;
+import org.junit.Test;
 import org.osgi.framework.BundleException;
 
-
 public class TestGrouping_002 extends AbstractStateTest {
-	public TestGrouping_002(String testName) {
-		super(testName);
-	}
 
 	BundleDescription bundle_1 = null;
 	BundleDescription bundle_2 = null;
 	BundleDescription bundle_3 = null;
 
-
+	@Test
 	public void testTest_002() {
 		State state = buildEmptyState();
 		StateObjectFactory sof = StateObjectFactory.defaultFactory;

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resolver/TestGrouping_003.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resolver/TestGrouping_003.java
@@ -13,18 +13,19 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.resolver;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import org.eclipse.osgi.service.resolver.BundleDescription;
 import org.eclipse.osgi.service.resolver.ExportPackageDescription;
 import org.eclipse.osgi.service.resolver.State;
 import org.eclipse.osgi.service.resolver.StateObjectFactory;
 import org.eclipse.osgi.tests.services.resolver.AbstractStateTest;
+import org.junit.Test;
 import org.osgi.framework.BundleException;
 
-
 public class TestGrouping_003 extends AbstractStateTest {
-	public TestGrouping_003(String testName) {
-		super(testName);
-	}
 
 	BundleDescription bundle_1 = null;
 	BundleDescription bundle_2 = null;
@@ -32,7 +33,7 @@ public class TestGrouping_003 extends AbstractStateTest {
 	BundleDescription bundle_4 = null;
 	BundleDescription bundle_5 = null;
 
-
+	@Test
 	public void testTest_003() {
 		State state = buildEmptyState();
 		StateObjectFactory sof = StateObjectFactory.defaultFactory;

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resolver/TestGrouping_006.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resolver/TestGrouping_006.java
@@ -13,23 +13,23 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.resolver;
 
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import org.eclipse.osgi.service.resolver.BundleDescription;
 import org.eclipse.osgi.service.resolver.State;
 import org.eclipse.osgi.service.resolver.StateObjectFactory;
 import org.eclipse.osgi.tests.services.resolver.AbstractStateTest;
+import org.junit.Test;
 import org.osgi.framework.BundleException;
 
-
 public class TestGrouping_006 extends AbstractStateTest {
-	public TestGrouping_006(String testName) {
-		super(testName);
-	}
 
 	BundleDescription bundle_1 = null;
 	BundleDescription bundle_2 = null;
 	BundleDescription bundle_3 = null;
 
-
+	@Test
 	public void testTest_001() {
 		State state = buildEmptyState();
 		StateObjectFactory sof = StateObjectFactory.defaultFactory;

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resolver/TestGrouping_008.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resolver/TestGrouping_008.java
@@ -13,24 +13,25 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.resolver;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import org.eclipse.osgi.service.resolver.BundleDescription;
+import org.eclipse.osgi.service.resolver.ExportPackageDescription;
 import org.eclipse.osgi.service.resolver.State;
 import org.eclipse.osgi.service.resolver.StateObjectFactory;
-import org.osgi.framework.BundleException;
-import org.eclipse.osgi.service.resolver.ExportPackageDescription;
 import org.eclipse.osgi.tests.services.resolver.AbstractStateTest;
-
+import org.junit.Test;
+import org.osgi.framework.BundleException;
 
 public class TestGrouping_008 extends AbstractStateTest {
-	public TestGrouping_008(String testName) {
-		super(testName);
-	}
 
 	BundleDescription bundle_1 = null;
 	BundleDescription bundle_2 = null;
 	BundleDescription bundle_3 = null;
 
-
+	@Test
 	public void testTest_008() {
 		State state = buildEmptyState();
 		StateObjectFactory sof = StateObjectFactory.defaultFactory;

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resolver/TestOptional_001.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resolver/TestOptional_001.java
@@ -13,24 +13,26 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.resolver;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import org.eclipse.osgi.service.resolver.BundleDescription;
 import org.eclipse.osgi.service.resolver.ExportPackageDescription;
 import org.eclipse.osgi.service.resolver.State;
 import org.eclipse.osgi.service.resolver.StateObjectFactory;
 import org.eclipse.osgi.tests.services.resolver.AbstractStateTest;
+import org.junit.Test;
 import org.osgi.framework.BundleException;
 
-
 public class TestOptional_001 extends AbstractStateTest {
-	public TestOptional_001(String testName) {
-		super(testName);
-	}
 
 	BundleDescription bundle_1 = null;
 	BundleDescription bundle_2 = null;
 	BundleDescription bundle_3 = null;
 
-
+	@Test
 	public void testTest_002() {
 		State state = buildEmptyState();
 		StateObjectFactory sof = StateObjectFactory.defaultFactory;

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resolver/TestOptional_002.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resolver/TestOptional_002.java
@@ -13,24 +13,26 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.resolver;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import org.eclipse.osgi.service.resolver.BundleDescription;
 import org.eclipse.osgi.service.resolver.ExportPackageDescription;
 import org.eclipse.osgi.service.resolver.State;
 import org.eclipse.osgi.service.resolver.StateObjectFactory;
 import org.eclipse.osgi.tests.services.resolver.AbstractStateTest;
+import org.junit.Test;
 import org.osgi.framework.BundleException;
 
-
 public class TestOptional_002 extends AbstractStateTest {
-	public TestOptional_002(String testName) {
-		super(testName);
-	}
 
 	BundleDescription bundle_1 = null;
 	BundleDescription bundle_2 = null;
 	BundleDescription bundle_3 = null;
 
-
+	@Test
 	public void testTest_002() {
 		State state = buildEmptyState();
 		StateObjectFactory sof = StateObjectFactory.defaultFactory;

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resolver/TestPropagation_001.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resolver/TestPropagation_001.java
@@ -13,25 +13,26 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.resolver;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import org.eclipse.osgi.service.resolver.BundleDescription;
 import org.eclipse.osgi.service.resolver.ExportPackageDescription;
 import org.eclipse.osgi.service.resolver.State;
 import org.eclipse.osgi.service.resolver.StateObjectFactory;
 import org.eclipse.osgi.tests.services.resolver.AbstractStateTest;
+import org.junit.Test;
 import org.osgi.framework.BundleException;
 
-
 public class TestPropagation_001 extends AbstractStateTest {
-	public TestPropagation_001(String testName) {
-		super(testName);
-	}
 
 	BundleDescription bundle_1 = null;
 	BundleDescription bundle_2 = null;
 	BundleDescription bundle_3 = null;
 	BundleDescription bundle_4 = null;
 
-
+	@Test
 	public void testTest_001() {
 		State state = buildEmptyState();
 		StateObjectFactory sof = StateObjectFactory.defaultFactory;

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resolver/TestPropagation_003.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resolver/TestPropagation_003.java
@@ -13,25 +13,26 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.resolver;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import org.eclipse.osgi.service.resolver.BundleDescription;
 import org.eclipse.osgi.service.resolver.ExportPackageDescription;
 import org.eclipse.osgi.service.resolver.State;
 import org.eclipse.osgi.service.resolver.StateObjectFactory;
 import org.eclipse.osgi.tests.services.resolver.AbstractStateTest;
+import org.junit.Test;
 import org.osgi.framework.BundleException;
 
-
 public class TestPropagation_003 extends AbstractStateTest {
-	public TestPropagation_003(String testName) {
-		super(testName);
-	}
 
 	BundleDescription bundle_1 = null;
 	BundleDescription bundle_2 = null;
 	BundleDescription bundle_3 = null;
 	BundleDescription bundle_4 = null;
 
-
+	@Test
 	public void testTest_001() {
 		State state = buildEmptyState();
 		StateObjectFactory sof = StateObjectFactory.defaultFactory;

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resolver/TestRFC79_001.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resolver/TestRFC79_001.java
@@ -13,24 +13,25 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.resolver;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import org.eclipse.osgi.service.resolver.BundleDescription;
 import org.eclipse.osgi.service.resolver.ExportPackageDescription;
 import org.eclipse.osgi.service.resolver.State;
 import org.eclipse.osgi.service.resolver.StateObjectFactory;
 import org.eclipse.osgi.tests.services.resolver.AbstractStateTest;
+import org.junit.Test;
 import org.osgi.framework.BundleException;
 
-
 public class TestRFC79_001 extends AbstractStateTest {
-	public TestRFC79_001(String testName) {
-		super(testName);
-	}
 
 	BundleDescription bundle_1 = null;
 	BundleDescription bundle_2 = null;
 	BundleDescription bundle_3 = null;
 
-
+	@Test
 	public void testTest_001() {
 		State state = buildEmptyState();
 		StateObjectFactory sof = StateObjectFactory.defaultFactory;

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resolver/TestRFC79_002.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resolver/TestRFC79_002.java
@@ -13,18 +13,19 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.resolver;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import org.eclipse.osgi.service.resolver.BundleDescription;
 import org.eclipse.osgi.service.resolver.ExportPackageDescription;
 import org.eclipse.osgi.service.resolver.State;
 import org.eclipse.osgi.service.resolver.StateObjectFactory;
 import org.eclipse.osgi.tests.services.resolver.AbstractStateTest;
+import org.junit.Test;
 import org.osgi.framework.BundleException;
 
-
 public class TestRFC79_002 extends AbstractStateTest {
-	public TestRFC79_002(String testName) {
-		super(testName);
-	}
 
 	BundleDescription bundle_1 = null;
 	BundleDescription bundle_2 = null;
@@ -32,7 +33,7 @@ public class TestRFC79_002 extends AbstractStateTest {
 	BundleDescription bundle_4 = null;
 	BundleDescription bundle_5 = null;
 
-
+	@Test
 	public void testTest_002() {
 		State state = buildEmptyState();
 		StateObjectFactory sof = StateObjectFactory.defaultFactory;

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resolver/TestRFC79_003.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resolver/TestRFC79_003.java
@@ -13,25 +13,26 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.resolver;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import org.eclipse.osgi.service.resolver.BundleDescription;
 import org.eclipse.osgi.service.resolver.ExportPackageDescription;
 import org.eclipse.osgi.service.resolver.State;
 import org.eclipse.osgi.service.resolver.StateObjectFactory;
 import org.eclipse.osgi.tests.services.resolver.AbstractStateTest;
+import org.junit.Test;
 import org.osgi.framework.BundleException;
 
-
 public class TestRFC79_003 extends AbstractStateTest {
-	public TestRFC79_003(String testName) {
-		super(testName);
-	}
 
 	BundleDescription bundle_1 = null;
 	BundleDescription bundle_2 = null;
 	BundleDescription bundle_3 = null;
 	BundleDescription bundle_4 = null;
 
-
+	@Test
 	public void testTest_003() {
 		State state = buildEmptyState();
 		StateObjectFactory sof = StateObjectFactory.defaultFactory;

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resolver/TestRFC79_004.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resolver/TestRFC79_004.java
@@ -13,25 +13,26 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.resolver;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import org.eclipse.osgi.service.resolver.BundleDescription;
 import org.eclipse.osgi.service.resolver.ExportPackageDescription;
 import org.eclipse.osgi.service.resolver.State;
 import org.eclipse.osgi.service.resolver.StateObjectFactory;
 import org.eclipse.osgi.tests.services.resolver.AbstractStateTest;
+import org.junit.Test;
 import org.osgi.framework.BundleException;
 
-
 public class TestRFC79_004 extends AbstractStateTest {
-	public TestRFC79_004(String testName) {
-		super(testName);
-	}
 
 	BundleDescription bundle_1 = null;
 	BundleDescription bundle_2 = null;
 	BundleDescription bundle_3 = null;
 	BundleDescription bundle_4 = null;
 
-
+	@Test
 	public void testTest_004() {
 		State state = buildEmptyState();
 		StateObjectFactory sof = StateObjectFactory.defaultFactory;

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resolver/TestRFC79_005.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resolver/TestRFC79_005.java
@@ -13,24 +13,25 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.resolver;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import org.eclipse.osgi.service.resolver.BundleDescription;
 import org.eclipse.osgi.service.resolver.ExportPackageDescription;
 import org.eclipse.osgi.service.resolver.State;
 import org.eclipse.osgi.service.resolver.StateObjectFactory;
 import org.eclipse.osgi.tests.services.resolver.AbstractStateTest;
+import org.junit.Test;
 import org.osgi.framework.BundleException;
 
-
 public class TestRFC79_005 extends AbstractStateTest {
-	public TestRFC79_005(String testName) {
-		super(testName);
-	}
 
 	BundleDescription bundle_1 = null;
 	BundleDescription bundle_2 = null;
 	BundleDescription bundle_3 = null;
 
-
+	@Test
 	public void testTest_005() {
 		State state = buildEmptyState();
 		StateObjectFactory sof = StateObjectFactory.defaultFactory;

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resolver/TestRFC79_006.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resolver/TestRFC79_006.java
@@ -13,18 +13,19 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.resolver;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import org.eclipse.osgi.service.resolver.BundleDescription;
 import org.eclipse.osgi.service.resolver.ExportPackageDescription;
 import org.eclipse.osgi.service.resolver.State;
 import org.eclipse.osgi.service.resolver.StateObjectFactory;
 import org.eclipse.osgi.tests.services.resolver.AbstractStateTest;
+import org.junit.Test;
 import org.osgi.framework.BundleException;
 
-
 public class TestRFC79_006 extends AbstractStateTest {
-	public TestRFC79_006(String testName) {
-		super(testName);
-	}
 
 	BundleDescription bundle_1 = null;
 	BundleDescription bundle_2 = null;
@@ -33,7 +34,7 @@ public class TestRFC79_006 extends AbstractStateTest {
 	BundleDescription bundle_5 = null;
 	BundleDescription bundle_6 = null;
 
-
+	@Test
 	public void testTest_006() {
 		State state = buildEmptyState();
 		StateObjectFactory sof = StateObjectFactory.defaultFactory;

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resolver/TestRFC79_007.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resolver/TestRFC79_007.java
@@ -13,18 +13,19 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.resolver;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import org.eclipse.osgi.service.resolver.BundleDescription;
 import org.eclipse.osgi.service.resolver.ExportPackageDescription;
 import org.eclipse.osgi.service.resolver.State;
 import org.eclipse.osgi.service.resolver.StateObjectFactory;
 import org.eclipse.osgi.tests.services.resolver.AbstractStateTest;
+import org.junit.Test;
 import org.osgi.framework.BundleException;
 
-
 public class TestRFC79_007 extends AbstractStateTest {
-	public TestRFC79_007(String testName) {
-		super(testName);
-	}
 
 	BundleDescription bundle_1 = null;
 	BundleDescription bundle_2 = null;
@@ -32,7 +33,7 @@ public class TestRFC79_007 extends AbstractStateTest {
 	BundleDescription bundle_4 = null;
 	BundleDescription bundle_5 = null;
 
-
+	@Test
 	public void testTest_007() {
 		State state = buildEmptyState();
 		StateObjectFactory sof = StateObjectFactory.defaultFactory;

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resolver/TestVersion_001.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resolver/TestVersion_001.java
@@ -13,24 +13,25 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.resolver;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import org.eclipse.osgi.service.resolver.BundleDescription;
 import org.eclipse.osgi.service.resolver.ExportPackageDescription;
 import org.eclipse.osgi.service.resolver.State;
 import org.eclipse.osgi.service.resolver.StateObjectFactory;
 import org.eclipse.osgi.tests.services.resolver.AbstractStateTest;
+import org.junit.Test;
 import org.osgi.framework.BundleException;
 
-
 public class TestVersion_001 extends AbstractStateTest {
-	public TestVersion_001(String testName) {
-		super(testName);
-	}
 
 	BundleDescription bundle_1 = null;
 	BundleDescription bundle_2 = null;
 	BundleDescription bundle_3 = null;
 
-
+	@Test
 	public void testTest_001() {
 		State state = buildEmptyState();
 		StateObjectFactory sof = StateObjectFactory.defaultFactory;

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resolver/TestVersion_002.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resolver/TestVersion_002.java
@@ -13,24 +13,25 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.resolver;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import org.eclipse.osgi.service.resolver.BundleDescription;
 import org.eclipse.osgi.service.resolver.ExportPackageDescription;
 import org.eclipse.osgi.service.resolver.State;
 import org.eclipse.osgi.service.resolver.StateObjectFactory;
 import org.eclipse.osgi.tests.services.resolver.AbstractStateTest;
+import org.junit.Test;
 import org.osgi.framework.BundleException;
 
-
 public class TestVersion_002 extends AbstractStateTest {
-	public TestVersion_002(String testName) {
-		super(testName);
-	}
 
 	BundleDescription bundle_1 = null;
 	BundleDescription bundle_2 = null;
 	BundleDescription bundle_3 = null;
 
-
+	@Test
 	public void testTest_002() {
 		State state = buildEmptyState();
 		StateObjectFactory sof = StateObjectFactory.defaultFactory;

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resolver/TestVersion_003.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resolver/TestVersion_003.java
@@ -13,24 +13,25 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.resolver;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import org.eclipse.osgi.service.resolver.BundleDescription;
 import org.eclipse.osgi.service.resolver.ExportPackageDescription;
 import org.eclipse.osgi.service.resolver.State;
 import org.eclipse.osgi.service.resolver.StateObjectFactory;
 import org.eclipse.osgi.tests.services.resolver.AbstractStateTest;
+import org.junit.Test;
 import org.osgi.framework.BundleException;
 
-
 public class TestVersion_003 extends AbstractStateTest {
-	public TestVersion_003(String testName) {
-		super(testName);
-	}
 
 	BundleDescription bundle_1 = null;
 	BundleDescription bundle_2 = null;
 	BundleDescription bundle_3 = null;
 
-
+	@Test
 	public void testTest_003() {
 		State state = buildEmptyState();
 		StateObjectFactory sof = StateObjectFactory.defaultFactory;

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/services/datalocation/FileManagerTests.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/services/datalocation/FileManagerTests.java
@@ -13,37 +13,48 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.services.datalocation;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.osgi.storagemanager.StorageManager;
-import org.eclipse.osgi.tests.OSGiTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.function.ThrowingRunnable;
+import org.junit.rules.TestName;
 import org.osgi.framework.Constants;
 
-public class FileManagerTests extends OSGiTest {
+public class FileManagerTests {
+
+	@Rule
+	public TestName testName = new TestName();
+
 	StorageManager manager1;
 	StorageManager manager2;
 	File base;
 
-	/**
-	 * Constructs a test case with the given name.
-	 */
-	public FileManagerTests(String name) {
-		super(name);
-	}
-
-	protected void setUp() throws Exception {
-		super.setUp();
+	@Before
+	public void setUp() throws Exception {
 		base = new File(Platform.getConfigurationLocation().getURL().getPath(), "FileManagerTests");
 		manager1 = null;
 		manager2 = null;
 	}
 
-	protected void tearDown() throws Exception {
-		super.tearDown();
+	@After
+	public void tearDown() throws Exception {
 		if (manager1 != null)
 			manager1.close();
 		if (manager2 != null)
@@ -64,21 +75,17 @@ public class FileManagerTests extends OSGiTest {
 	}
 
 	/**
-	 * Open a filemanager in readonly and ensure files are
-	 * not created.
+	 * Open a filemanager in readonly and ensure files are not created.
 	 */
-	public void testReadOnly() {
+	@Test
+	public void testReadOnly() throws IOException {
 		File testDir = new File(base, "readOnlyManager");
 		String fileName = "testReadOnly";
 		testDir.mkdirs();
 		String[] files = testDir.list();
 		assertEquals(files.length, 0);
 		manager1 = new StorageManager(testDir, null, true);
-		try {
-			manager1.open(true);
-		} catch (IOException e) {
-			fail("unexpected exception", e);
-		}
+		manager1.open(true);
 		files = testDir.list();
 		assertEquals(files.length, 0);
 		try {
@@ -106,19 +113,15 @@ public class FileManagerTests extends OSGiTest {
 		manager1.close();
 		manager1 = null;
 
-		try {
-			// lets create a file in a writable file manager
-			manager2 = new StorageManager(testDir, null, false);
-			manager2.open(true);
-			manager2.lookup(fileName, true);
-			File tmpFile = manager2.createTempFile(fileName);
-			writeToFile(tmpFile, "This file exists");
-			manager2.update(new String[] {fileName}, new String[] {tmpFile.getName()});
-			manager2.close();
-			manager2 = null;
-		} catch (IOException e) {
-			fail("unexpected exception", e);
-		}
+		// lets create a file in a writable file manager
+		manager2 = new StorageManager(testDir, null, false);
+		manager2.open(true);
+		manager2.lookup(fileName, true);
+		File tmpFile = manager2.createTempFile(fileName);
+		writeToFile(tmpFile, "This file exists");
+		manager2.update(new String[] { fileName }, new String[] { tmpFile.getName() });
+		manager2.close();
+		manager2 = null;
 	}
 
 	void writeToFile(File file, String str) throws IOException {
@@ -144,99 +147,90 @@ public class FileManagerTests extends OSGiTest {
 	}
 
 	/**
-	 * This tests a FM update where the a specific file is managed with a
-	 * revision number of (n) and an update is requested while there already
-	 * exists a file with revision number (n+1). FM should skip that generation
-	 * number and update the database with file version set to (n+2). This test is
-	 * possible if a power loss occurs between FM rename() and FM save().
+	 * This tests a FM update where the a specific file is managed with a revision
+	 * number of (n) and an update is requested while there already exists a file
+	 * with revision number (n+1). FM should skip that generation number and update
+	 * the database with file version set to (n+2). This test is possible if a power
+	 * loss occurs between FM rename() and FM save().
 	 */
-	public void testExistingVersion() {
+	@Test
+	public void testExistingVersion() throws IOException {
 		String testFile = "testExistingVersion.txt";
 		manager1 = new StorageManager(base, null);
-		try {
-			manager1.open(false);
-			File file1 = new File(base, testFile + ".1");
-			File file2 = new File(base, testFile + ".2");
-			File file3 = new File(base, testFile + ".3");
-			File file4 = new File(base, testFile + ".4");
-			if (file1.exists() || file2.exists() || file3.exists() || file4.exists()) {
-				fail("Test files already exists.");
-				return;
-			}
-			// create file version (1)
-			manager1.add(testFile);
-			File file = manager1.createTempFile(testFile);
-			writeToFile(file, "contents irrelevant");
-			manager1.update(new String[] {testFile}, new String[] {file.getName()});
-			if (!file1.exists() || file2.exists() || file3.exists() || file4.exists()) {
-				fail("Failed to create a single test file");
-				return;
-			}
 
-			// create file version (2) outside filemanager
-			writeToFile(file2, "file2 exists");
-
-			// update another file after generation 2 already exists...
-			file = manager1.createTempFile(testFile);
-			writeToFile(file, "file 3 contents");
-			manager1.update(new String[] {testFile}, new String[] {file.getName()});
-			if (!file3.exists() || file4.exists()) {
-				fail("Failed to skip existing filemanager file.");
-				return;
-			}
-
-			// open a new manager, ensure a lookup results in file version (3)
-			manager2 = new StorageManager(base, null);
-			manager2.open(true);
-			file = manager2.lookup(testFile, false);
-			if (file == null) {
-				fail("Unable to lookup exising file");
-				return;
-			}
-			assertTrue(file.getName().endsWith(".3"));
-			assertTrue(file.exists());
-			FileInputStream fis = new FileInputStream(file);
-			assertEquals(getInputStreamContents(fis), "file 3 contents");
-
-			manager2.close();
-			manager2 = null;
-
-			manager1.close();
-			manager1 = null;
-		} catch (IOException e) {
-			fail("unexpected exception", e);
+		manager1.open(false);
+		File file1 = new File(base, testFile + ".1");
+		File file2 = new File(base, testFile + ".2");
+		File file3 = new File(base, testFile + ".3");
+		File file4 = new File(base, testFile + ".4");
+		if (file1.exists() || file2.exists() || file3.exists() || file4.exists()) {
+			fail("Test files already exists.");
+			return;
 		}
+		// create file version (1)
+		manager1.add(testFile);
+		File file = manager1.createTempFile(testFile);
+		writeToFile(file, "contents irrelevant");
+		manager1.update(new String[] { testFile }, new String[] { file.getName() });
+		if (!file1.exists() || file2.exists() || file3.exists() || file4.exists()) {
+			fail("Failed to create a single test file");
+			return;
+		}
+
+		// create file version (2) outside filemanager
+		writeToFile(file2, "file2 exists");
+
+		// update another file after generation 2 already exists...
+		file = manager1.createTempFile(testFile);
+		writeToFile(file, "file 3 contents");
+		manager1.update(new String[] { testFile }, new String[] { file.getName() });
+		if (!file3.exists() || file4.exists()) {
+			fail("Failed to skip existing filemanager file.");
+			return;
+		}
+
+		// open a new manager, ensure a lookup results in file version (3)
+		manager2 = new StorageManager(base, null);
+		manager2.open(true);
+		file = manager2.lookup(testFile, false);
+		if (file == null) {
+			fail("Unable to lookup exising file");
+			return;
+		}
+		assertTrue(file.getName().endsWith(".3"));
+		assertTrue(file.exists());
+		FileInputStream fis = new FileInputStream(file);
+		assertEquals(getInputStreamContents(fis), "file 3 contents");
+
+		manager2.close();
+		manager2 = null;
+
+		manager1.close();
+		manager1 = null;
 	}
 
 	/**
-	 * This tests that FM apis throw exceptions if FM has not yet been opened
-	 * or if FM has been closed.
+	 * This tests that FM apis throw exceptions if FM has not yet been opened or if
+	 * FM has been closed.
 	 */
-	public void testNotOpen() {
+	@Test
+	public void testNotOpen() throws Throwable {
 		String permanentFile = "testNotOpen.txt";
 		String scratchFile = "testNotOpenScratch";
 		manager1 = new StorageManager(base, null);
 		// create a permanent file and a managed scratch file
-		try {
-			manager1.open(true);
-			manager1.add(permanentFile);
-			File tmpFile = manager1.createTempFile(permanentFile);
-			this.writeToFile(tmpFile, "File exists");
-			manager1.update(new String[] {permanentFile}, new String[] {tmpFile.getName()});
-			manager1.add(scratchFile);
-		} catch (IOException e) {
-			fail("unexpected exception", e);
-		}
+		manager1.open(true);
+		manager1.add(permanentFile);
+		File tmpFile = manager1.createTempFile(permanentFile);
+		this.writeToFile(tmpFile, "File exists");
+		manager1.update(new String[] { permanentFile }, new String[] { tmpFile.getName() });
+		manager1.add(scratchFile);
 
 		// create a new manager, and try making calls
 		manager2 = new StorageManager(base, null);
 		checkOpen(false, permanentFile, scratchFile);
 		// open the manager, try again
-		try {
-			manager2.open(true);
-		} catch (IOException e) {
-			fail("unexpected exception", e);
-		}
+		manager2.open(true);
 		checkOpen(true, permanentFile, scratchFile);
 		// close manager, try again
 		manager2.close();
@@ -247,133 +241,119 @@ public class FileManagerTests extends OSGiTest {
 		manager1 = null;
 	}
 
-	void checkOpen(boolean open, String permanentFile, String scratchFile) {
+	void checkOpen(boolean open, String permanentFile, String scratchFile) throws Throwable {
 		// check add()
-		try {
-			manager2.add("failFile");
-			if (!open)
-				fail("add did not fail.");
+		ThrowingRunnable addOperation = () -> manager2.add("failFile");
+		if (open) {
+			addOperation.run();
 			manager2.remove("failFile");
-		} catch (IOException e) {
-			if (open)
-				fail("unexpected exception", e);
+		} else {
+			assertThrows("add did not fail", IOException.class, addOperation);
 		}
 		// check lookup()
-		try {
-			// expect TEST2 to exist
-			manager2.lookup(permanentFile, false);
-			if (!open)
-				fail("lookup did not fail.");
-		} catch (IOException e) {
-			if (open)
-				fail("unexpected exception", e);
+		// expect TEST2 to exist
+		ThrowingRunnable lookupOperation = () -> manager2.lookup(permanentFile, false);
+		if (open) {
+			lookupOperation.run();
+		} else {
+			assertThrows("lookup did not fail", IOException.class, lookupOperation);
 		}
 		// check update, first create a real file to add
-		File tmpFile;
-		try {
-			tmpFile = manager2.createTempFile("openTest");
-			writeToFile(tmpFile, "contents irrelevant");
-		} catch (IOException e) {
-			fail("unexpected exception", e);
-			tmpFile = null;
-		}
+		File tmpFile = manager2.createTempFile("openTest");
+		writeToFile(tmpFile, "contents irrelevant");
 		if (tmpFile != null) {
-			try {
-				manager2.update(new String[] {permanentFile}, new String[] {tmpFile.getName()});
-				if (!open)
-					fail("update did not fail.");
-			} catch (IOException e) {
-				if (open)
-					fail("unexpected exception", e);
+			ThrowingRunnable updateOperation = () -> manager2.update(new String[] { permanentFile },
+					new String[] { tmpFile.getName() });
+			if (open) {
+				updateOperation.run();
+			} else {
+				assertThrows("update did not fail", IOException.class, updateOperation);
 			}
 		}
 		// check remove()
-		try {
-			manager2.remove(scratchFile);
-			if (!open)
-				fail("remove did not fail");
-			else
-				// add the file back if expected to complete
-				manager2.add(scratchFile);
-		} catch (IOException e) {
-			if (open)
-				fail("unexpected exception", e);
+		ThrowingRunnable removeOperation = () -> manager2.remove(scratchFile);
+		if (open) {
+			removeOperation.run();
+			// add the file back if expected to complete
+			manager2.add(scratchFile);
+		} else {
+			assertThrows("update did not fail", IOException.class, removeOperation);
 		}
 	}
 
 	/**
-	 * This tests FM remove() then add().  On a remove(), the file can not be deleted as it may
-	 * be in use by another FM. Then add() the file back and see if the version number written to
-	 * is (n+1) where (n) is the version when remove() called.  This is likely if framework uses
-	 * -clean where on clean we remove the file, then on exit we add the file back.  Make sure
-	 * this is orderly.
+	 * This tests FM remove() then add(). On a remove(), the file can not be deleted
+	 * as it may be in use by another FM. Then add() the file back and see if the
+	 * version number written to is (n+1) where (n) is the version when remove()
+	 * called. This is likely if framework uses -clean where on clean we remove the
+	 * file, then on exit we add the file back. Make sure this is orderly.
 	 *
-	 * Currently is is a known issues that remove() will never delete any old manager contents.
+	 * Currently is is a known issues that remove() will never delete any old
+	 * manager contents.
 	 */
-	public void testRemoveThenAdd() {
+	@Test
+	public void testRemoveThenAdd() throws IOException {
 		String fileName = "testRemoveThenAdd.txt";
 		File file1 = new File(base, fileName + ".1");
 		File file2 = new File(base, fileName + ".2");
 		File file3 = new File(base, fileName + ".3");
 		manager1 = new StorageManager(base, null);
 		// create a permanent file
-		try {
-			manager1.open(true);
-			manager1.add(fileName);
-			// create version (1)
-			File tmpFile = manager1.createTempFile(fileName);
-			writeToFile(tmpFile, "File exists");
-			manager1.update(new String[] {fileName}, new String[] {tmpFile.getName()});
-			// do it again, now version (2)
-			tmpFile = manager1.createTempFile(fileName);
-			writeToFile(tmpFile, "File exists #2");
-			manager1.update(new String[] {fileName}, new String[] {tmpFile.getName()});
-			manager1.close(); // force a cleanup
-			manager1 = null;
-			// sanity check
-			if (file1.exists() || !file2.exists() || file3.exists())
-				fail("Failed creating a file revision");
 
-			manager2 = new StorageManager(base, null);
-			manager2.open(true);
-			manager2.remove(fileName);
-			// check lookup & getInputStream
-			File testFile = manager2.lookup(fileName, false);
-			assertNull(testFile);
-			manager2.add(fileName);
-			testFile = manager2.lookup(fileName, false);
-			assertNotNull(testFile);
-			assertTrue(testFile.getName().endsWith(".0"));
-			// write new file, ensure it version 3
-			tmpFile = manager2.createTempFile(fileName);
-			writeToFile(tmpFile, "File exists #3");
-			manager2.update(new String[] {fileName}, new String[] {tmpFile.getName()});
-			testFile = manager2.lookup(fileName, false);
-			assertNotNull(testFile);
-			assertTrue(testFile.getName().endsWith(".3"));
-			assertTrue(file3.exists());
+		manager1.open(true);
+		manager1.add(fileName);
+		// create version (1)
+		File tmpFile = manager1.createTempFile(fileName);
+		writeToFile(tmpFile, "File exists");
+		manager1.update(new String[] { fileName }, new String[] { tmpFile.getName() });
+		// do it again, now version (2)
+		tmpFile = manager1.createTempFile(fileName);
+		writeToFile(tmpFile, "File exists #2");
+		manager1.update(new String[] { fileName }, new String[] { tmpFile.getName() });
+		manager1.close(); // force a cleanup
+		manager1 = null;
+		// sanity check
+		if (file1.exists() || !file2.exists() || file3.exists())
+			fail("Failed creating a file revision");
 
-			// open a new manager, ensure that the database was updated
-			// by checking version is also #3
-			manager1 = new StorageManager(base, null);
-			manager1.open(true);
-			testFile = manager1.lookup(fileName, false);
-			assertNotNull(testFile);
-			assertTrue(testFile.getName().endsWith(".3"));
+		manager2 = new StorageManager(base, null);
+		manager2.open(true);
+		manager2.remove(fileName);
+		// check lookup & getInputStream
+		File testFile = manager2.lookup(fileName, false);
+		assertNull(testFile);
+		manager2.add(fileName);
+		testFile = manager2.lookup(fileName, false);
+		assertNotNull(testFile);
+		assertTrue(testFile.getName().endsWith(".0"));
+		// write new file, ensure it version 3
+		tmpFile = manager2.createTempFile(fileName);
+		writeToFile(tmpFile, "File exists #3");
+		manager2.update(new String[] { fileName }, new String[] { tmpFile.getName() });
+		testFile = manager2.lookup(fileName, false);
+		assertNotNull(testFile);
+		assertTrue(testFile.getName().endsWith(".3"));
+		assertTrue(file3.exists());
 
-			manager1.close();
-			manager1 = null;
-			manager2.close();
-			manager2 = null;
-		} catch (IOException e) {
-			fail("unexpected exception", e);
-		}
+		// open a new manager, ensure that the database was updated
+		// by checking version is also #3
+		manager1 = new StorageManager(base, null);
+		manager1.open(true);
+		testFile = manager1.lookup(fileName, false);
+		assertNotNull(testFile);
+		assertTrue(testFile.getName().endsWith(".3"));
+
+		manager1.close();
+		manager1 = null;
+		manager2.close();
+		manager2 = null;
 	}
 
 	/**
 	 * Test multiple FM do not cleanup any old files as they may be in use.
 	 */
-	public void testMultipleFileManagers() {
+	@Test
+	public void testMultipleFileManagers() throws IOException {
 		// This test relies on a file lock to fail if the same process already
 		// holds a file lock. This is true on Win32 but not on Linux/Mac unless using Java 6.
 		// So run this test for windows only.
@@ -385,70 +365,68 @@ public class FileManagerTests extends OSGiTest {
 		File file1 = new File(base, fileName + ".1");
 		File file2 = new File(base, fileName + ".2");
 		manager1 = new StorageManager(base, null);
-		try {
-			manager1.open(true);
-			File file = manager1.lookup(fileName, true);
-			assertNotNull(file);
-			file = manager1.createTempFile(fileName);
-			writeToFile(file, "test contents #1");
-			manager1.update(new String[] {fileName}, new String[] {file.getName()});
 
-			// ensure file is version #1
-			file = manager1.lookup(fileName, false);
-			assertNotNull(file);
-			assertTrue(file.getName().endsWith(".1"));
-			assertTrue(file1.exists());
+		manager1.open(true);
+		File file = manager1.lookup(fileName, true);
+		assertNotNull(file);
+		file = manager1.createTempFile(fileName);
+		writeToFile(file, "test contents #1");
+		manager1.update(new String[] { fileName }, new String[] { file.getName() });
 
-			//new fileMangager using version #1
-			manager2 = new StorageManager(base, null);
-			manager2.open(true);
-			// sanity check
-			file = manager2.lookup(fileName, false);
-			assertNotNull(file);
-			assertTrue(file.getName().endsWith(".1"));
-			assertTrue(file1.exists() && !file2.exists());
+		// ensure file is version #1
+		file = manager1.lookup(fileName, false);
+		assertNotNull(file);
+		assertTrue(file.getName().endsWith(".1"));
+		assertTrue(file1.exists());
 
-			// back to manager #1, update file again, close
-			file = manager1.createTempFile(fileName);
-			writeToFile(file, "test contents #2");
-			manager1.update(new String[] {fileName}, new String[] {file.getName()});
-			//sanity check
-			assertTrue(file1.exists());
-			assertTrue(file2.exists());
-			manager1.close();
-			manager1 = null;
-			// both files better still exists
-			assertTrue(file1.exists());
-			assertTrue(file2.exists());
+		// new fileMangager using version #1
+		manager2 = new StorageManager(base, null);
+		manager2.open(true);
+		// sanity check
+		file = manager2.lookup(fileName, false);
+		assertNotNull(file);
+		assertTrue(file.getName().endsWith(".1"));
+		assertTrue(file1.exists() && !file2.exists());
 
-			// manager #2
-			// sanity check
-			file = manager2.lookup(fileName, false);
-			assertNotNull(file);
-			assertTrue(file.getName().endsWith(".1"));
-			// close manager2, cleanup should occur
-			manager2.close();
-			manager2 = null;
-			assertTrue(!file1.exists());
-			assertTrue(file2.exists());
+		// back to manager #1, update file again, close
+		file = manager1.createTempFile(fileName);
+		writeToFile(file, "test contents #2");
+		manager1.update(new String[] { fileName }, new String[] { file.getName() });
+		// sanity check
+		assertTrue(file1.exists());
+		assertTrue(file2.exists());
+		manager1.close();
+		manager1 = null;
+		// both files better still exists
+		assertTrue(file1.exists());
+		assertTrue(file2.exists());
 
-			// new manager1, does it get version 1?
-			manager1 = new StorageManager(base, null);
-			manager1.open(true);
-			file = manager1.lookup(fileName, false);
-			assertNotNull(file);
-			assertTrue(file.getName().endsWith(".2"));
-			manager1.close();
-			manager1 = null;
-		} catch (IOException e) {
-			fail("unexpected exception", e);
-		}
+		// manager #2
+		// sanity check
+		file = manager2.lookup(fileName, false);
+		assertNotNull(file);
+		assertTrue(file.getName().endsWith(".1"));
+		// close manager2, cleanup should occur
+		manager2.close();
+		manager2 = null;
+		assertTrue(!file1.exists());
+		assertTrue(file2.exists());
+
+		// new manager1, does it get version 1?
+		manager1 = new StorageManager(base, null);
+		manager1.open(true);
+		file = manager1.lookup(fileName, false);
+		assertNotNull(file);
+		assertTrue(file.getName().endsWith(".2"));
+		manager1.close();
+		manager1 = null;
 	}
 
 	/**
 	 * This test will verify that a FM will fail if a lock is held
 	 */
-	public void testJavaIOLocking() {
+	@Test
+	public void testJavaIOLocking() throws FileNotFoundException, IOException {
 		// This type of locking is only sure to work on Win32.
 		if (!"win32".equalsIgnoreCase(System.getProperty("osgi.os")))
 			// this is a Windows-only test
@@ -456,11 +434,7 @@ public class FileManagerTests extends OSGiTest {
 		String fileName = "testJavaIOLocking";
 		File lockFile = new File(new File(base, ".manager"), ".fileTableLock");
 		lockFile.getParentFile().mkdirs();
-		try {
-			new FileOutputStream(lockFile).close();
-		} catch (IOException e) {
-			fail("unexpected exception", e);
-		}
+		new FileOutputStream(lockFile).close();
 		assertTrue(lockFile.exists());
 		FileOutputStream fos = null;
 		try {
@@ -485,20 +459,16 @@ public class FileManagerTests extends OSGiTest {
 			assertNull(manager1.lookup(fileName, false));
 			manager1.close();
 			manager1 = null;
-		} catch (IOException e) {
-			fail("unexpected exception", e);
 		} finally {
-			try {
-				if (fos != null)
-					fos.close();
-			} catch (IOException e) {
-				fail("unexpected exception", e);
+			if (fos != null) {
+				fos.close();
 			}
 		}
 	}
 
-	public void testCleanupOnOpen() {
-		String fileName = getName() + ".txt";
+	@Test
+	public void testCleanupOnOpen() throws IOException {
+		String fileName = testName.getMethodName() + ".txt";
 		File file1 = new File(base, fileName + ".1");
 		File file2 = new File(base, fileName + ".2");
 		File file3 = new File(base, fileName + ".3");
@@ -574,15 +544,14 @@ public class FileManagerTests extends OSGiTest {
 			assertFalse(file1.toString(), file1.exists());
 			assertFalse(file2.toString(), file2.exists());
 			assertTrue(file3.toString(), file3.exists());
-		} catch (IOException e) {
-			fail("unexpected exception", e);
 		} finally {
 			System.setProperty("osgi.embedded.cleanupOnOpen", "false");
 		}
 	}
 
-	public void testCleanupOnSave() {
-		String fileName = getName() + ".txt";
+	@Test
+	public void testCleanupOnSave() throws IOException {
+		String fileName = testName.getMethodName() + ".txt";
 		File file1 = new File(base, fileName + ".1");
 		File file2 = new File(base, fileName + ".2");
 		File file3 = new File(base, fileName + ".3");
@@ -625,8 +594,6 @@ public class FileManagerTests extends OSGiTest {
 			assertFalse(file1.toString(), file1.exists());
 			assertFalse(file2.toString(), file2.exists());
 			assertTrue(file3.toString(), file3.exists());
-		} catch (IOException e) {
-			fail("unexpected exception", e);
 		} finally {
 			System.setProperty("osgi.embedded.cleanupOnSave", "false");
 		}

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/services/datalocation/StreamManagerTests.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/services/datalocation/StreamManagerTests.java
@@ -13,6 +13,13 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.services.datalocation;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.DataInputStream;
@@ -25,31 +32,32 @@ import java.io.RandomAccessFile;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.osgi.storagemanager.ManagedOutputStream;
 import org.eclipse.osgi.storagemanager.StorageManager;
-import org.eclipse.osgi.tests.OSGiTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
 
-public class StreamManagerTests extends OSGiTest {
+public class StreamManagerTests {
+
+	@Rule
+	public TestName testName = new TestName();
+
 	StorageManager manager1;
 	StorageManager manager2;
 	File base;
 	String reliableFile;
 
-	/**
-	 * Constructs a test case with the given name.
-	 */
-	public StreamManagerTests(String name) {
-		super(name);
-	}
-
-	protected void setUp() throws Exception {
-		super.setUp();
+	@Before
+	public void setUp() throws Exception {
 		base = new File(Platform.getConfigurationLocation().getURL().getPath(), "StreamManagerTests");
 		manager1 = null;
 		manager2 = null;
 		reliableFile = System.getProperty("osgi.useReliableFiles");
 	}
 
-	protected void tearDown() throws Exception {
-		super.tearDown();
+	@After
+	public void tearDown() throws Exception {
 		if (manager1 != null)
 			manager1.close();
 		if (manager2 != null)
@@ -99,7 +107,8 @@ public class StreamManagerTests extends OSGiTest {
 	 * This tests that FM will keep a backup version of a reliableFile and that
 	 * corrupting the reliableFile will recover the previous contents.
 	 */
-	public void testReliableFile() {
+	@Test
+	public void testReliableFile() throws Exception {
 		String fileName = "testReliableFile.txt";
 		File file1 = new File(base, fileName + ".1");
 		File file2 = new File(base, fileName + ".2");
@@ -184,54 +193,50 @@ public class StreamManagerTests extends OSGiTest {
 			}
 			manager1.close();
 			manager1 = null;
-		} catch (IOException e) {
-			fail("unexepected exception", e);
 		} finally {
 			System.setProperty("osgi.useReliableFiles", "false"); // force reliable files off
 		}
 	}
 
-	public void testBigReliableFile() {
-		String fileName = getName() + ".txt";
-		try {
-			System.setProperty("osgi.useReliableFiles", "true"); // force reliable files
-			manager1 = new StorageManager(base, null);
-			manager1.open(true);
-			try (ManagedOutputStream fmos = manager1.getOutputStream(fileName)) {
-				assertNotNull(fmos);
-				try (DataOutputStream bufferedOut = new DataOutputStream(new BufferedOutputStream(fmos))) {
-					// 200 K of integers (200 * 1024 / 4)
-					for (int i = 0; i < (200 * 1024 / 4); i++)
-						bufferedOut.writeInt(i);
-				}
-			}
-			manager1.close();
-			manager1 = null;
+	@Test
+	public void testBigReliableFile() throws IOException {
+		String fileName = testName.getMethodName() + ".txt";
 
-			//now, open new manager, verify file contents are there
-			System.setProperty("osgi.useReliableFiles", "true"); // force reliable files
-			manager2 = new StorageManager(base, null);
-			manager2.open(true);
-			try (InputStream is = manager2.getInputStream(fileName)) {
-				assertNotNull(is);
-				try (DataInputStream bufferedIn = new DataInputStream(new BufferedInputStream(is))) {
-					for (int i = 0; i < (200 * 1024 / 4); i++)
-						assertEquals("Wrong content found", i, bufferedIn.readInt());
-				}
+		System.setProperty("osgi.useReliableFiles", "true"); // force reliable files
+		manager1 = new StorageManager(base, null);
+		manager1.open(true);
+		try (ManagedOutputStream fmos = manager1.getOutputStream(fileName)) {
+			assertNotNull(fmos);
+			try (DataOutputStream bufferedOut = new DataOutputStream(new BufferedOutputStream(fmos))) {
+				// 200 K of integers (200 * 1024 / 4)
+				for (int i = 0; i < (200 * 1024 / 4); i++)
+					bufferedOut.writeInt(i);
 			}
-			manager2.close();
-			manager2 = null;
-
-		} catch (IOException e) {
-			fail("unexepected exception", e);
 		}
+		manager1.close();
+		manager1 = null;
+
+		// now, open new manager, verify file contents are there
+		System.setProperty("osgi.useReliableFiles", "true"); // force reliable files
+		manager2 = new StorageManager(base, null);
+		manager2.open(true);
+		try (InputStream is = manager2.getInputStream(fileName)) {
+			assertNotNull(is);
+			try (DataInputStream bufferedIn = new DataInputStream(new BufferedInputStream(is))) {
+				for (int i = 0; i < (200 * 1024 / 4); i++)
+					assertEquals("Wrong content found", i, bufferedIn.readInt());
+			}
+		}
+		manager2.close();
+		manager2 = null;
 	}
 
 	/**
-	 * This tests if migration from a prior (non-ReliableFile) .fileTable
-	 * to the current .fileTable is correct.
+	 * This tests if migration from a prior (non-ReliableFile) .fileTable to the
+	 * current .fileTable is correct.
 	 */
-	public void testMigration() {
+	@Test
+	public void testMigration() throws IOException {
 		File testDir = new File(base, "testMigrationManager");
 		File managerDir = new File(testDir, ".manager");
 		String fileName = "testMigration.txt";
@@ -244,68 +249,65 @@ public class StreamManagerTests extends OSGiTest {
 		String contents1 = "test reliable file contents #1";
 		String contents2 = "test reliable file contents #2";
 		String contents3 = "test reliable file contents #3";
-		try {
-			// create a .fileTable and a normal file
-			managerDir.mkdirs();
-			writeToFile(fileTable, "#safe table\n" + fileName + "=2\n");
-			writeToFile(file2, contents1);
-			manager1 = new StorageManager(testDir, null);
-			manager1.open(true);
-			File test = manager1.lookup(fileName, false);
-			assertNotNull(test);
-			assertTrue(test.exists());
 
-			// update a new file
-			File testFile = manager1.createTempFile(fileName);
-			writeToFile(testFile, contents2);
-			manager1.update(new String[] {fileName}, new String[] {testFile.getName()});
-			// again
-			testFile = manager1.createTempFile(fileName);
-			writeToFile(testFile, contents3);
-			manager1.update(new String[] {fileName}, new String[] {testFile.getName()});
-			// again
-			testFile = manager1.createTempFile(fileName);
-			writeToFile(testFile, contents1);
-			manager1.update(new String[] {fileName}, new String[] {testFile.getName()});
-			manager1.close();
-			manager1 = null;
+		// create a .fileTable and a normal file
+		managerDir.mkdirs();
+		writeToFile(fileTable, "#safe table\n" + fileName + "=2\n");
+		writeToFile(file2, contents1);
+		manager1 = new StorageManager(testDir, null);
+		manager1.open(true);
+		File test = manager1.lookup(fileName, false);
+		assertNotNull(test);
+		assertTrue(test.exists());
 
-			String[] files = managerDir.list();
-			assertEquals(4, files.length);
-			//original file never gets deleted
-			assertTrue(fileTable.exists());
-			//behaves like a reliableFile?
-			assertFalse(fileTable1.exists());
-			assertTrue(fileTable2.exists());
-			assertTrue(fileTable3.exists());
-			//files are as expected?
-			files = testDir.list();
-			assertEquals(2, files.length);
-			assertTrue(file5.exists());
+		// update a new file
+		File testFile = manager1.createTempFile(fileName);
+		writeToFile(testFile, contents2);
+		manager1.update(new String[] { fileName }, new String[] { testFile.getName() });
+		// again
+		testFile = manager1.createTempFile(fileName);
+		writeToFile(testFile, contents3);
+		manager1.update(new String[] { fileName }, new String[] { testFile.getName() });
+		// again
+		testFile = manager1.createTempFile(fileName);
+		writeToFile(testFile, contents1);
+		manager1.update(new String[] { fileName }, new String[] { testFile.getName() });
+		manager1.close();
+		manager1 = null;
 
-			manager2 = new StorageManager(testDir, null);
-			manager2.open(true);
-			testFile = manager2.lookup(fileName, false);
-			assertNotNull(testFile);
-			assertTrue(testFile.exists());
-			assertTrue(testFile.getName().endsWith(".5"));
-			manager2.close();
-			manager2 = null;
+		String[] files = managerDir.list();
+		assertEquals(4, files.length);
+		// original file never gets deleted
+		assertTrue(fileTable.exists());
+		// behaves like a reliableFile?
+		assertFalse(fileTable1.exists());
+		assertTrue(fileTable2.exists());
+		assertTrue(fileTable3.exists());
+		// files are as expected?
+		files = testDir.list();
+		assertEquals(2, files.length);
+		assertTrue(file5.exists());
 
-		} catch (IOException e) {
-			fail("unexepected exception", e);
-		}
+		manager2 = new StorageManager(testDir, null);
+		manager2.open(true);
+		testFile = manager2.lookup(fileName, false);
+		assertNotNull(testFile);
+		assertTrue(testFile.exists());
+		assertTrue(testFile.getName().endsWith(".5"));
+		manager2.close();
+		manager2 = null;
 	}
 
 	/**
 	 * This tests that an output stream abort behave as expected.
 	 */
-	public void testAbort() {
+	@Test
+	public void testAbort() throws IOException {
 		testAbort(true);
 		testAbort(false);
 	}
 
-	private void testAbort(boolean reliable) {
+	private void testAbort(boolean reliable) throws IOException {
 		String fileName;
 		if (reliable)
 			fileName = "abortFileReliable.txt";
@@ -316,60 +318,58 @@ public class StreamManagerTests extends OSGiTest {
 		File file3 = new File(base, fileName + ".3");
 		String contents1 = "test reliable file contents #1";
 		String contents2 = "test reliable file contents #2";
-		try {
-			System.setProperty("osgi.useReliableFiles", "true"); // force reliable files
-			manager1 = new StorageManager(base, null);
-			manager1.open(true);
-			//create version 1
-			ManagedOutputStream smos = manager1.getOutputStream(fileName);
-			smos.write(contents1.getBytes());
-			smos.close();
 
-			//start creating version 2
-			smos = manager1.getOutputStream(fileName);
-			smos.write(contents2.getBytes());
-			smos.abort();
-			smos.close(); // shouldn't cause exception, check!
+		System.setProperty("osgi.useReliableFiles", "true"); // force reliable files
+		manager1 = new StorageManager(base, null);
+		manager1.open(true);
+		// create version 1
+		ManagedOutputStream smos = manager1.getOutputStream(fileName);
+		smos.write(contents1.getBytes());
+		smos.close();
 
-			// now see if we're still on version #1
-			assertEquals(1, manager1.getId(fileName));
-			// check contents also
-			InputStream is = manager1.getInputStream(fileName);
-			assertNotNull(is);
-			assertEquals(contents1, getInputStreamContents(is));
-			manager1.close();
-			manager1 = null;
+		// start creating version 2
+		smos = manager1.getOutputStream(fileName);
+		smos.write(contents2.getBytes());
+		smos.abort();
+		smos.close(); // shouldn't cause exception, check!
 
-			// open a new manager & check the same thing to ensure the database is correct
-			System.setProperty("osgi.useReliableFiles", "true"); // force reliable files
-			manager2 = new StorageManager(base, null);
-			manager2.open(true);
-			//create version 1
-			// now see if we're still on version #1
-			assertEquals(1, manager2.getId(fileName));
-			// check contents also
-			is = manager2.getInputStream(fileName);
-			assertNotNull(is);
-			assertEquals(contents1, getInputStreamContents(is));
-			manager2.close();
-			manager2 = null;
-			assertTrue(file1.exists());
-			assertFalse(file2.exists());
-			assertFalse(file3.exists());
-		} catch (IOException e) {
-			fail("unexepected exception", e);
-		}
+		// now see if we're still on version #1
+		assertEquals(1, manager1.getId(fileName));
+		// check contents also
+		InputStream is = manager1.getInputStream(fileName);
+		assertNotNull(is);
+		assertEquals(contents1, getInputStreamContents(is));
+		manager1.close();
+		manager1 = null;
+
+		// open a new manager & check the same thing to ensure the database is correct
+		System.setProperty("osgi.useReliableFiles", "true"); // force reliable files
+		manager2 = new StorageManager(base, null);
+		manager2.open(true);
+		// create version 1
+		// now see if we're still on version #1
+		assertEquals(1, manager2.getId(fileName));
+		// check contents also
+		is = manager2.getInputStream(fileName);
+		assertNotNull(is);
+		assertEquals(contents1, getInputStreamContents(is));
+		manager2.close();
+		manager2 = null;
+		assertTrue(file1.exists());
+		assertFalse(file2.exists());
+		assertFalse(file3.exists());
 	}
 
 	/**
 	 * This tests if getting an output stream-set work properly.
 	 */
-	public void testGetOutputStreamSet() {
+	@Test
+	public void testGetOutputStreamSet() throws IOException {
 		testGetOutputStreamSet(true);
 		testGetOutputStreamSet(false);
 	}
 
-	private void testGetOutputStreamSet(boolean reliable) {
+	private void testGetOutputStreamSet(boolean reliable) throws IOException {
 		File mgrDir;
 		if (reliable)
 			mgrDir = new File(base, "getSetReliable");
@@ -383,61 +383,58 @@ public class StreamManagerTests extends OSGiTest {
 		File file2_2 = new File(mgrDir, fileName2 + ".2");
 		String contents1 = "test reliable file contents #1";
 		String contents2 = "test reliable file contents #2";
-		try {
-			System.setProperty("osgi.useReliableFiles", reliable ? "true" : "false"); // force reliable files
-			manager1 = new StorageManager(mgrDir, null);
-			manager1.open(true);
-			ManagedOutputStream[] outs = manager1.getOutputStreamSet(new String[] {fileName1, fileName2});
-			assertNotNull(outs);
-			assertEquals(2, outs.length);
 
-			outs[0].write(contents1.getBytes());
-			outs[1].write(contents2.getBytes());
-			outs[1].close();
-			assertFalse(file1_1.exists());
-			assertFalse(file2_1.exists());
-			outs[0].close();
+		System.setProperty("osgi.useReliableFiles", reliable ? "true" : "false"); // force reliable files
+		manager1 = new StorageManager(mgrDir, null);
+		manager1.open(true);
+		ManagedOutputStream[] outs = manager1.getOutputStreamSet(new String[] { fileName1, fileName2 });
+		assertNotNull(outs);
+		assertEquals(2, outs.length);
+
+		outs[0].write(contents1.getBytes());
+		outs[1].write(contents2.getBytes());
+		outs[1].close();
+		assertFalse(file1_1.exists());
+		assertFalse(file2_1.exists());
+		outs[0].close();
+		assertTrue(file1_1.exists());
+		assertTrue(file2_1.exists());
+
+		outs = manager1.getOutputStreamSet(new String[] { fileName1, fileName2 });
+		assertNotNull(outs);
+
+		outs[0].write("new data #1".getBytes());
+		outs[1].write("new data #2".getBytes());
+		outs[0].close();
+		assertFalse(file1_2.exists());
+		assertFalse(file2_2.exists());
+		outs[1].close();
+		assertTrue(file1_2.exists());
+		assertTrue(file2_2.exists());
+		manager1.close();
+		manager1 = null;
+
+		if (reliable) {
+			// verify FM thinks they are reliable
 			assertTrue(file1_1.exists());
 			assertTrue(file2_1.exists());
-
-			outs = manager1.getOutputStreamSet(new String[] {fileName1, fileName2});
-			assertNotNull(outs);
-
-			outs[0].write("new data #1".getBytes());
-			outs[1].write("new data #2".getBytes());
-			outs[0].close();
-			assertFalse(file1_2.exists());
-			assertFalse(file2_2.exists());
-			outs[1].close();
-			assertTrue(file1_2.exists());
-			assertTrue(file2_2.exists());
-			manager1.close();
-			manager1 = null;
-
-			if (reliable) {
-				// verify FM thinks they are reliable
-				assertTrue(file1_1.exists());
-				assertTrue(file2_1.exists());
-			} else {
-				// verify FM thinks they are not reliable
-				assertFalse(file1_1.exists());
-				assertFalse(file2_1.exists());
-			}
-
-		} catch (IOException e) {
-			fail("unexepected exception", e);
+		} else {
+			// verify FM thinks they are not reliable
+			assertFalse(file1_1.exists());
+			assertFalse(file2_1.exists());
 		}
 	}
 
 	/**
 	 * This tests if aborting a managed stream-set works as expected
 	 */
-	public void testAbortStreamSet() {
+	@Test
+	public void testAbortStreamSet() throws IOException {
 		testAbortSet(true);
 		testAbortSet(false);
 	}
 
-	private void testAbortSet(boolean reliable) {
+	private void testAbortSet(boolean reliable) throws IOException {
 		File mgrDir;
 		if (reliable)
 			mgrDir = new File(base, "abortSetReliable");
@@ -449,55 +446,51 @@ public class StreamManagerTests extends OSGiTest {
 		String fileName4 = "test4.txt";
 		String contents1 = "test reliable file contents #1";
 		String contents2 = "test reliable file contents #2";
-		try {
-			mgrDir.mkdirs();
-			String[] list = mgrDir.list();
-			assertEquals(0, list.length);
-			System.setProperty("osgi.useReliableFiles", reliable ? "true" : "false"); // force reliable files
-			manager1 = new StorageManager(mgrDir, null);
-			manager1.open(true);
-			ManagedOutputStream[] outs = manager1.getOutputStreamSet(new String[] {fileName1, fileName2, fileName3, fileName4});
-			assertNotNull(outs);
 
-			outs[0].write(contents1.getBytes());
-			outs[1].write(contents2.getBytes());
-			outs[2].write(contents2.getBytes());
-			outs[3].write(contents1.getBytes());
-			//sanity check
-			list = mgrDir.list();
-			assertEquals(5, list.length);
-			outs[2].close();
-			outs[1].abort();
-			outs[0].close(); //noop
-			outs[3].close(); //noop
-			outs[2].close(); //noop
-			outs[1].close(); //noop
-			list = mgrDir.list();
-			assertEquals(1, list.length);
-			assertNull(manager1.lookup(fileName1, false));
-			assertNull(manager1.lookup(fileName2, false));
-			assertNull(manager1.lookup(fileName3, false));
-			assertNull(manager1.lookup(fileName4, false));
-			manager1.close();
-			manager1 = null;
+		mgrDir.mkdirs();
+		String[] list = mgrDir.list();
+		assertEquals(0, list.length);
+		System.setProperty("osgi.useReliableFiles", reliable ? "true" : "false"); // force reliable files
+		manager1 = new StorageManager(mgrDir, null);
+		manager1.open(true);
+		ManagedOutputStream[] outs = manager1.getOutputStreamSet(new String[] {fileName1, fileName2, fileName3, fileName4});
+		assertNotNull(outs);
 
-			// open a new manager & check the same thing to ensure the database is correct
-			System.setProperty("osgi.useReliableFiles", reliable ? "true" : "false"); // force reliable files
-			manager2 = new StorageManager(mgrDir, null);
-			manager2.open(true);
-			//create version 1
-			assertNull(manager2.lookup(fileName1, false));
-			assertNull(manager2.lookup(fileName2, false));
-			assertNull(manager2.lookup(fileName3, false));
-			assertNull(manager2.lookup(fileName4, false));
-			list = mgrDir.list();
-			assertEquals(1, list.length);
-			manager2.close();
-			manager2 = null;
+		outs[0].write(contents1.getBytes());
+		outs[1].write(contents2.getBytes());
+		outs[2].write(contents2.getBytes());
+		outs[3].write(contents1.getBytes());
+		//sanity check
+		list = mgrDir.list();
+		assertEquals(5, list.length);
+		outs[2].close();
+		outs[1].abort();
+		outs[0].close(); //noop
+		outs[3].close(); //noop
+		outs[2].close(); //noop
+		outs[1].close(); //noop
+		list = mgrDir.list();
+		assertEquals(1, list.length);
+		assertNull(manager1.lookup(fileName1, false));
+		assertNull(manager1.lookup(fileName2, false));
+		assertNull(manager1.lookup(fileName3, false));
+		assertNull(manager1.lookup(fileName4, false));
+		manager1.close();
+		manager1 = null;
 
-		} catch (IOException e) {
-			fail("unexepected exception", e);
-		}
+		// open a new manager & check the same thing to ensure the database is correct
+		System.setProperty("osgi.useReliableFiles", reliable ? "true" : "false"); // force reliable files
+		manager2 = new StorageManager(mgrDir, null);
+		manager2.open(true);
+		//create version 1
+		assertNull(manager2.lookup(fileName1, false));
+		assertNull(manager2.lookup(fileName2, false));
+		assertNull(manager2.lookup(fileName3, false));
+		assertNull(manager2.lookup(fileName4, false));
+		list = mgrDir.list();
+		assertEquals(1, list.length);
+		manager2.close();
+		manager2 = null;
 	}
 
 }

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/services/resolver/AbstractStateTest.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/services/resolver/AbstractStateTest.java
@@ -13,6 +13,12 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.services.resolver;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import java.util.Dictionary;
 import java.util.Hashtable;
 import java.util.StringTokenizer;
@@ -25,26 +31,26 @@ import org.eclipse.osgi.service.resolver.PlatformAdmin;
 import org.eclipse.osgi.service.resolver.State;
 import org.eclipse.osgi.service.resolver.StateObjectFactory;
 import org.eclipse.osgi.service.resolver.VersionConstraint;
-import org.eclipse.osgi.tests.OSGiTest;
 import org.eclipse.osgi.tests.OSGiTestsActivator;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
 import org.osgi.framework.BundleException;
 import org.osgi.framework.ServiceReference;
 
-public abstract class AbstractStateTest extends OSGiTest {
+public abstract class AbstractStateTest {
 	private ServiceReference platformAdminRef;
 	protected PlatformAdmin platformAdminService;
 
-	protected void setUp() throws Exception {
+	@Before
+	public void setUp() throws Exception {
 		platformAdminRef = OSGiTestsActivator.getContext().getServiceReference(PlatformAdmin.class);
 		platformAdminService = (PlatformAdmin) OSGiTestsActivator.getContext().getService(platformAdminRef);
 	}
 
-	protected void tearDown() throws Exception {
+	@After
+	public void tearDown() throws Exception {
 		OSGiTestsActivator.getContext().ungetService(platformAdminRef);
-	}
-
-	public AbstractStateTest(String testName) {
-		super(testName);
 	}
 
 	public void assertContains(String tag, Object[] array, Object element) {
@@ -54,6 +60,14 @@ public abstract class AbstractStateTest extends OSGiTest {
 			}
 		}
 		fail(tag);
+	}
+
+	public void assertEquals(Object expected, Object actual) {
+		Assert.assertEquals(expected, actual);
+	}
+
+	public void assertEquals(String message, Object expected, Object actual) {
+		Assert.assertEquals(message, expected, actual);
 	}
 
 	public void assertEquals(State original, State copy) {

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/services/resolver/DevModeTest.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/services/resolver/DevModeTest.java
@@ -13,19 +13,19 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.services.resolver;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import java.util.Dictionary;
 import java.util.Hashtable;
 import org.eclipse.osgi.service.resolver.BundleDescription;
 import org.eclipse.osgi.service.resolver.ExportPackageDescription;
 import org.eclipse.osgi.service.resolver.State;
+import org.junit.Test;
 import org.osgi.framework.BundleException;
 import org.osgi.framework.Constants;
 
 public class DevModeTest extends AbstractStateTest {
-
-	public DevModeTest(String name) {
-		super(name);
-	}
 
 	private State buildDevModeState() {
 		State state = buildEmptyState();
@@ -35,6 +35,7 @@ public class DevModeTest extends AbstractStateTest {
 		return state;
 	}
 
+	@Test
 	public void testDevModeDomino02() throws BundleException {
 		State state = buildDevModeState();
 
@@ -108,6 +109,7 @@ public class DevModeTest extends AbstractStateTest {
 		assertTrue("3.2", cRequired[0] == a);
 	}
 
+	@Test
 	public void testDevModeDomino01() throws BundleException {
 		State state = buildDevModeState();
 
@@ -156,6 +158,7 @@ public class DevModeTest extends AbstractStateTest {
 		assertTrue("2.2", cRequired[0] == a);
 	}
 
+	@Test
 	public void testDevModeFragment01() throws BundleException {
 		State state = buildDevModeState();
 
@@ -225,6 +228,7 @@ public class DevModeTest extends AbstractStateTest {
 		assertTrue("3.5", aFrag.getHost().getSupplier() == a);
 	}
 
+	@Test
 	public void testDevModeSingleton01() throws BundleException {
 		State state = buildDevModeState();
 
@@ -279,6 +283,7 @@ public class DevModeTest extends AbstractStateTest {
 		assertTrue("2.2", cRequired[0] == a1);
 	}
 
+	@Test
 	public void testDevModeSingleton02() throws BundleException {
 		State state = buildDevModeState();
 
@@ -335,6 +340,7 @@ public class DevModeTest extends AbstractStateTest {
 		assertTrue("2.2", cRequired[0] == a1);
 	}
 
+	@Test
 	public void testDevModeGenericCapability() throws BundleException {
 		State state = buildDevModeState();
 

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/services/resolver/DisabledInfoTest.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/services/resolver/DisabledInfoTest.java
@@ -13,12 +13,17 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.services.resolver;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.io.File;
 import java.io.IOException;
 import org.eclipse.osgi.service.resolver.BundleDescription;
 import org.eclipse.osgi.service.resolver.DisabledInfo;
 import org.eclipse.osgi.service.resolver.State;
 import org.eclipse.osgi.tests.OSGiTestsActivator;
+import org.junit.Test;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.BundleException;
 
@@ -28,10 +33,7 @@ public class DisabledInfoTest extends AbstractStateTest {
 	private final String B3_LOCATION = "b3"; //$NON-NLS-1$
 	private final String POLICY = "test.policy"; //$NON-NLS-1$
 
-	public DisabledInfoTest(String name) {
-		super(name);
-	}
-
+	@Test
 	public void testDisabledInfo01() throws BundleException {
 		State state = buildTestState();
 		BundleDescription b1 = state.getBundleByLocation(B1_LOCATION);
@@ -64,6 +66,7 @@ public class DisabledInfoTest extends AbstractStateTest {
 		assertTrue("copyInfo3 bundle", copyInfo3.getBundle() == copyB3); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testDisabledInfo02() throws BundleException {
 		State state = buildTestState();
 		BundleDescription b1 = state.getBundleByLocation(B1_LOCATION);
@@ -89,7 +92,8 @@ public class DisabledInfoTest extends AbstractStateTest {
 		assertFalse("b3 resolved", b3.isResolved()); //$NON-NLS-1$
 	}
 
-	public void testDisabledInfo03() throws BundleException {
+	@Test
+	public void testDisabledInfo03() throws BundleException, IOException {
 		State state = buildTestState();
 		BundleDescription b1 = state.getBundleByLocation(B1_LOCATION);
 		BundleDescription b2 = state.getBundleByLocation(B2_LOCATION);
@@ -105,28 +109,25 @@ public class DisabledInfoTest extends AbstractStateTest {
 		BundleContext context = OSGiTestsActivator.getContext();
 		File stateDir = context.getDataFile("testDisabledInfo03"); //$NON-NLS-1$
 		stateDir.mkdirs();
-		try {
-			state.getFactory().writeState(state, stateDir);
-			State copy = state.getFactory().readState(stateDir);
-			BundleDescription copyB1 = copy.getBundleByLocation(B1_LOCATION);
-			BundleDescription copyB2 = copy.getBundleByLocation(B2_LOCATION);
-			BundleDescription copyB3 = copy.getBundleByLocation(B3_LOCATION);
-			DisabledInfo copyInfo1 = copy.getDisabledInfo(copyB1, POLICY);
-			DisabledInfo copyInfo2 = copy.getDisabledInfo(copyB2, POLICY);
-			DisabledInfo copyInfo3 = copy.getDisabledInfo(copyB3, POLICY);
+		state.getFactory().writeState(state, stateDir);
+		State copy = state.getFactory().readState(stateDir);
+		BundleDescription copyB1 = copy.getBundleByLocation(B1_LOCATION);
+		BundleDescription copyB2 = copy.getBundleByLocation(B2_LOCATION);
+		BundleDescription copyB3 = copy.getBundleByLocation(B3_LOCATION);
+		DisabledInfo copyInfo1 = copy.getDisabledInfo(copyB1, POLICY);
+		DisabledInfo copyInfo2 = copy.getDisabledInfo(copyB2, POLICY);
+		DisabledInfo copyInfo3 = copy.getDisabledInfo(copyB3, POLICY);
 
-			assertNotNull("copyInfo1", copyInfo1); //$NON-NLS-1$
-			assertNotNull("copyInfo2", copyInfo2); //$NON-NLS-1$
-			assertNotNull("copyInfo3", copyInfo3); //$NON-NLS-1$
+		assertNotNull("copyInfo1", copyInfo1); //$NON-NLS-1$
+		assertNotNull("copyInfo2", copyInfo2); //$NON-NLS-1$
+		assertNotNull("copyInfo3", copyInfo3); //$NON-NLS-1$
 
-			assertTrue("copyInfo1 bundle", copyInfo1.getBundle() == copyB1); //$NON-NLS-1$
-			assertTrue("copyInfo2 bundle", copyInfo2.getBundle() == copyB2); //$NON-NLS-1$
-			assertTrue("copyInfo3 bundle", copyInfo3.getBundle() == copyB3); //$NON-NLS-1$
-		} catch (IOException e) {
-			fail("Unexpected exception", e); //$NON-NLS-1$
-		}
+		assertTrue("copyInfo1 bundle", copyInfo1.getBundle() == copyB1); //$NON-NLS-1$
+		assertTrue("copyInfo2 bundle", copyInfo2.getBundle() == copyB2); //$NON-NLS-1$
+		assertTrue("copyInfo3 bundle", copyInfo3.getBundle() == copyB3); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testDisabledInfo04() throws BundleException {
 		State state = buildTestState();
 		BundleDescription b1 = state.getBundleByLocation(B1_LOCATION);
@@ -172,6 +173,7 @@ public class DisabledInfoTest extends AbstractStateTest {
 		assertEquals("disabledBundles length", 0, disabledBundles.length); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testBug251427() throws BundleException {
 		State state = buildTestState();
 		BundleDescription b1 = state.getBundleByLocation(B1_LOCATION);

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/services/resolver/GenericCapabilityTest.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/services/resolver/GenericCapabilityTest.java
@@ -13,12 +13,16 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.services.resolver;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import java.util.Dictionary;
 import java.util.Hashtable;
 import org.eclipse.osgi.service.resolver.BundleDescription;
 import org.eclipse.osgi.service.resolver.GenericDescription;
 import org.eclipse.osgi.service.resolver.GenericSpecification;
 import org.eclipse.osgi.service.resolver.State;
+import org.junit.Test;
 import org.osgi.framework.BundleException;
 import org.osgi.framework.Constants;
 
@@ -26,10 +30,7 @@ public class GenericCapabilityTest extends AbstractStateTest {
 	static final String GENERIC_REQUIRE = "Eclipse-GenericRequire"; //$NON-NLS-1$
 	static final String GENERIC_CAPABILITY = "Eclipse-GenericCapability"; //$NON-NLS-1$
 
-	public GenericCapabilityTest(String name) {
-		super(name);
-	}
-
+	@Test
 	public void testGenericsBasics() throws BundleException {
 		State state = buildEmptyState();
 		Hashtable manifest = new Hashtable();
@@ -80,6 +81,7 @@ public class GenericCapabilityTest extends AbstractStateTest {
 		assertEquals("2.4.1", genSpecs[3].getSupplier(), genCap.getGenericCapabilities()[3]);
 	}
 
+	@Test
 	public void testGenericsUpdate() throws BundleException {
 		State state = buildEmptyState();
 		Hashtable manifest = new Hashtable();
@@ -164,6 +166,7 @@ public class GenericCapabilityTest extends AbstractStateTest {
 
 	}
 
+	@Test
 	public void testGenericsRefresh() throws BundleException {
 		State state = buildEmptyState();
 		Hashtable manifest = new Hashtable();
@@ -230,6 +233,7 @@ public class GenericCapabilityTest extends AbstractStateTest {
 
 	}
 
+	@Test
 	public void testGenericsFrags() throws BundleException {
 		State state = buildEmptyState();
 		Hashtable manifest = new Hashtable();
@@ -302,6 +306,7 @@ public class GenericCapabilityTest extends AbstractStateTest {
 		assertEquals("2.6.1", genSpecs[5].getSupplier(), selectedFragCapabilities[0]);
 	}
 
+	@Test
 	public void testGenericsIntraFrags() throws BundleException {
 		State state = buildEmptyState();
 		long bundleID = 0;
@@ -361,6 +366,7 @@ public class GenericCapabilityTest extends AbstractStateTest {
 		assertEquals("2.4.1", genSpecs[3].getSupplier(), selectedFragBCapabilities[0]);
 	}
 
+	@Test
 	public void testGenericsAliases() throws BundleException {
 		State state = buildEmptyState();
 		Dictionary[] allPlatProps = state.getPlatformProperties();
@@ -402,6 +408,7 @@ public class GenericCapabilityTest extends AbstractStateTest {
 		assertEquals("2.3.1", genSpecs[2].getSupplier(), genCap.getGenericCapabilities()[0]);
 	}
 
+	@Test
 	public void testGenericsOptionalMultiple() throws BundleException {
 		State state = buildEmptyState();
 		Hashtable manifest = new Hashtable();
@@ -466,6 +473,7 @@ public class GenericCapabilityTest extends AbstractStateTest {
 		assertEquals("2.6.3", suppliers[1], genCap.getGenericCapabilities()[5]);
 	}
 
+	@Test
 	public void testGenericsCycles() throws BundleException {
 		State state = buildEmptyState();
 		Hashtable manifest = new Hashtable();

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/services/resolver/NewResolverTest.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/services/resolver/NewResolverTest.java
@@ -13,21 +13,22 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.services.resolver;
 
+import static org.junit.Assert.assertNotNull;
+
 import org.eclipse.osgi.service.resolver.BundleDescription;
 import org.eclipse.osgi.service.resolver.State;
+import org.junit.Test;
 import org.osgi.framework.BundleException;
 
 public class NewResolverTest extends AbstractStateTest {
 
-	public NewResolverTest(String testName) {
-		super(testName);
-	}
-
+	@Test
 	public void testSkeleton() {
 		State state = buildEmptyState();
 		state.resolve();
 	}
 
+	@Test
 	public void testBasicScenario1() throws BundleException {
 		State state = buildEmptyState();
 

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/services/resolver/PlatformAdminTest.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/services/resolver/PlatformAdminTest.java
@@ -13,6 +13,11 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.services.resolver;
 
+import static org.eclipse.osgi.tests.OSGiTestsActivator.getContext;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -24,16 +29,18 @@ import org.eclipse.osgi.service.resolver.ExportPackageDescription;
 import org.eclipse.osgi.service.resolver.State;
 import org.eclipse.osgi.service.resolver.StateObjectFactory;
 import org.eclipse.osgi.service.resolver.VersionConstraint;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
 import org.osgi.framework.BundleException;
 import org.osgi.framework.Constants;
 
 public class PlatformAdminTest extends AbstractStateTest {
+	@Rule
+	public TestName testName = new TestName();
+
 	private static final String GENERIC_REQUIRE = "Eclipse-GenericRequire"; //$NON-NLS-1$
 	private static final String GENERIC_CAPABILITY = "Eclipse-GenericCapability"; //$NON-NLS-1$
-
-	public PlatformAdminTest(String name) {
-		super(name);
-	}
 
 	private State storeAndRetrieve(State toStore) throws IOException {
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -42,6 +49,7 @@ public class PlatformAdminTest extends AbstractStateTest {
 		return toStore.getFactory().readState(bais);
 	}
 
+	@Test
 	public void testCache() throws IOException, BundleException {
 		State originalState = buildSimpleState();
 		State retrievedState = storeAndRetrieve(originalState);
@@ -52,6 +60,7 @@ public class PlatformAdminTest extends AbstractStateTest {
 		assertIdentical("2.0", originalState, retrievedState);
 	}
 
+	@Test
 	public void testClone() throws BundleException {
 		State original = buildSimpleState();
 		State newState = original.getFactory().createState(original);
@@ -61,6 +70,7 @@ public class PlatformAdminTest extends AbstractStateTest {
 		assertEquals("2", original, newState);
 	}
 
+	@Test
 	public void testBug205270() throws BundleException {
 		State state = buildSimpleState();
 		Hashtable manifest = new Hashtable();
@@ -71,16 +81,13 @@ public class PlatformAdminTest extends AbstractStateTest {
 		manifest.put(Constants.BUNDLE_VERSION, "1.0.0");
 		manifest.put(Constants.BUNDLE_NATIVECODE, "libwrapper-linux-x86-32.so; wrapper-linux-x86-32; osname=linux; processor=x86");
 		BundleDescription a = state.getFactory().createBundleDescription(state, manifest, (String) manifest.get(Constants.BUNDLE_SYMBOLICNAME) + "_" + manifest.get(Constants.BUNDLE_VERSION), id++);
-		try {
-			BundleDescription aPrime = state.getFactory().createBundleDescription(a);
-			assertEquals("Copy is not equal", a, aPrime);
-		} catch (Throwable t) {
-			fail("Unexpected error while cloning a BundleDescription", t);
-		}
+		BundleDescription aPrime = state.getFactory().createBundleDescription(a);
+		assertEquals("Copy is not equal", a, aPrime);
 	}
 
-	public void testBug184127() throws BundleException {
-		File resolverData = getContext().getDataFile(getName());
+	@Test
+	public void testBug184127() throws BundleException, IOException {
+		File resolverData = getContext().getDataFile(testName.getMethodName());
 		resolverData.mkdirs();
 
 		State systemState = StateObjectFactory.defaultFactory.createState(true);
@@ -133,25 +140,18 @@ public class PlatformAdminTest extends AbstractStateTest {
 		assertTrue("a is not resolved", a.isResolved());
 		assertTrue("b is not resolved", b.isResolved());
 
-		try {
-			StateObjectFactory.defaultFactory.writeState(systemState, resolverData);
-			systemState = StateObjectFactory.defaultFactory.readState(resolverData);
-		} catch (IOException e) {
-			fail("failed to shudown StateManager", e);
-		}
+		StateObjectFactory.defaultFactory.writeState(systemState, resolverData);
+		systemState = StateObjectFactory.defaultFactory.readState(resolverData);
 
 		assertNotNull("SystemState is null", systemState);
 		b = systemState.getBundle("b", null);
 		ExportPackageDescription[] exports = null;
-		try {
-			exports = b.getExportPackages();
-		} catch (Throwable e) {
-			fail("Unexpected exception getting exports", e);
-		}
+		exports = b.getExportPackages();
 		assertNotNull("exports is null", exports);
 		assertEquals("Wrong number of exports", 2, exports.length);
 	}
 
+	@Test
 	public void testBug241128_01() throws BundleException {
 		State state = buildEmptyState();
 		Hashtable manifest = new Hashtable();
@@ -193,6 +193,7 @@ public class PlatformAdminTest extends AbstractStateTest {
 		assertEquals("Wrong unsatisfied constraint", b.getRequiredBundles()[0], unsatisified[0]);
 	}
 
+	@Test
 	public void testBug241128_02() throws BundleException {
 		State state = buildEmptyState();
 		Hashtable manifest = new Hashtable();
@@ -234,6 +235,7 @@ public class PlatformAdminTest extends AbstractStateTest {
 		assertEquals("Wrong unsatisfied constraint", b.getHost(), unsatisified[0]);
 	}
 
+	@Test
 	public void testBug241128_03() throws BundleException {
 		State state = buildEmptyState();
 		Hashtable manifest = new Hashtable();
@@ -277,6 +279,7 @@ public class PlatformAdminTest extends AbstractStateTest {
 		assertEquals("Wrong unsatisfied constraint", b.getImportPackages()[0], unsatisified[0]);
 	}
 
+	@Test
 	public void testBug241128_04() throws BundleException {
 		State state = buildEmptyState();
 		Dictionary[] props = new Dictionary[] {new Hashtable()};
@@ -319,6 +322,7 @@ public class PlatformAdminTest extends AbstractStateTest {
 		assertEquals("Wrong unsatisfied constraint", a2.getNativeCodeSpecification(), unsatisified[0]);
 	}
 
+	@Test
 	public void testGenericsBasics() throws BundleException {
 		State state = buildEmptyState();
 		Hashtable manifest = new Hashtable();

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/services/resolver/StateComparisonTest.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/services/resolver/StateComparisonTest.java
@@ -13,18 +13,19 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.services.resolver;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import org.eclipse.osgi.service.resolver.BundleDelta;
 import org.eclipse.osgi.service.resolver.BundleDescription;
 import org.eclipse.osgi.service.resolver.State;
 import org.eclipse.osgi.service.resolver.StateDelta;
+import org.junit.Test;
 import org.osgi.framework.BundleException;
 
 public class StateComparisonTest extends AbstractStateTest {
 
-	public StateComparisonTest(String testName) {
-		super(testName);
-	}
-
+	@Test
 	public void testAddition() throws BundleException {
 		State state1 = buildEmptyState();
 		State state2 = state1.getFactory().createState(state1);
@@ -47,6 +48,7 @@ public class StateComparisonTest extends AbstractStateTest {
 		assertEquals("3.3", BundleDelta.ADDED, addition.getType());
 	}
 
+	@Test
 	public void testRemoval() throws BundleException {
 		State state1 = buildSimpleState();
 		State state2 = state1.getFactory().createState(state1);
@@ -69,6 +71,7 @@ public class StateComparisonTest extends AbstractStateTest {
 		assertEquals("3.3", BundleDelta.ADDED, addition.getType());
 	}
 
+	@Test
 	public void testUpdate() throws BundleException {
 		State state1 = buildSimpleState();
 		State state2 = state1.getFactory().createState(state1);

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/services/resolver/StateCycleTest.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/services/resolver/StateCycleTest.java
@@ -13,19 +13,19 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.services.resolver;
 
+import static org.junit.Assert.assertTrue;
+
 import java.util.Hashtable;
 import org.eclipse.osgi.service.resolver.BundleDescription;
 import org.eclipse.osgi.service.resolver.ExportPackageDescription;
 import org.eclipse.osgi.service.resolver.State;
+import org.junit.Test;
 import org.osgi.framework.BundleException;
 import org.osgi.framework.Constants;
 
 public class StateCycleTest extends AbstractStateTest {
 
-	public StateCycleTest(String testName) {
-		super(testName);
-	}
-
+	@Test
 	public void testCycle1() throws BundleException {
 		State state1 = buildEmptyState();
 		String A_MANIFEST = "Bundle-SymbolicName: org.eclipse.a\nBundle-Version: 1.0\n";
@@ -65,6 +65,7 @@ public class StateCycleTest extends AbstractStateTest {
 		assertTrue("6.0", bundleF.isResolved());
 	}
 
+	@Test
 	public void testCycle2() throws BundleException {
 		State state1 = buildEmptyState();
 		String A_MANIFEST = "Bundle-SymbolicName: org.eclipse.a\nBundle-Version: 1.0\n";
@@ -105,6 +106,7 @@ public class StateCycleTest extends AbstractStateTest {
 
 	}
 
+	@Test
 	public void testCycle3() throws BundleException {
 		State state = buildEmptyState();
 		String A_MANIFEST = "Bundle-SymbolicName: org.eclipse.a\nBundle-Version: 1.0\n";
@@ -134,6 +136,7 @@ public class StateCycleTest extends AbstractStateTest {
 		assertTrue("3.0", bundleD.isResolved());
 	}
 
+	@Test
 	public void testCycle4() throws BundleException {
 		State state = buildEmptyState();
 		String A_MANIFEST = "Bundle-SymbolicName: org.eclipse.a\nBundle-Version: 1.0\n";
@@ -163,6 +166,7 @@ public class StateCycleTest extends AbstractStateTest {
 		assertTrue("3.0", bundleD.isResolved());
 	}
 
+	@Test
 	public void test185285() throws BundleException {
 		// if two versions of the same bundle export and import two different packages at the same version
 		// then we should resolve both sets of imports to the first bundle installed.

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/services/resolver/StateResolverTest.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/services/resolver/StateResolverTest.java
@@ -13,6 +13,13 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.services.resolver;
 
+import static org.eclipse.osgi.tests.OSGiTestsActivator.getContext;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
@@ -34,8 +41,8 @@ import org.eclipse.osgi.service.resolver.State;
 import org.eclipse.osgi.service.resolver.StateDelta;
 import org.eclipse.osgi.service.resolver.StateHelper;
 import org.eclipse.osgi.service.resolver.StateObjectFactory;
-import org.eclipse.osgi.tests.OSGiTestsActivator;
 import org.eclipse.osgi.util.ManifestElement;
+import org.junit.Test;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.BundleException;
 import org.osgi.framework.Constants;
@@ -53,15 +60,13 @@ import org.osgi.resource.Capability;
 
 public class StateResolverTest extends AbstractStateTest {
 
-	public StateResolverTest(String name) {
-		super(name);
-	}
 
 	/**
 	 * Tests adding 3 new bundles to an already resolved state and then
 	 * resolving only one of the bundles. The result should be all 3 added
 	 * bundles being resolved.
 	 */
+	@Test
 	public void testAdd3Resolve1() throws BundleException {
 		State state = buildInitialState();
 		StateDelta delta = state.resolve();
@@ -123,6 +128,7 @@ public class StateResolverTest extends AbstractStateTest {
 		assertEquals("2.3", (BundleDelta.RESOLVED | BundleDelta.ADDED), ((BundleDelta) deltasMap.get(Long.valueOf(3))).getType()); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testBasicResolution() throws BundleException {
 		State state = buildSimpleState();
 		StateDelta delta = state.resolve();
@@ -153,6 +159,7 @@ public class StateResolverTest extends AbstractStateTest {
 		assertFullyUnresolved("5.3", b3); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testComplexResolution() throws BundleException {
 		State state = buildComplexState();
 		StateDelta delta = state.resolve();
@@ -194,6 +201,7 @@ public class StateResolverTest extends AbstractStateTest {
 		assertFullyResolved("5.6", b6); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testDependentBundles() throws BundleException {
 		State state = buildComplexState();
 		state.resolve();
@@ -209,6 +217,7 @@ public class StateResolverTest extends AbstractStateTest {
 		assertContains("2.4", dependent, state.getBundle(6)); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testPrerequisiteBundle() throws BundleException {
 		State state = buildComplexState();
 		state.resolve();
@@ -244,7 +253,7 @@ public class StateResolverTest extends AbstractStateTest {
 		assertContains("6.4", prereqs, state.getBundle(6)); //$NON-NLS-1$
 	}
 
-	// temporarily disabled
+	@Test
 	public void testLinkageChange() throws BundleException {
 		State state = buildEmptyState();
 		// don't add b1 for now
@@ -302,7 +311,7 @@ public class StateResolverTest extends AbstractStateTest {
 		assertFullyResolved("10.3", b3); //$NON-NLS-1$
 	}
 
-	// temporarily disabled
+	@Test
 	public void testReinstall() throws BundleException {
 		State state = buildComplexState();
 		StateDelta delta = state.resolve();
@@ -310,19 +319,20 @@ public class StateResolverTest extends AbstractStateTest {
 		state.removeBundle(4);
 		delta = state.resolve();
 		assertEquals("1.0", 1, delta.getChanges(BundleDelta.REMOVED | BundleDelta.UNRESOLVED | BundleDelta.REMOVAL_COMPLETE, true).length); //$NON-NLS-1$
-		assertEquals("1.1", 4, delta.getChanges(BundleDelta.REMOVED | BundleDelta.UNRESOLVED | BundleDelta.REMOVAL_COMPLETE, true)[0].getBundle().getBundleId()); //$NON-NLS-1$
+		assertEquals("1.1", 4L, delta.getChanges(BundleDelta.REMOVED | BundleDelta.UNRESOLVED | BundleDelta.REMOVAL_COMPLETE, true)[0].getBundle().getBundleId()); //$NON-NLS-1$
 		assertEquals("2.0", 1, delta.getChanges(BundleDelta.UNRESOLVED, true).length); //$NON-NLS-1$
-		assertEquals("2.1", 6, delta.getChanges(BundleDelta.UNRESOLVED, true)[0].getBundle().getBundleId()); //$NON-NLS-1$
+		assertEquals("2.1", 6L, delta.getChanges(BundleDelta.UNRESOLVED, true)[0].getBundle().getBundleId()); //$NON-NLS-1$
 		// reinstall bundle 4 - should cause 6 to be resolved again
 		BundleDescription b4 = delta.getChanges(BundleDelta.REMOVED | BundleDelta.UNRESOLVED | BundleDelta.REMOVAL_COMPLETE, true)[0].getBundle();
 		state.addBundle(b4);
 		delta = state.resolve();
 		assertEquals("3.0", 1, delta.getChanges(BundleDelta.ADDED | BundleDelta.RESOLVED, true).length); //$NON-NLS-1$
-		assertEquals("3.1", 4, delta.getChanges(BundleDelta.ADDED | BundleDelta.RESOLVED, true)[0].getBundle().getBundleId()); //$NON-NLS-1$
+		assertEquals("3.1", 4L, delta.getChanges(BundleDelta.ADDED | BundleDelta.RESOLVED, true)[0].getBundle().getBundleId()); //$NON-NLS-1$
 		assertEquals("4.0", 1, delta.getChanges(BundleDelta.RESOLVED, true).length); //$NON-NLS-1$
-		assertEquals("4.1", 6, delta.getChanges(BundleDelta.RESOLVED, true)[0].getBundle().getBundleId()); //$NON-NLS-1$
+		assertEquals("4.1", 6L, delta.getChanges(BundleDelta.RESOLVED, true)[0].getBundle().getBundleId()); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testRemoval() throws BundleException {
 		String B1_LOCATION = "org.eclipse.b1"; //$NON-NLS-1$
 		final String B1_MANIFEST = "Bundle-SymbolicName: org.eclipse.b1\n" + "Bundle-Version: 1.0\n"; //$NON-NLS-1$ //$NON-NLS-2$
@@ -353,6 +363,7 @@ public class StateResolverTest extends AbstractStateTest {
 		assertEquals("2.4", BundleDelta.REMOVED | BundleDelta.UNRESOLVED, changes[0].getType()); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testRemoveAndAdd() throws BundleException {
 		String B_LOCATION = "org.eclipse.b"; //$NON-NLS-1$
 		final String B_MANIFEST = "Bundle-SymbolicName: org.eclipse.b\n" + "Bundle-Version: 1.0\n"; //$NON-NLS-1$ //$NON-NLS-2$
@@ -376,6 +387,7 @@ public class StateResolverTest extends AbstractStateTest {
 		assertEquals("2.3", b2, delta.getChanges(BundleDelta.RESOLVED | BundleDelta.ADDED, true)[0].getBundle()); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testRemovalResolve() throws BundleException {
 		State state = buildInitialState();
 		StateDelta delta = state.resolve();
@@ -450,6 +462,7 @@ public class StateResolverTest extends AbstractStateTest {
 	 * bundles being resolved. Then re-resolving the same bundle. The result
 	 * should be only the one bundle being resolved.
 	 */
+	@Test
 	public void testReresolveBundle() throws BundleException {
 		State state = buildInitialState();
 		StateDelta delta = state.resolve();
@@ -525,6 +538,7 @@ public class StateResolverTest extends AbstractStateTest {
 
 	}
 
+	@Test
 	public void testUpdate() throws BundleException {
 		State state = buildEmptyState();
 		String B1_LOCATION = "org.eclipse.b"; //$NON-NLS-1$
@@ -567,6 +581,7 @@ public class StateResolverTest extends AbstractStateTest {
 		assertFullyResolved("3.3", b111); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testSingletons() throws BundleException {
 		State state = buildEmptyState();
 		Hashtable manifest = new Hashtable();
@@ -615,6 +630,7 @@ public class StateResolverTest extends AbstractStateTest {
 		assertTrue("1.4", testDependent.isResolved()); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testSingletonsSameVersion() throws BundleException {
 		// this is a testcase to handle how PDE build is using the state
 		// with multiple singleton bundles installed with the same BSN and version
@@ -657,6 +673,7 @@ public class StateResolverTest extends AbstractStateTest {
 		assertFalse("1.3", testFrag101.isResolved()); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testSingletonsSelection1() throws BundleException {
 		State state = buildEmptyState();
 
@@ -733,6 +750,7 @@ public class StateResolverTest extends AbstractStateTest {
 		assertFalse("2.6", rcp10.isResolved()); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testSingletonsSelection2() throws BundleException {
 		State state = buildEmptyState();
 
@@ -819,6 +837,7 @@ public class StateResolverTest extends AbstractStateTest {
 		assertFalse("2.7", rcp10.isResolved()); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testSingletonsSelection3() throws BundleException {
 		State state = buildEmptyState();
 		int bundleID = 0;
@@ -956,6 +975,7 @@ public class StateResolverTest extends AbstractStateTest {
 
 	}
 
+	@Test
 	public void testSingletonsSelection4() throws BundleException {
 		State state = buildEmptyState();
 		int bundleID = 0;
@@ -1099,6 +1119,7 @@ public class StateResolverTest extends AbstractStateTest {
 
 	}
 
+	@Test
 	public void testSingletonsSelection5() throws BundleException {
 		State state = buildEmptyState();
 		// test the selection algorithm of the resolver to pick the bundles with the largest version
@@ -1197,6 +1218,7 @@ public class StateResolverTest extends AbstractStateTest {
 		assertFalse("1.9", import10.isResolved()); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testSingletonsSelection6() throws BundleException {
 		State state = buildEmptyState();
 
@@ -1283,6 +1305,7 @@ public class StateResolverTest extends AbstractStateTest {
 		assertFalse("2.6", rcp10.isResolved()); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testSingletonsSelection7() throws BundleException {
 		State state = buildEmptyState();
 		long id = 0;
@@ -1348,6 +1371,7 @@ public class StateResolverTest extends AbstractStateTest {
 		assertEquals("Unexpected exporter", a2, imports[0].getExporter()); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testNonSingletonsSameVersion() throws BundleException {
 		// this is a testcase to handle how PDE build is using the state
 		// with multiple singleton bundles installed with the same BSN and version
@@ -1390,6 +1414,7 @@ public class StateResolverTest extends AbstractStateTest {
 		assertTrue("1.3", testFrag101.isResolved()); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testTransitiveUses() throws BundleException {
 		State state = buildEmptyState();
 		Hashtable manifest = new Hashtable();
@@ -1457,6 +1482,7 @@ public class StateResolverTest extends AbstractStateTest {
 		assertNull("1.2 Packages are not consistent: " + isConsistent, isConsistent); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testMultipleExportsUses01() throws BundleException {
 		State state = buildEmptyState();
 		Hashtable manifest = new Hashtable();
@@ -1524,6 +1550,7 @@ public class StateResolverTest extends AbstractStateTest {
 		assertNull("1.2 Packages are not consistent: " + isConsistent, isConsistent); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testRequireBundleUses() throws BundleException {
 		State state = buildEmptyState();
 		int id = 0;
@@ -1579,6 +1606,7 @@ public class StateResolverTest extends AbstractStateTest {
 		assertEquals("2.2", c1ResolvedImports[index].getExporter(), a_100); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testCyclicTransitiveUses() throws BundleException {
 		State state = buildEmptyState();
 		Hashtable manifest = new Hashtable();
@@ -1661,6 +1689,7 @@ public class StateResolverTest extends AbstractStateTest {
 		assertNull("3.1 Packages are not consistent: " + isConsistent, isConsistent); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testFragmentTransitiveUses() throws BundleException {
 		State state = buildEmptyState();
 		Hashtable manifest = new Hashtable();
@@ -1752,6 +1781,7 @@ public class StateResolverTest extends AbstractStateTest {
 		assertNull("3.1 Packages are not consistent: " + isConsistent, isConsistent); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testFragmentUses01() throws BundleException {
 		long id = 0;
 		State state = buildEmptyState();
@@ -1809,6 +1839,7 @@ public class StateResolverTest extends AbstractStateTest {
 		assertTrue("0.5", c2.isResolved()); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testFragmentUses02() throws BundleException {
 		long id = 0;
 		State state = buildEmptyState();
@@ -1870,6 +1901,7 @@ public class StateResolverTest extends AbstractStateTest {
 		assertTrue("0.5", c2.isResolved()); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testCyclicUsesExportDrop() throws BundleException {
 		State state = buildEmptyState();
 		Hashtable manifest = new Hashtable();
@@ -1918,6 +1950,7 @@ public class StateResolverTest extends AbstractStateTest {
 		assertEquals("1.2", "b", w1_100.getSelectedExports()[0].getName()); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
+	@Test
 	public void testRemovalPending() throws BundleException {
 		State state = buildEmptyState();
 		Hashtable wManifest = new Hashtable();
@@ -1976,6 +2009,7 @@ public class StateResolverTest extends AbstractStateTest {
 		assertNull("4.1 Packages are not consistent: " + isConsistent, isConsistent); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testFragmentConstraints01() throws BundleException {
 		int id = 0;
 		State state = buildEmptyState();
@@ -2088,6 +2122,7 @@ public class StateResolverTest extends AbstractStateTest {
 		assertFalse("3.5", d1_100.isResolved()); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testFragmentConstraints02() throws BundleException {
 		int id = 0;
 		State state = buildEmptyState();
@@ -2165,6 +2200,7 @@ public class StateResolverTest extends AbstractStateTest {
 		}
 	}
 
+	@Test
 	public void testFragmentConstraints03() throws BundleException {
 		// same as testFragmentConstraints02 but with a cycle
 		int id = 0;
@@ -2249,6 +2285,7 @@ public class StateResolverTest extends AbstractStateTest {
 		assertEquals("2.2", aSelectedExports[0], bResolvedImports[0]); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testFragmentConstraints04() throws BundleException {
 		int id = 0;
 		State state = buildEmptyState();
@@ -2330,6 +2367,7 @@ public class StateResolverTest extends AbstractStateTest {
 		assertEquals("1.3", d, aResolvedRequires[2]); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testFragmentConstraints05() throws BundleException {
 		// same as testFragmentConstraints04 but with a cycle
 		int id = 0;
@@ -2416,6 +2454,7 @@ public class StateResolverTest extends AbstractStateTest {
 		assertEquals("2.1", a, dResolvedRequires[0]); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testFragmentConstraints06() throws BundleException {
 		int id = 0;
 		State state = buildEmptyState();
@@ -2510,6 +2549,7 @@ public class StateResolverTest extends AbstractStateTest {
 		assertEquals("1.3", d, aResolvedRequires[2]); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testFragmentConstraints07() throws BundleException {
 		// same as testFragmentConstraints06 but with a cycle
 		int id = 0;
@@ -2613,6 +2653,7 @@ public class StateResolverTest extends AbstractStateTest {
 		assertEquals("2.2", aSelectedExports[0], dResolvedImports[0]); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testFragmentsBug188199() throws BundleException {
 		State state = buildEmptyState();
 		int bundleID = 0;
@@ -2680,6 +2721,7 @@ public class StateResolverTest extends AbstractStateTest {
 		assertTrue("3.4", aExports[1] == bImports[1]); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testFragmentsMultipleVersion() throws BundleException {
 		State state = buildEmptyState();
 		int bundleID = 0;
@@ -2730,6 +2772,7 @@ public class StateResolverTest extends AbstractStateTest {
 		assertEquals("1.4", a1, aFrag2.getHost().getSupplier()); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testPlatformProperties01() throws BundleException {
 		State state = buildEmptyState();
 		int bundleID = 0;
@@ -2849,6 +2892,7 @@ public class StateResolverTest extends AbstractStateTest {
 		assertTrue("2.2", c.getResolvedImports()[1].getExporter() == systemB); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testPlatformProperties02() throws BundleException {
 		// same as 01 except use alias system.bundle to another name "test.system.bundle"
 		State state = buildEmptyState();
@@ -2926,6 +2970,7 @@ public class StateResolverTest extends AbstractStateTest {
 		assertTrue("2.1", b_updated.getResolvedImports()[0].getExporter() == systemB); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testPlatformProperties03() throws BundleException {
 		// test that require-bundle, fragment-host, and import-package of system.bundle can be aliased properly
 		State state = buildEmptyState();
@@ -3031,6 +3076,7 @@ public class StateResolverTest extends AbstractStateTest {
 		assertTrue("2.7", h.getHost().getHosts()[0] == systemBundle); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testPlatformProperties04() throws BundleException {
 		// same as 03 except use a different system.bundle alias other than org.eclipse.osgi
 		// test that require-bundle, fragment-host, and import-package of system.bundle can be aliased properly
@@ -3138,6 +3184,7 @@ public class StateResolverTest extends AbstractStateTest {
 		assertTrue("2.7", h.getHost().getHosts()[0] == systemBundle); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testPlatformPropertiesBug188075() throws BundleException, IOException {
 		State state = buildEmptyState();
 		int bundleID = 0;
@@ -3167,7 +3214,7 @@ public class StateResolverTest extends AbstractStateTest {
 		assertFalse("1.1", a.isResolved()); //$NON-NLS-1$
 		assertTrue("1.2", b.isResolved()); //$NON-NLS-1$
 
-		BundleContext context = OSGiTestsActivator.getContext();
+		BundleContext context = getContext();
 		File stateCache = context.getDataFile("statecache"); //$NON-NLS-1$
 		stateCache.mkdirs();
 		StateObjectFactory.defaultFactory.writeState(state, stateCache);
@@ -3180,6 +3227,7 @@ public class StateResolverTest extends AbstractStateTest {
 		assertTrue("2.2", bCache.isResolved()); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testPlatformPropertiesBug207500a() throws BundleException, IOException {
 		State state = buildEmptyState();
 		int bundleID = 0;
@@ -3210,7 +3258,7 @@ public class StateResolverTest extends AbstractStateTest {
 		assertTrue("1.1", a.isResolved()); //$NON-NLS-1$
 		assertTrue("1.2", b.isResolved()); //$NON-NLS-1$
 
-		BundleContext context = OSGiTestsActivator.getContext();
+		BundleContext context = getContext();
 		File stateCache = context.getDataFile("statecache"); //$NON-NLS-1$
 		stateCache.mkdirs();
 		StateObjectFactory.defaultFactory.writeState(state, stateCache);
@@ -3231,6 +3279,7 @@ public class StateResolverTest extends AbstractStateTest {
 		assertFalse("3.2", bCache.isResolved()); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testPlatformPropertiesBug207500b() throws BundleException {
 		State state = buildEmptyState();
 		int bundleID = 0;
@@ -3256,6 +3305,7 @@ public class StateResolverTest extends AbstractStateTest {
 		assertTrue("1.1", a.isResolved()); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testPlatformPropertiesBug246640a() throws BundleException {
 		State state = buildEmptyState();
 		int bundleID = 0;
@@ -3310,6 +3360,7 @@ public class StateResolverTest extends AbstractStateTest {
 		assertTrue("2.0", a.getResolvedImports()[0].getExporter() == systemBundle2); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testPlatformPropertiesBug246640b() throws BundleException {
 		State state = buildEmptyState();
 		int bundleID = 0;
@@ -3365,6 +3416,7 @@ public class StateResolverTest extends AbstractStateTest {
 		assertTrue("2.0", a.getResolvedImports()[0].getExporter() == systemBundle2); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testEECapabilityRequirement() throws BundleException {
 		State state = buildEmptyState();
 		int bundleID = 0;
@@ -3569,6 +3621,7 @@ public class StateResolverTest extends AbstractStateTest {
 		}
 	}
 
+	@Test
 	public void testEECapabilityRequirement1() throws BundleException {
 		State state = buildEmptyState();
 		int bundleID = 0;
@@ -3680,6 +3733,7 @@ public class StateResolverTest extends AbstractStateTest {
 		assertEquals("2.4", 1, wiresE.size());
 	}
 
+	@Test
 	public void testEEBug377510() throws BundleException {
 		State state = buildEmptyState();
 		int bundleID = 0;
@@ -3723,6 +3777,7 @@ public class StateResolverTest extends AbstractStateTest {
 		assertTrue("fragment not resolved", aFrag.isResolved());
 	}
 
+	@Test
 	public void testImportJavaPackages() throws Exception {
 		State state = buildEmptyState();
 		int bundleID = 0;
@@ -3796,18 +3851,14 @@ public class StateResolverTest extends AbstractStateTest {
 
 	private static final String MANIFEST_ROOT = "test_files/resolverTests/";
 
-	private Dictionary loadManifest(String manifest) {
+	private Dictionary loadManifest(String manifest) throws IOException, BundleException {
 		URL url = getContext().getBundle().getEntry(MANIFEST_ROOT + manifest);
-		try {
-			CaseInsensitiveDictionaryMap<String, String> headers = new CaseInsensitiveDictionaryMap<>();
-			ManifestElement.parseBundleManifest(url.openStream(), headers);
-			return headers.asUnmodifiableDictionary();
-		} catch (IOException | BundleException e) {
-			fail("Unexpected error loading manifest: " + manifest, e);
-		}
-		return null;
+		CaseInsensitiveDictionaryMap<String, String> headers = new CaseInsensitiveDictionaryMap<>();
+		ManifestElement.parseBundleManifest(url.openStream(), headers);
+		return headers.asUnmodifiableDictionary();
 	}
 
+	@Test
 	public void testSelectionPolicy() throws BundleException {
 		State state = buildEmptyState();
 		Resolver resolver = state.getResolver();
@@ -3860,6 +3911,7 @@ public class StateResolverTest extends AbstractStateTest {
 		assertTrue("1.4", testDependent.isResolved()); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testBug187616() throws BundleException {
 		State state = buildEmptyState();
 		Hashtable manifest = new Hashtable();
@@ -3911,6 +3963,7 @@ public class StateResolverTest extends AbstractStateTest {
 		assertTrue("2.0", bDelta.length == 5); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testBug217150() throws BundleException {
 		State state = buildEmptyState();
 		Hashtable manifest = new Hashtable();
@@ -3938,6 +3991,7 @@ public class StateResolverTest extends AbstractStateTest {
 		assertEquals("Unexpected number of hosts", 0, hosts.length); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testNativeCodeResolution01() throws BundleException {
 		State state = buildEmptyState();
 		Dictionary[] props = new Dictionary[] {new Hashtable()};
@@ -3960,6 +4014,7 @@ public class StateResolverTest extends AbstractStateTest {
 
 	}
 
+	@Test
 	public void testNativeCodeResolution02() throws BundleException {
 		State state = buildEmptyState();
 		Dictionary[] props = new Dictionary[] {new Hashtable()};
@@ -3979,6 +4034,7 @@ public class StateResolverTest extends AbstractStateTest {
 		assertTrue("1.0", testNativeBundle.isResolved()); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testNativeCodeResolution03() throws BundleException {
 		State state = buildEmptyState();
 		Dictionary[] props = new Dictionary[] {new Hashtable()};
@@ -3998,6 +4054,7 @@ public class StateResolverTest extends AbstractStateTest {
 		assertTrue("1.0", testNativeBundle.isResolved()); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testNativeCodeResolution04() throws BundleException {
 		State state = buildEmptyState();
 		Dictionary[] props = new Dictionary[] {new Hashtable()};
@@ -4017,6 +4074,7 @@ public class StateResolverTest extends AbstractStateTest {
 		assertTrue("1.0", testNativeBundle.isResolved()); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testNativeCodeResolution05() throws BundleException {
 		State state = buildEmptyState();
 		Dictionary[] props = new Dictionary[] {new Hashtable(), new Hashtable(), new Hashtable()};
@@ -4071,6 +4129,7 @@ public class StateResolverTest extends AbstractStateTest {
 		assertTrue("3.0", testNativeBundle3.isResolved()); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testNativeCodeResolution06() throws BundleException {
 		State state = buildEmptyState();
 		Dictionary[] props = new Dictionary[] {new Hashtable(), new Hashtable(), new Hashtable()};
@@ -4102,6 +4161,7 @@ public class StateResolverTest extends AbstractStateTest {
 		assertTrue("1.0", testNativeBundle1.isResolved()); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testMultiStateAdd01() throws BundleException {
 		State state1 = buildEmptyState();
 
@@ -4153,6 +4213,7 @@ public class StateResolverTest extends AbstractStateTest {
 		}
 	}
 
+	@Test
 	public void testMultiStateAdd02() throws BundleException {
 		State state1 = buildEmptyState();
 
@@ -4207,6 +4268,7 @@ public class StateResolverTest extends AbstractStateTest {
 		}
 	}
 
+	@Test
 	public void testMultiStateAdd03() throws BundleException {
 		State state1 = buildEmptyState();
 
@@ -4255,11 +4317,7 @@ public class StateResolverTest extends AbstractStateTest {
 		state1.resolve(new BundleDescription[] {rcp10});
 		State state2 = buildEmptyState();
 
-		try {
-			state2.addBundle(rcp10);
-		} catch (IllegalStateException e) {
-			fail("Unexpected IllegalStateException on adding to state", e); //$NON-NLS-1$
-		}
+		state2.addBundle(rcp10);
 	}
 
 	private State createBug266935State() throws BundleException {
@@ -4300,6 +4358,7 @@ public class StateResolverTest extends AbstractStateTest {
 		return newA;
 	}
 
+	@Test
 	public void testBug266935_01() throws BundleException {
 		State state = createBug266935State();
 		BundleDescription a = state.getBundle("a", new Version("1.0")); //$NON-NLS-1$ //$NON-NLS-2$
@@ -4308,6 +4367,7 @@ public class StateResolverTest extends AbstractStateTest {
 		state.resolve(new BundleDescription[] {newA});
 	}
 
+	@Test
 	public void testBug266935_02() throws BundleException {
 		State state = createBug266935State();
 		BundleDescription a = state.getBundle("a", new Version("1.0")); //$NON-NLS-1$ //$NON-NLS-2$
@@ -4316,6 +4376,7 @@ public class StateResolverTest extends AbstractStateTest {
 		state.resolve(new BundleDescription[] {a});
 	}
 
+	@Test
 	public void testBug266935_03() throws BundleException {
 		State state = createBug266935State();
 		BundleDescription a = state.getBundle("a", new Version("1.0")); //$NON-NLS-1$ //$NON-NLS-2$
@@ -4324,6 +4385,7 @@ public class StateResolverTest extends AbstractStateTest {
 		state.resolve(new BundleDescription[] {newA});
 	}
 
+	@Test
 	public void testBug266935_04() throws BundleException {
 		State state = createBug266935State();
 		BundleDescription a = state.getBundle("a", new Version("1.0")); //$NON-NLS-1$ //$NON-NLS-2$
@@ -4332,6 +4394,7 @@ public class StateResolverTest extends AbstractStateTest {
 		state.resolve(new BundleDescription[] {a});
 	}
 
+	@Test
 	public void testBug320124() throws BundleException {
 		State state = buildEmptyState();
 		int bundleID = 0;
@@ -4390,6 +4453,7 @@ public class StateResolverTest extends AbstractStateTest {
 		assertEquals("Wrong number of visible", 2, visible.length);
 	}
 
+	@Test
 	public void testCycleBug570984() throws BundleException {
 		State state = buildEmptyState();
 		int bundleID = 0;
@@ -4449,7 +4513,8 @@ public class StateResolverTest extends AbstractStateTest {
 		}
 	}
 
-	public void testBug324618() throws BundleException {
+	@Test
+	public void testBug324618() throws BundleException, IOException {
 		State state = buildEmptyState();
 		long bundleID = 0;
 		Dictionary manifest;
@@ -4477,6 +4542,7 @@ public class StateResolverTest extends AbstractStateTest {
 		assertNotNull("x.extra dynamic import is null", xExtra);
 	}
 
+	@Test
 	public void testRequirements() throws BundleException, InvalidSyntaxException, IOException {
 		State state = buildEmptyState();
 		long bundleID = 0;
@@ -4491,7 +4557,7 @@ public class StateResolverTest extends AbstractStateTest {
 
 		doTestRequirements(hostDescription, fragDescription);
 
-		File stateCache = OSGiTestsActivator.getContext().getDataFile("statecache"); //$NON-NLS-1$
+		File stateCache = getContext().getDataFile("statecache"); //$NON-NLS-1$
 		stateCache.mkdirs();
 		StateObjectFactory.defaultFactory.writeState(state, stateCache);
 		state = StateObjectFactory.defaultFactory.readState(stateCache);
@@ -4615,6 +4681,7 @@ public class StateResolverTest extends AbstractStateTest {
 		}
 	}
 
+	@Test
 	public void testCapabilities() throws InvalidSyntaxException, BundleException, IOException {
 		State state = buildEmptyState();
 		long bundleID = 0;
@@ -4626,7 +4693,7 @@ public class StateResolverTest extends AbstractStateTest {
 
 		doTestCapabilities(hostDescription);
 
-		File stateCache = OSGiTestsActivator.getContext().getDataFile("statecache"); //$NON-NLS-1$
+		File stateCache = getContext().getDataFile("statecache"); //$NON-NLS-1$
 		stateCache.mkdirs();
 		StateObjectFactory.defaultFactory.writeState(state, stateCache);
 		state = StateObjectFactory.defaultFactory.readState(stateCache);
@@ -4669,6 +4736,7 @@ public class StateResolverTest extends AbstractStateTest {
 		}
 	}
 
+	@Test
 	public void testRanges() throws BundleException {
 		State state = buildEmptyState();
 		int bundleID = 0;
@@ -4724,6 +4792,7 @@ public class StateResolverTest extends AbstractStateTest {
 		assertTrue("E is not resolved", e.isResolved()); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testBug369880() throws BundleException {
 		State state = buildEmptyState();
 		Dictionary[] props = new Dictionary[] {new Hashtable()};
@@ -4768,6 +4837,7 @@ public class StateResolverTest extends AbstractStateTest {
 		assertEquals("Wrong number of wires from fragment", 1, bRequiredWires.size());
 	}
 
+	@Test
 	public void testResolveFragmentEE01() throws BundleException {
 		State state = buildEmptyState();
 		Dictionary[] props = new Dictionary[] {new Hashtable()};
@@ -4838,6 +4908,7 @@ public class StateResolverTest extends AbstractStateTest {
 		assertFalse("C is not resolved", c.isResolved()); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testResolveFragmentEE02() throws BundleException, IOException {
 		State state = buildEmptyState();
 		Dictionary[] props = new Dictionary[] {new Hashtable()};
@@ -4916,7 +4987,7 @@ public class StateResolverTest extends AbstractStateTest {
 		assertEquals("Wrong number of osgi.ee requirements from c", 1, cRequirements.size());
 		assertEquals("Wrong number of wires from c", 1, cRequiredWires.size());
 
-		File stateCache = OSGiTestsActivator.getContext().getDataFile("statecache"); //$NON-NLS-1$
+		File stateCache = getContext().getDataFile("statecache"); //$NON-NLS-1$
 		stateCache.mkdirs();
 		StateObjectFactory.defaultFactory.writeState(state, stateCache);
 		state = StateObjectFactory.defaultFactory.readState(stateCache);
@@ -4945,6 +5016,7 @@ public class StateResolverTest extends AbstractStateTest {
 		assertEquals("Wrong number of wires from c", 1, cRequiredWires.size());
 	}
 
+	@Test
 	public void testBug376322() throws BundleException, IOException {
 		State state = buildEmptyState();
 		int bundleID = 0;
@@ -4962,7 +5034,7 @@ public class StateResolverTest extends AbstractStateTest {
 		props[0].put(Constants.FRAMEWORK_SYSTEMPACKAGES_EXTRA, longExport);
 		state.setPlatformProperties(props);
 
-		File stateCache = OSGiTestsActivator.getContext().getDataFile("statecache"); //$NON-NLS-1$
+		File stateCache = getContext().getDataFile("statecache"); //$NON-NLS-1$
 		stateCache.mkdirs();
 		StateObjectFactory.defaultFactory.writeState(state, stateCache);
 		state = StateObjectFactory.defaultFactory.readState(stateCache);
@@ -4974,6 +5046,7 @@ public class StateResolverTest extends AbstractStateTest {
 	 * Not easy to preproduce, as it depends heavily on the internal sort algorithm, TimSort, and
 	 * therefore trimmed real life data is used for this test.
 	 */
+	@Test
 	 public void testIssue156() throws BundleException, IOException, Exception {
 		State state = buildEmptyState();
 		int bundleID = 0;

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/services/resolver/SubstitutableExportsTest.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/services/resolver/SubstitutableExportsTest.java
@@ -14,6 +14,10 @@
 package org.eclipse.osgi.tests.services.resolver;
 
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.Hashtable;
 import org.eclipse.osgi.service.resolver.BundleDelta;
@@ -23,14 +27,11 @@ import org.eclipse.osgi.service.resolver.ImportPackageSpecification;
 import org.eclipse.osgi.service.resolver.State;
 import org.eclipse.osgi.service.resolver.StateDelta;
 import org.eclipse.osgi.service.resolver.VersionConstraint;
+import org.junit.Test;
 import org.osgi.framework.BundleException;
 import org.osgi.framework.Constants;
 
 public class SubstitutableExportsTest extends AbstractStateTest {
-
-	public SubstitutableExportsTest(String name) {
-		super(name);
-	}
 
 	private State getSubstituteBasicState() throws BundleException {
 		// Basic substitutable export test with A, B, C all exporting and importing x,y packages
@@ -1285,6 +1286,7 @@ public class SubstitutableExportsTest extends AbstractStateTest {
 		return state;
 	}
 
+	@Test
 	public void testSubstitutableExports001() throws BundleException {
 		State state = getSubstituteBasicState();
 		state.resolve();
@@ -1333,6 +1335,7 @@ public class SubstitutableExportsTest extends AbstractStateTest {
 		assertArrayEquals("fVisible not correct", aSubtitutes, fVisible); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testSubstitutableExports002() throws BundleException {
 		State state = getSubstituteUsesState();
 		state.resolve();
@@ -1385,6 +1388,7 @@ public class SubstitutableExportsTest extends AbstractStateTest {
 		assertArrayEquals("fVisible not correct", aExports, fVisible); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testSubstitutableExports003() throws BundleException {
 		State state = getSubstituteUsesCycleState();
 		state.resolve();
@@ -1451,6 +1455,7 @@ public class SubstitutableExportsTest extends AbstractStateTest {
 		}
 	}
 
+	@Test
 	public void testSubstitutableExports004() throws BundleException {
 		State state = getSubstituteBasicFragState();
 		state.resolve();
@@ -1519,6 +1524,7 @@ public class SubstitutableExportsTest extends AbstractStateTest {
 		assertArrayEquals("fVisible not correct", aExports, fVisible); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testSubstitutableExports005() throws BundleException {
 		State state = getSubstituteUsesFragState();
 		state.resolve();
@@ -1593,6 +1599,7 @@ public class SubstitutableExportsTest extends AbstractStateTest {
 		assertArrayEquals("fVisible not correct", aExports, fVisible); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testSubstitutableExports006() throws BundleException {
 		State state = getSubstituteUsesFragCycleState();
 		state.resolve();
@@ -1689,6 +1696,7 @@ public class SubstitutableExportsTest extends AbstractStateTest {
 		assertArrayEquals("iVisible not correct", expectedHIVisible, iVisible); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testSubstitutableExports007() throws BundleException {
 		State state = getSubstituteBasicReexportState();
 		state.resolve();
@@ -1754,6 +1762,7 @@ public class SubstitutableExportsTest extends AbstractStateTest {
 		assertArrayEquals("iVisible not correct", aExports, iVisible); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testSubstitutableExports008() throws BundleException {
 		State state = getSubstituteUsesReexportState();
 		state.resolve();
@@ -1824,6 +1833,7 @@ public class SubstitutableExportsTest extends AbstractStateTest {
 		assertArrayEquals("iVisible not correct", aExports, iVisible); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testSubstitutableExports009() throws BundleException {
 		State state = getSubstituteUsesReexportCycleState();
 		state.resolve();
@@ -1899,6 +1909,7 @@ public class SubstitutableExportsTest extends AbstractStateTest {
 		assertArrayEquals("jVisible not correct", aExports, jVisible); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testSubstitutableExports010() throws BundleException {
 		State state = getSubstituteBasicState();
 		state.resolve();
@@ -1930,6 +1941,7 @@ public class SubstitutableExportsTest extends AbstractStateTest {
 		assertEquals("bunldeDeltas wrong number", 1, bundleDeltas.length); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testSubstitutableExports011() throws BundleException {
 		State state = getSubstituteUsesState();
 		state.resolve();
@@ -1967,6 +1979,7 @@ public class SubstitutableExportsTest extends AbstractStateTest {
 		assertEquals("bunldeDeltas wrong number", 1, bundleDeltas.length); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testSubstitutableExports012() throws BundleException {
 		State state = getSubstituteUsesCycleState();
 		state.resolve();
@@ -2015,6 +2028,7 @@ public class SubstitutableExportsTest extends AbstractStateTest {
 		}
 	}
 
+	@Test
 	public void testSubstitutableExports013() throws BundleException {
 		State state = getSubstituteBasicFragState();
 		state.resolve();
@@ -2066,6 +2080,7 @@ public class SubstitutableExportsTest extends AbstractStateTest {
 		}
 	}
 
+	@Test
 	public void testSubstitutableExports014() throws BundleException {
 		State state = getSubstituteUsesFragState();
 		state.resolve();
@@ -2124,6 +2139,7 @@ public class SubstitutableExportsTest extends AbstractStateTest {
 		}
 	}
 
+	@Test
 	public void testSubstitutableExports015() throws BundleException {
 		State state = getSubstituteUsesFragCycleState();
 		state.resolve();
@@ -2177,6 +2193,7 @@ public class SubstitutableExportsTest extends AbstractStateTest {
 		}
 	}
 
+	@Test
 	public void testSubstitutableExports016() throws BundleException {
 		State state = getSubstituteBasicReexportState();
 		state.resolve();
@@ -2227,6 +2244,7 @@ public class SubstitutableExportsTest extends AbstractStateTest {
 		assertEquals("bunldeDeltas wrong number", 1, bundleDeltas.length); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testSubstitutableExports017() throws BundleException {
 		State state = getSubstituteUsesReexportState();
 		state.resolve();
@@ -2284,6 +2302,7 @@ public class SubstitutableExportsTest extends AbstractStateTest {
 		assertEquals("bunldeDeltas wrong number", 1, bundleDeltas.length); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testSubstitutableExports018() throws BundleException {
 		State state = getSubstituteUsesReexportCycleState();
 		state.resolve();
@@ -2334,6 +2353,7 @@ public class SubstitutableExportsTest extends AbstractStateTest {
 		}
 	}
 
+	@Test
 	public void testSubstitutableExports019() throws BundleException {
 		State state = getSubstituteUnresolvedFragState();
 		state.resolve();
@@ -2398,6 +2418,7 @@ public class SubstitutableExportsTest extends AbstractStateTest {
 		assertArrayEquals("fVisible not correct", aExports, fVisible); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testSubstitutableExports020() throws BundleException {
 		State state = getSubstituteUnresolvedFragState();
 		state.resolve();
@@ -2479,6 +2500,7 @@ public class SubstitutableExportsTest extends AbstractStateTest {
 		assertArrayEquals("fVisible not correct", aExports, fVisible); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testSubstitutableExports021() throws BundleException {
 		State state = getSubstituteBasicState();
 		state.resolve();
@@ -2522,6 +2544,7 @@ public class SubstitutableExportsTest extends AbstractStateTest {
 		assertArrayEquals("fVisible not correct", bExports, fVisible); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testSubstitutableExports022() throws BundleException {
 		State state = getSubstituteSplitState();
 		state.resolve();
@@ -2601,6 +2624,7 @@ public class SubstitutableExportsTest extends AbstractStateTest {
 		}
 	}
 
+	@Test
 	public void testSubstitutableExports023() throws BundleException {
 		State state = getSubstituteSplitUsesState();
 		state.resolve();
@@ -2722,6 +2746,7 @@ public class SubstitutableExportsTest extends AbstractStateTest {
 		}
 	}
 
+	@Test
 	public void testSubstitutableExports024() throws BundleException {
 		State state = getNonOverlapingSubstituteBasicState();
 		state.resolve();
@@ -2772,6 +2797,7 @@ public class SubstitutableExportsTest extends AbstractStateTest {
 		assertEquals("Should not have any unresolvable constraints", 0, unsatisfied.length);
 	}
 
+	@Test
 	public void testSubstitutableExports025() throws BundleException {
 		State state = getSubstituteUsesState();
 		BundleDescription a = state.getBundle(1);

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/services/resolver/XFriendsInternalResolverTest.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/services/resolver/XFriendsInternalResolverTest.java
@@ -13,20 +13,20 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.services.resolver;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import java.util.Dictionary;
 import java.util.Hashtable;
 import org.eclipse.osgi.service.resolver.BundleDescription;
 import org.eclipse.osgi.service.resolver.ExportPackageDescription;
 import org.eclipse.osgi.service.resolver.State;
 import org.eclipse.osgi.service.resolver.StateHelper;
+import org.junit.Test;
 import org.osgi.framework.BundleException;
 import org.osgi.framework.Constants;
 
 public class XFriendsInternalResolverTest extends AbstractStateTest {
-
-	public XFriendsInternalResolverTest(String name) {
-		super(name);
-	}
 
 	/**
 	 * Tests the x-friends directive.  A bundle should not be allowed to import a package which
@@ -34,6 +34,7 @@ public class XFriendsInternalResolverTest extends AbstractStateTest {
 	 * anther bundle which exports packages which declare an x-friends directive it should not
 	 * have access to the packages unless the requiring bundle is a friend.
 	 */
+	@Test
 	public void testXFriends() throws BundleException {
 		State state = buildEmptyState();
 		int bundleID = 0;
@@ -142,6 +143,7 @@ public class XFriendsInternalResolverTest extends AbstractStateTest {
 		assertTrue("5.2", contains(validPackages2, required2[1].getName()));
 	}
 
+	@Test
 	public void testVisiblePackages001() throws BundleException {
 		State state = buildEmptyState();
 		int bundleID = 0;
@@ -191,6 +193,7 @@ public class XFriendsInternalResolverTest extends AbstractStateTest {
 		assertTrue("2.4", exporter2 == aBase || exporter2 == aExtra);
 	}
 
+	@Test
 	public void testVisiblePackages002() throws BundleException {
 		State state = buildEmptyState();
 		int bundleID = 0;
@@ -287,6 +290,7 @@ public class XFriendsInternalResolverTest extends AbstractStateTest {
 		assertTrue("4.2", visImporter3[0].getExporter() == baseImporter2);
 	}
 
+	@Test
 	public void testVisiblePackages003() throws BundleException {
 		State state = buildEmptyState();
 		int bundleID = 0;

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/util/NLSTestCase.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/util/NLSTestCase.java
@@ -14,17 +14,14 @@
 
 package org.eclipse.osgi.tests.util;
 
-import org.eclipse.core.tests.harness.CoreTest;
 import org.eclipse.osgi.util.NLS;
+import org.junit.Test;
 
-public class NLSTestCase extends CoreTest {
+public class NLSTestCase {
 
+	@Test
 	public void testEmptyMessageBug200296() {
-		try {
-			NLS.bind("", Integer.valueOf(0));
-		} catch (NegativeArraySizeException e) {
-			fail("1.0", e);
-		}
+		NLS.bind("", Integer.valueOf(0));
 	}
 
 }

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/util/ObjectPoolTestCase.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/util/ObjectPoolTestCase.java
@@ -14,13 +14,27 @@
 
 package org.eclipse.osgi.tests.util;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import java.util.ArrayList;
 import java.util.List;
-import org.eclipse.core.tests.harness.CoreTest;
 import org.eclipse.osgi.framework.util.ObjectPool;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
 import org.osgi.framework.Version;
 
-public class ObjectPoolTestCase extends CoreTest {
+public class ObjectPoolTestCase {
+
+	@Rule
+	public TestName testName = new TestName();
+
+	private String getName() {
+		return testName.getMethodName();
+	}
+
+	@Test
 	public void testObjectPool01() {
 		// Tests ObjectPool with strings only
 		List objects = new ArrayList();
@@ -55,6 +69,7 @@ public class ObjectPoolTestCase extends CoreTest {
 		doGC();
 	}
 
+	@Test
 	public void testObjectPool02() {
 		// Test both strings and versions
 		List strings = new ArrayList();

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/util/StorageUtilTestCase.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/util/StorageUtilTestCase.java
@@ -13,13 +13,15 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.util;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import java.io.File;
 import org.eclipse.core.runtime.Platform;
-import org.eclipse.core.tests.harness.CoreTest;
 import org.eclipse.osgi.storage.StorageUtil;
 import org.junit.Test;
 
-public class StorageUtilTestCase extends CoreTest {
+public class StorageUtilTestCase {
 
 	@Test
 	public void testRegularWindowsFileName() {

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/util/TestCaseinsensitiveMap.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/util/TestCaseinsensitiveMap.java
@@ -1,13 +1,16 @@
 package org.eclipse.osgi.tests.util;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import org.eclipse.core.tests.harness.CoreTest;
 import org.eclipse.osgi.framework.util.CaseInsensitiveDictionaryMap;
+import org.junit.Test;
 import org.osgi.framework.Constants;
 
-public class TestCaseinsensitiveMap extends CoreTest {
+public class TestCaseinsensitiveMap {
 	@SuppressWarnings("deprecation")
 	static String[] COMMON_KEY_NAMES = new String[] { //
 
@@ -77,10 +80,12 @@ public class TestCaseinsensitiveMap extends CoreTest {
 	private static final String VALUE1 = "-VALUE1";
 	private static final String VALUE2 = "-VALUE2";
 
+	@Test
 	public void testCommonKeys() {
 		testKeys(COMMON_KEY_NAMES);
 	}
 
+	@Test
 	public void testOtherKeys() {
 		testKeys(OTHER_KEY_NAMES);
 	}


### PR DESCRIPTION
This migrates all tests in `org.eclipse.osgi.tests.resolver` and `org.eclipse.osgi.tests.services.resolver` to JUnit 4

* Add JUnit 4 annotations `@Test`, `@Before`, `@After`
* Remove inheritance of JUnit 3 `TestCase` and `CoreTest`
* Replace try-catch for actual errors with making the test method throw the exception