### PR TITLE
Make session tests in o.e.osgi.tests independent from OSGiTest/CoreTest

### DIFF
--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/appadmin/ApplicationAdminTest.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/appadmin/ApplicationAdminTest.java
@@ -13,15 +13,20 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.appadmin;
 
+import static org.eclipse.osgi.tests.OSGiTest.PI_OSGI_TESTS;
+import static org.eclipse.osgi.tests.OSGiTest.addRequiredOSGiTestsBundles;
+import static org.eclipse.osgi.tests.OSGiTestsActivator.getContext;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import junit.framework.AssertionFailedError;
 import junit.framework.Test;
+import junit.framework.TestCase;
 import junit.framework.TestSuite;
 import org.eclipse.core.tests.session.ConfigurationSessionTestSuite;
 import org.eclipse.core.tests.session.SetupManager.SetupException;
-import org.eclipse.osgi.tests.OSGiTest;
 import org.eclipse.osgi.tests.OSGiTestsActivator;
 import org.eclipse.osgi.tests.bundles.BundleInstaller;
 import org.osgi.framework.Bundle;
@@ -37,7 +42,7 @@ import org.osgi.service.application.ScheduledApplication;
 import org.osgi.util.tracker.ServiceTracker;
 import org.osgi.util.tracker.ServiceTrackerCustomizer;
 
-public class ApplicationAdminTest extends OSGiTest {
+public class ApplicationAdminTest extends TestCase {
 	public static final String testRunnerApp = "org.eclipse.pde.junit.runtime.coretestapplicationnonmain"; //$NON-NLS-1$
 	public static final String testResults = "test.results"; //$NON-NLS-1$
 	public static final String SUCCESS = "success"; //$NON-NLS-1$
@@ -106,6 +111,12 @@ public class ApplicationAdminTest extends OSGiTest {
 		HashMap args = new HashMap();
 		args.put(testResults, new HashMap());
 		return args;
+	}
+
+	private void fail(String message, Throwable throwable) {
+		AssertionFailedError error = new AssertionFailedError(message);
+		error.initCause(throwable);
+		throw error;
 	}
 
 	public void testSimpleApp() {

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/appadmin/ApplicationRelaunchTest.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/appadmin/ApplicationRelaunchTest.java
@@ -13,12 +13,16 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.appadmin;
 
+import static org.eclipse.osgi.tests.OSGiTest.PI_OSGI_TESTS;
+import static org.eclipse.osgi.tests.OSGiTest.addRequiredOSGiTestsBundles;
+import static org.eclipse.osgi.tests.OSGiTestsActivator.getContext;
+
 import java.util.HashMap;
 import junit.framework.Test;
+import junit.framework.TestCase;
 import junit.framework.TestSuite;
 import org.eclipse.core.tests.session.ConfigurationSessionTestSuite;
 import org.eclipse.core.tests.session.SetupManager.SetupException;
-import org.eclipse.osgi.tests.OSGiTest;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.framework.ServiceReference;
@@ -26,7 +30,7 @@ import org.osgi.service.application.ApplicationDescriptor;
 import org.osgi.service.application.ApplicationHandle;
 
 // This is for the most part a stripped down copy of ApplicationAdminTest.
-public class ApplicationRelaunchTest extends OSGiTest {
+public class ApplicationRelaunchTest extends TestCase {
 	public static final String testRunnerRelauncherApp = PI_OSGI_TESTS + ".relaunchApp"; //$NON-NLS-1$
 	public static final String testResults = "test.results"; //$NON-NLS-1$
 	public static final String SUCCESS = "success"; //$NON-NLS-1$
@@ -57,35 +61,31 @@ public class ApplicationRelaunchTest extends OSGiTest {
 		super(name);
 	}
 
-	private ApplicationDescriptor getApplication(String appName) {
-		try {
-			BundleContext context = getContext();
-			assertNotNull("BundleContext is null!!", context); //$NON-NLS-1$
-			Class appDescClass = ApplicationDescriptor.class;
-			assertNotNull("ApplicationDescriptor.class is null!!", appDescClass); //$NON-NLS-1$
-			ServiceReference[] refs = context.getServiceReferences(appDescClass.getName(), "(" + ApplicationDescriptor.APPLICATION_PID + "=" + appName + ")"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-			if (refs == null || refs.length == 0) {
-				refs = getContext().getServiceReferences(ApplicationDescriptor.class.getName(), null);
-				String availableApps = ""; //$NON-NLS-1$
-				if (refs != null) {
-					for (int i = 0; i < refs.length; i++) {
-						availableApps += refs[i].getProperty(ApplicationDescriptor.APPLICATION_PID);
-						if (i < refs.length - 1)
-							availableApps += ","; //$NON-NLS-1$
-					}
+	private ApplicationDescriptor getApplication(String appName) throws InvalidSyntaxException {
+		BundleContext context = getContext();
+		assertNotNull("BundleContext is null!!", context); //$NON-NLS-1$
+		Class appDescClass = ApplicationDescriptor.class;
+		assertNotNull("ApplicationDescriptor.class is null!!", appDescClass); //$NON-NLS-1$
+		ServiceReference[] refs = context.getServiceReferences(appDescClass.getName(),
+				"(" + ApplicationDescriptor.APPLICATION_PID + "=" + appName + ")"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+		if (refs == null || refs.length == 0) {
+			refs = getContext().getServiceReferences(ApplicationDescriptor.class.getName(), null);
+			String availableApps = ""; //$NON-NLS-1$
+			if (refs != null) {
+				for (int i = 0; i < refs.length; i++) {
+					availableApps += refs[i].getProperty(ApplicationDescriptor.APPLICATION_PID);
+					if (i < refs.length - 1)
+						availableApps += ","; //$NON-NLS-1$
 				}
-				fail("Could not find app pid: " + appName + " available apps are: " + availableApps); //$NON-NLS-1$ //$NON-NLS-2$
 			}
-			ApplicationDescriptor result = (ApplicationDescriptor) getContext().getService(refs[0]);
-			if (result != null)
-				getContext().ungetService(refs[0]);
-			else
-				fail("Could not get application descriptor service: " + appName); //$NON-NLS-1$
-			return result;
-		} catch (InvalidSyntaxException e) {
-			fail("Could not create app filter", e); //$NON-NLS-1$
+			fail("Could not find app pid: " + appName + " available apps are: " + availableApps); //$NON-NLS-1$ //$NON-NLS-2$
 		}
-		return null;
+		ApplicationDescriptor result = (ApplicationDescriptor) getContext().getService(refs[0]);
+		if (result != null)
+			getContext().ungetService(refs[0]);
+		else
+			fail("Could not get application descriptor service: " + appName); //$NON-NLS-1$
+		return result;
 	}
 
 	private HashMap getArguments() {
@@ -94,19 +94,15 @@ public class ApplicationRelaunchTest extends OSGiTest {
 		return args;
 	}
 
-	public void testRelaunch() {
+	public void testRelaunch() throws Exception {
 		// this is the same as ApplicationAdminTest.testSimpleApp() (but launched
 		// through a different test runner app RelaunchApp which is the thing being
 		// tested)
 		ApplicationDescriptor app = getApplication(PI_OSGI_TESTS + ".simpleApp"); //$NON-NLS-1$
 		HashMap args = getArguments();
 		HashMap results = (HashMap) args.get(testResults);
-		try {
-			ApplicationHandle handle = app.launch(args);
-			handle.destroy();
-		} catch (Throwable e) {
-			fail("failed to launch simpleApp", e); //$NON-NLS-1$
-		}
+		ApplicationHandle handle = app.launch(args);
+		handle.destroy();
 		String result = (String) results.get(simpleResults);
 		assertEquals("Check application result", SUCCESS, result); //$NON-NLS-1$
 	}

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/configuration/EclipseStarterConfigurationAreaTest.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/configuration/EclipseStarterConfigurationAreaTest.java
@@ -13,18 +13,22 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.configuration;
 
+import static org.eclipse.osgi.tests.OSGiTest.PI_OSGI_TESTS;
+import static org.eclipse.osgi.tests.OSGiTest.addRequiredOSGiTestsBundles;
+import static org.eclipse.osgi.tests.OSGiTestsActivator.getContext;
+
 import java.util.List;
 import junit.framework.Test;
+import junit.framework.TestCase;
 import junit.framework.TestSuite;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.tests.session.ConfigurationSessionTestSuite;
-import org.eclipse.osgi.tests.OSGiTest;
 import org.osgi.framework.Constants;
 import org.osgi.framework.namespace.HostNamespace;
 import org.osgi.framework.wiring.BundleWire;
 import org.osgi.framework.wiring.BundleWiring;
 
-public class EclipseStarterConfigurationAreaTest extends OSGiTest {
+public class EclipseStarterConfigurationAreaTest extends TestCase {
 
 	public static Test suite() {
 		TestSuite suite = new TestSuite(EclipseStarterConfigurationAreaTest.class.getName());

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/configuration/MovableConfigurationAreaTest.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/configuration/MovableConfigurationAreaTest.java
@@ -13,6 +13,10 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.configuration;
 
+import static org.eclipse.osgi.tests.OSGiTest.PI_OSGI_TESTS;
+import static org.eclipse.osgi.tests.OSGiTest.addRequiredOSGiTestsBundles;
+import static org.eclipse.osgi.tests.OSGiTestsActivator.getContext;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -24,12 +28,11 @@ import org.eclipse.core.tests.harness.BundleTestingHelper;
 import org.eclipse.core.tests.harness.FileSystemComparator;
 import org.eclipse.core.tests.harness.FileSystemHelper;
 import org.eclipse.core.tests.session.ConfigurationSessionTestSuite;
-import org.eclipse.osgi.tests.OSGiTest;
 import org.eclipse.osgi.tests.OSGiTestsActivator;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleException;
 
-public class MovableConfigurationAreaTest extends OSGiTest {
+public class MovableConfigurationAreaTest extends TestCase {
 
 	static void doMove(final IPath sourcePath, final IPath destinationPath) {
 		assertTrue("Failed moving " + sourcePath + " to " + destinationPath, sourcePath.toFile().renameTo(destinationPath.toFile()));
@@ -109,16 +112,13 @@ public class MovableConfigurationAreaTest extends OSGiTest {
 		}
 	}
 
-	public void testInitialization() throws MalformedURLException, IOException {
+	public void testInitialization() throws Exception {
 		// initialization session
-		try {
-			Bundle installed = BundleTestingHelper.installBundle("1.0", getContext(), OSGiTestsActivator.TEST_FILES_ROOT + "configuration/bundle01");
-			// not read-only yet, should work fine
-			if (!BundleTestingHelper.resolveBundles(getContext(), new Bundle[] {installed}))
-				fail("1.1");
-		} catch (BundleException be) {
-			fail("1.2", be);
-		}
+		Bundle installed = BundleTestingHelper.installBundle("1.0", getContext(),
+				OSGiTestsActivator.TEST_FILES_ROOT + "configuration/bundle01");
+		// not read-only yet, should work fine
+		assertTrue("installed bundle could not be resolved: " + installed,
+				BundleTestingHelper.resolveBundles(getContext(), new Bundle[] { installed }));
 	}
 
 	public void testVerifySnapshot() throws IOException {

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/configuration/ReadOnlyConfigurationAreaTest.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/configuration/ReadOnlyConfigurationAreaTest.java
@@ -13,19 +13,22 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.configuration;
 
+import static org.eclipse.osgi.tests.OSGiTest.PI_OSGI_TESTS;
+import static org.eclipse.osgi.tests.OSGiTest.addRequiredOSGiTestsBundles;
+import static org.eclipse.osgi.tests.OSGiTestsActivator.getContext;
+
 import java.io.File;
 import java.io.IOException;
-import java.net.MalformedURLException;
 import junit.framework.Test;
+import junit.framework.TestCase;
 import org.eclipse.core.tests.harness.BundleTestingHelper;
 import org.eclipse.core.tests.harness.FileSystemComparator;
 import org.eclipse.core.tests.session.ConfigurationSessionTestSuite;
-import org.eclipse.osgi.tests.OSGiTest;
 import org.eclipse.osgi.tests.OSGiTestsActivator;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleException;
 
-public class ReadOnlyConfigurationAreaTest extends OSGiTest {
+public class ReadOnlyConfigurationAreaTest extends TestCase {
 
 	public static Test suite() {
 		ConfigurationSessionTestSuite suite = new ConfigurationSessionTestSuite(PI_OSGI_TESTS, ReadOnlyConfigurationAreaTest.class);
@@ -38,31 +41,26 @@ public class ReadOnlyConfigurationAreaTest extends OSGiTest {
 		super(name);
 	}
 
-	public void test0thSession() throws MalformedURLException, IOException {
+	public void test0thSession() throws Exception {
 		// initialization session
-		try {
-			Bundle installed = BundleTestingHelper.installBundle("1.0", getContext(), OSGiTestsActivator.TEST_FILES_ROOT + "configuration/bundle01");
-			// not read-only yet, should work fine
-			if (!BundleTestingHelper.resolveBundles(getContext(), new Bundle[] {installed}))
-				fail("1.1");
-		} catch (BundleException be) {
-			fail("1.2", be);
-		}
+		Bundle installed = BundleTestingHelper.installBundle("1.0", getContext(),
+				OSGiTestsActivator.TEST_FILES_ROOT + "configuration/bundle01");
+		// not read-only yet, should work fine
+		assertTrue("installed bundle could not be resolved: " + installed,
+				BundleTestingHelper.resolveBundles(getContext(), new Bundle[] { installed }));
 	}
 
 	/**
 	 * Takes a snapshot of the file system.
+	 * 
+	 * @throws IOException
 	 */
-	public void test1stSession() {
+	public void test1stSession() throws IOException {
 		// compute and save tree image
 		File configurationDir = ConfigurationSessionTestSuite.getConfigurationDir();
 		FileSystemComparator comparator = new FileSystemComparator();
 		Object snapshot = comparator.takeSnapshot(configurationDir, true);
-		try {
-			comparator.saveSnapshot(snapshot, configurationDir);
-		} catch (IOException e) {
-			fail("1.0");
-		}
+		comparator.saveSnapshot(snapshot, configurationDir);
 	}
 
 	public void test1stSessionFollowUp() throws IOException {

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/security/BaseSecurityTest.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/security/BaseSecurityTest.java
@@ -24,8 +24,8 @@ import java.security.KeyStoreException;
 import java.security.cert.Certificate;
 import java.util.ArrayList;
 import java.util.Hashtable;
+import junit.framework.TestCase;
 import org.eclipse.core.runtime.FileLocator;
-import org.eclipse.core.tests.harness.CoreTest;
 import org.eclipse.core.tests.session.ConfigurationSessionTestSuite;
 import org.eclipse.osgi.internal.provisional.service.security.AuthorizationEngine;
 import org.eclipse.osgi.internal.service.security.KeyStoreTrustEngine;
@@ -33,11 +33,12 @@ import org.eclipse.osgi.service.security.TrustEngine;
 import org.eclipse.osgi.signedcontent.SignedContentFactory;
 import org.eclipse.osgi.tests.OSGiTestsActivator;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleException;
 import org.osgi.framework.Constants;
 import org.osgi.framework.ServiceReference;
 import org.osgi.framework.ServiceRegistration;
 
-public class BaseSecurityTest extends CoreTest {
+public class BaseSecurityTest extends TestCase {
 
 	private static char[] PASSWORD_DEFAULT = {'c', 'h', 'a', 'n', 'g', 'e', 'i', 't'};
 	private static String TYPE_DEFAULT = "JKS";
@@ -133,15 +134,10 @@ public class BaseSecurityTest extends CoreTest {
 		return engine;
 	}
 
-	protected Bundle installBundle(String bundlePath) {
+	protected Bundle installBundle(String bundlePath) throws BundleException, IOException {
 		URL bundleURL = OSGiTestsActivator.getBundle().getEntry(bundlePath);
 		assertNotNull("Bundle URL is null " + bundlePath, bundleURL);
-		try {
-			return OSGiTestsActivator.getContext().installBundle(bundlePath, bundleURL.openStream());
-		} catch (Exception e) {
-			fail("unexpected install exception", e);
-		}
-		return null;
+		return OSGiTestsActivator.getContext().installBundle(bundlePath, bundleURL.openStream());
 	}
 
 	protected static File getEntryFile(String entryPath) throws IOException {

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/security/OSGiAPICertificateTest.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/security/OSGiAPICertificateTest.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.security;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import org.osgi.framework.AdminPermission;
@@ -95,295 +96,212 @@ public class OSGiAPICertificateTest extends BaseSecurityTest {
 	}
 
 	@Override
-	protected Bundle installBundle(String bundlePath) {
+	protected Bundle installBundle(String bundlePath) throws BundleException, IOException {
 		Bundle b = super.installBundle(bundlePath);
 		installedBundles.add(b);
 		return b;
 	}
 
-	public void testBundleSignerCondition01() {
+	public void testBundleSignerCondition01() throws Exception {
 		// test trusted cert with all signed match
-		try {
-			getTrustEngine().addTrustAnchor(getTestCertificate("ca1_leafa"), "ca1_leafa"); //$NON-NLS-1$ //$NON-NLS-2$
-			Bundle testBundle = installBundle(getTestJarPath("signed")); //$NON-NLS-1$
-			Condition condition = BundleSignerCondition.getCondition(testBundle, info01True);
-			assertEquals("Unexpected condition value", Condition.TRUE, condition); //$NON-NLS-1$
-		} catch (Exception e) {
-			fail("Unexpected exception", e); //$NON-NLS-1$
-		}
+		getTrustEngine().addTrustAnchor(getTestCertificate("ca1_leafa"), "ca1_leafa"); //$NON-NLS-1$ //$NON-NLS-2$
+		Bundle testBundle = installBundle(getTestJarPath("signed")); //$NON-NLS-1$
+		Condition condition = BundleSignerCondition.getCondition(testBundle, info01True);
+		assertEquals("Unexpected condition value", Condition.TRUE, condition); //$NON-NLS-1$
 	}
 
-	public void testBundleSignerCondition02() {
+	public void testBundleSignerCondition02() throws Exception {
 		// test trusted cert with all signed match + "!" not operation
-		try {
-			getTrustEngine().addTrustAnchor(getTestCertificate("ca1_leafa"), "ca1_leafa"); //$NON-NLS-1$ //$NON-NLS-2$
-			Bundle testBundle = installBundle(getTestJarPath("signed")); //$NON-NLS-1$
-			Condition condition = BundleSignerCondition.getCondition(testBundle, info02False);
-			assertEquals("Unexpected condition value", Condition.FALSE, condition); //$NON-NLS-1$
-		} catch (Exception e) {
-			fail("Unexpected exception", e); //$NON-NLS-1$
-		}
+		getTrustEngine().addTrustAnchor(getTestCertificate("ca1_leafa"), "ca1_leafa"); //$NON-NLS-1$ //$NON-NLS-2$
+		Bundle testBundle = installBundle(getTestJarPath("signed")); //$NON-NLS-1$
+		Condition condition = BundleSignerCondition.getCondition(testBundle, info02False);
+		assertEquals("Unexpected condition value", Condition.FALSE, condition); //$NON-NLS-1$
 	}
 
-	public void testBundleSignerCondition03() {
+	public void testBundleSignerCondition03() throws Exception {
 		// test untrusted cert with all signed match
-		try {
-			Bundle testBundle = installBundle(getTestJarPath("signed")); //$NON-NLS-1$
-			Condition condition = BundleSignerCondition.getCondition(testBundle, info01True);
-			assertEquals("Unexpected condition value", Condition.FALSE, condition); //$NON-NLS-1$
-		} catch (Exception e) {
-			fail("Unexpected exception", e); //$NON-NLS-1$
-		}
+		Bundle testBundle = installBundle(getTestJarPath("signed")); //$NON-NLS-1$
+		Condition condition = BundleSignerCondition.getCondition(testBundle, info01True);
+		assertEquals("Unexpected condition value", Condition.FALSE, condition); //$NON-NLS-1$
 	}
 
-	public void testBundleSignerCondition04() {
+	public void testBundleSignerCondition04() throws Exception {
 		// test untrusted cert with all signed match + "!" not operation
-		try {
-			Bundle testBundle = installBundle(getTestJarPath("signed")); //$NON-NLS-1$
-			Condition condition = BundleSignerCondition.getCondition(testBundle, info02False);
-			assertEquals("Unexpected condition value", Condition.TRUE, condition); //$NON-NLS-1$
-		} catch (Exception e) {
-			fail("Unexpected exception", e); //$NON-NLS-1$
-		}
+		Bundle testBundle = installBundle(getTestJarPath("signed")); //$NON-NLS-1$
+		Condition condition = BundleSignerCondition.getCondition(testBundle, info02False);
+		assertEquals("Unexpected condition value", Condition.TRUE, condition); //$NON-NLS-1$
 	}
 
-	public void testBundleSignerCondition05() {
+	public void testBundleSignerCondition05() throws Exception {
 		// test trusted cert with exact match pattern
-		try {
-			getTrustEngine().addTrustAnchor(getTestCertificate("ca1_leafa"), "ca1_leafa"); //$NON-NLS-1$ //$NON-NLS-2$
-			Bundle testBundle = installBundle(getTestJarPath("signed")); //$NON-NLS-1$
-			Condition condition = BundleSignerCondition.getCondition(testBundle, info03True);
-			assertEquals("Unexpected condition value", Condition.TRUE, condition); //$NON-NLS-1$
-		} catch (Exception e) {
-			fail("Unexpected exception", e); //$NON-NLS-1$
-		}
+		getTrustEngine().addTrustAnchor(getTestCertificate("ca1_leafa"), "ca1_leafa"); //$NON-NLS-1$ //$NON-NLS-2$
+		Bundle testBundle = installBundle(getTestJarPath("signed")); //$NON-NLS-1$
+		Condition condition = BundleSignerCondition.getCondition(testBundle, info03True);
+		assertEquals("Unexpected condition value", Condition.TRUE, condition); //$NON-NLS-1$
 	}
 
-	public void testBundleSignerCondition06() {
+	public void testBundleSignerCondition06() throws Exception {
 		// test trusted cert with prefix wildcard match pattern
-		try {
-			getTrustEngine().addTrustAnchor(getTestCertificate("ca1_leafa"), "ca1_leafa"); //$NON-NLS-1$ //$NON-NLS-2$
-			Bundle testBundle = installBundle(getTestJarPath("signed")); //$NON-NLS-1$
-			Condition condition = BundleSignerCondition.getCondition(testBundle, info04True);
-			assertEquals("Unexpected condition value", Condition.TRUE, condition); //$NON-NLS-1$
-		} catch (Exception e) {
-			fail("Unexpected exception", e); //$NON-NLS-1$
-		}
+		getTrustEngine().addTrustAnchor(getTestCertificate("ca1_leafa"), "ca1_leafa"); //$NON-NLS-1$ //$NON-NLS-2$
+		Bundle testBundle = installBundle(getTestJarPath("signed")); //$NON-NLS-1$
+		Condition condition = BundleSignerCondition.getCondition(testBundle, info04True);
+		assertEquals("Unexpected condition value", Condition.TRUE, condition); //$NON-NLS-1$
 	}
 
-	public void testBundleSignerCondition07() {
+	public void testBundleSignerCondition07() throws Exception {
 		// test trusted cert with postfix wildcard match pattern
-		try {
-			getTrustEngine().addTrustAnchor(getTestCertificate("ca1_leafa"), "ca1_leafa"); //$NON-NLS-1$ //$NON-NLS-2$
-			Bundle testBundle = installBundle(getTestJarPath("signed")); //$NON-NLS-1$
-			Condition condition = BundleSignerCondition.getCondition(testBundle, info05True);
-			assertEquals("Unexpected condition value", Condition.TRUE, condition); //$NON-NLS-1$
-		} catch (Exception e) {
-			fail("Unexpected exception", e); //$NON-NLS-1$
-		}
+		getTrustEngine().addTrustAnchor(getTestCertificate("ca1_leafa"), "ca1_leafa"); //$NON-NLS-1$ //$NON-NLS-2$
+		Bundle testBundle = installBundle(getTestJarPath("signed")); //$NON-NLS-1$
+		Condition condition = BundleSignerCondition.getCondition(testBundle, info05True);
+		assertEquals("Unexpected condition value", Condition.TRUE, condition); //$NON-NLS-1$
 	}
 
-	public void testBundleSignerCondition08() {
+	public void testBundleSignerCondition08() throws Exception {
 		// test trusted cert with wrong prefix dn
-		try {
-			getTrustEngine().addTrustAnchor(getTestCertificate("ca1_leafa"), "ca1_leafa"); //$NON-NLS-1$ //$NON-NLS-2$
-			Bundle testBundle = installBundle(getTestJarPath("signed")); //$NON-NLS-1$
-			Condition condition = BundleSignerCondition.getCondition(testBundle, info06False);
-			assertEquals("Unexpected condition value", Condition.FALSE, condition); //$NON-NLS-1$
-		} catch (Exception e) {
-			fail("Unexpected exception", e); //$NON-NLS-1$
-		}
+		getTrustEngine().addTrustAnchor(getTestCertificate("ca1_leafa"), "ca1_leafa"); //$NON-NLS-1$ //$NON-NLS-2$
+		Bundle testBundle = installBundle(getTestJarPath("signed")); //$NON-NLS-1$
+		Condition condition = BundleSignerCondition.getCondition(testBundle, info06False);
+		assertEquals("Unexpected condition value", Condition.FALSE, condition); //$NON-NLS-1$
 	}
 
-	public void testBundleSignerCondition09() {
+	public void testBundleSignerCondition09() throws Exception {
 		// test trusted cert with wrong postfix dn
-		try {
-			getTrustEngine().addTrustAnchor(getTestCertificate("ca1_leafa"), "ca1_leafa"); //$NON-NLS-1$ //$NON-NLS-2$
-			Bundle testBundle = installBundle(getTestJarPath("signed")); //$NON-NLS-1$
-			Condition condition = BundleSignerCondition.getCondition(testBundle, info07False);
-			assertEquals("Unexpected condition value", Condition.FALSE, condition); //$NON-NLS-1$
-		} catch (Exception e) {
-			fail("Unexpected exception", e); //$NON-NLS-1$
-		}
+		getTrustEngine().addTrustAnchor(getTestCertificate("ca1_leafa"), "ca1_leafa"); //$NON-NLS-1$ //$NON-NLS-2$
+		Bundle testBundle = installBundle(getTestJarPath("signed")); //$NON-NLS-1$
+		Condition condition = BundleSignerCondition.getCondition(testBundle, info07False);
+		assertEquals("Unexpected condition value", Condition.FALSE, condition); //$NON-NLS-1$
 	}
 
-	public void testBundleSignerCondition10() {
+	public void testBundleSignerCondition10() throws Exception {
 		// test trusted cert with RDN wildcard match pattern
-		try {
-			getTrustEngine().addTrustAnchor(getTestCertificate("ca1_leafa"), "ca1_leafa"); //$NON-NLS-1$ //$NON-NLS-2$
-			Bundle testBundle = installBundle(getTestJarPath("signed")); //$NON-NLS-1$
-			Condition condition = BundleSignerCondition.getCondition(testBundle, info08True);
-			assertEquals("Unexpected condition value", Condition.TRUE, condition); //$NON-NLS-1$
-		} catch (Exception e) {
-			fail("Unexpected exception", e); //$NON-NLS-1$
-		}
+		getTrustEngine().addTrustAnchor(getTestCertificate("ca1_leafa"), "ca1_leafa"); //$NON-NLS-1$ //$NON-NLS-2$
+		Bundle testBundle = installBundle(getTestJarPath("signed")); //$NON-NLS-1$
+		Condition condition = BundleSignerCondition.getCondition(testBundle, info08True);
+		assertEquals("Unexpected condition value", Condition.TRUE, condition); //$NON-NLS-1$
 	}
 
-	public void testBundleSignerCondition11() {
+	public void testBundleSignerCondition11() throws Exception {
 		// test trusted cert with RDN wildcard match pattern
-		try {
-			getTrustEngine().addTrustAnchor(getTestCertificate("ca1_leafa"), "ca1_leafa"); //$NON-NLS-1$ //$NON-NLS-2$
-			Bundle testBundle = installBundle(getTestJarPath("signed")); //$NON-NLS-1$
-			Condition condition = BundleSignerCondition.getCondition(testBundle, info09True);
-			assertEquals("Unexpected condition value", Condition.TRUE, condition); //$NON-NLS-1$
-		} catch (Exception e) {
-			fail("Unexpected exception", e); //$NON-NLS-1$
-		}
+		getTrustEngine().addTrustAnchor(getTestCertificate("ca1_leafa"), "ca1_leafa"); //$NON-NLS-1$ //$NON-NLS-2$
+		Bundle testBundle = installBundle(getTestJarPath("signed")); //$NON-NLS-1$
+		Condition condition = BundleSignerCondition.getCondition(testBundle, info09True);
+		assertEquals("Unexpected condition value", Condition.TRUE, condition); //$NON-NLS-1$
 	}
 
-	public void testBundleSignerCondition12() {
+	public void testBundleSignerCondition12() throws Exception {
 		// test trusted cert with RDN wildcard match pattern
-		try {
-			getTrustEngine().addTrustAnchor(getTestCertificate("ca1_leafa"), "ca1_leafa"); //$NON-NLS-1$ //$NON-NLS-2$
-			Bundle testBundle = installBundle(getTestJarPath("signed")); //$NON-NLS-1$
-			Condition condition = BundleSignerCondition.getCondition(testBundle, info10True);
-			assertEquals("Unexpected condition value", Condition.TRUE, condition); //$NON-NLS-1$
-		} catch (Exception e) {
-			fail("Unexpected exception", e); //$NON-NLS-1$
-		}
+		getTrustEngine().addTrustAnchor(getTestCertificate("ca1_leafa"), "ca1_leafa"); //$NON-NLS-1$ //$NON-NLS-2$
+		Bundle testBundle = installBundle(getTestJarPath("signed")); //$NON-NLS-1$
+		Condition condition = BundleSignerCondition.getCondition(testBundle, info10True);
+		assertEquals("Unexpected condition value", Condition.TRUE, condition); //$NON-NLS-1$
 	}
 
-	public void testAdminPermission01() {
+	public void testAdminPermission01() throws Exception {
 		// test trusted cert with exact match pattern
-		try {
-			getTrustEngine().addTrustAnchor(getTestCertificate("ca1_leafa"), "ca1_leafa"); //$NON-NLS-1$ //$NON-NLS-2$
-			Bundle testBundle = installBundle(getTestJarPath("signed")); //$NON-NLS-1$
-			AdminPermission declaredPerm = new AdminPermission("(signer=-)", AdminPermission.CONTEXT); //$NON-NLS-1$
-			AdminPermission checkedPerm = new AdminPermission(testBundle, AdminPermission.CONTEXT);
-			assertTrue("Security check failed", declaredPerm.implies(checkedPerm)); //$NON-NLS-1$
-		} catch (Exception e) {
-			fail("Unexpected exception", e); //$NON-NLS-1$
-		}
+		getTrustEngine().addTrustAnchor(getTestCertificate("ca1_leafa"), "ca1_leafa"); //$NON-NLS-1$ //$NON-NLS-2$
+		Bundle testBundle = installBundle(getTestJarPath("signed")); //$NON-NLS-1$
+		AdminPermission declaredPerm = new AdminPermission("(signer=-)", AdminPermission.CONTEXT); //$NON-NLS-1$
+		AdminPermission checkedPerm = new AdminPermission(testBundle, AdminPermission.CONTEXT);
+		assertTrue("Security check failed", declaredPerm.implies(checkedPerm)); //$NON-NLS-1$
 	}
 
-	public void testAdminPermission02() {
+	public void testAdminPermission02() throws Exception {
 		// test trusted cert with exact match pattern
-		try {
-			getTrustEngine().addTrustAnchor(getTestCertificate("ca1_leafa"), "ca1_leafa"); //$NON-NLS-1$ //$NON-NLS-2$
-			Bundle testBundle = installBundle(getTestJarPath("signed")); //$NON-NLS-1$
-			AdminPermission declaredPerm = new AdminPermission("(signer=" + dnChain01TrueEscaped + ")", AdminPermission.CONTEXT); //$NON-NLS-1$ //$NON-NLS-2$
-			AdminPermission checkedPerm = new AdminPermission(testBundle, AdminPermission.CONTEXT);
-			assertTrue("Security check failed", declaredPerm.implies(checkedPerm)); //$NON-NLS-1$
-		} catch (Exception e) {
-			fail("Unexpected exception", e); //$NON-NLS-1$
-		}
+		getTrustEngine().addTrustAnchor(getTestCertificate("ca1_leafa"), "ca1_leafa"); //$NON-NLS-1$ //$NON-NLS-2$
+		Bundle testBundle = installBundle(getTestJarPath("signed")); //$NON-NLS-1$
+		AdminPermission declaredPerm = new AdminPermission("(signer=" + dnChain01TrueEscaped + ")", //$NON-NLS-1$ //$NON-NLS-2$
+				AdminPermission.CONTEXT);
+		AdminPermission checkedPerm = new AdminPermission(testBundle, AdminPermission.CONTEXT);
+		assertTrue("Security check failed", declaredPerm.implies(checkedPerm)); //$NON-NLS-1$
 	}
 
-	public void testAdminPermission03() {
+	public void testAdminPermission03() throws Exception {
 		// test trusted cert with exact match pattern + ! operation
-		try {
-			getTrustEngine().addTrustAnchor(getTestCertificate("ca1_leafa"), "ca1_leafa"); //$NON-NLS-1$ //$NON-NLS-2$
-			Bundle testBundle = installBundle(getTestJarPath("signed")); //$NON-NLS-1$
-			AdminPermission declaredPerm = new AdminPermission("(!(signer=-))", AdminPermission.CONTEXT); //$NON-NLS-1$
-			AdminPermission checkedPerm = new AdminPermission(testBundle, AdminPermission.CONTEXT);
-			assertFalse("Security check failed", declaredPerm.implies(checkedPerm)); //$NON-NLS-1$
-		} catch (Exception e) {
-			fail("Unexpected exception", e); //$NON-NLS-1$
-		}
+		getTrustEngine().addTrustAnchor(getTestCertificate("ca1_leafa"), "ca1_leafa"); //$NON-NLS-1$ //$NON-NLS-2$
+		Bundle testBundle = installBundle(getTestJarPath("signed")); //$NON-NLS-1$
+		AdminPermission declaredPerm = new AdminPermission("(!(signer=-))", AdminPermission.CONTEXT); //$NON-NLS-1$
+		AdminPermission checkedPerm = new AdminPermission(testBundle, AdminPermission.CONTEXT);
+		assertFalse("Security check failed", declaredPerm.implies(checkedPerm)); //$NON-NLS-1$
 	}
 
-	public void testAdminPermission04() {
+	public void testAdminPermission04() throws Exception {
 		// test trusted cert with exact match pattern + ! operation
-		try {
-			getTrustEngine().addTrustAnchor(getTestCertificate("ca1_leafa"), "ca1_leafa"); //$NON-NLS-1$ //$NON-NLS-2$
-			Bundle testBundle = installBundle(getTestJarPath("signed")); //$NON-NLS-1$
-			AdminPermission declaredPerm = new AdminPermission("(!(signer=" + dnChain01TrueEscaped + "))", AdminPermission.CONTEXT); //$NON-NLS-1$ //$NON-NLS-2$
-			AdminPermission checkedPerm = new AdminPermission(testBundle, AdminPermission.CONTEXT);
-			assertFalse("Security check failed", declaredPerm.implies(checkedPerm)); //$NON-NLS-1$
-		} catch (Exception e) {
-			fail("Unexpected exception", e); //$NON-NLS-1$
-		}
+		getTrustEngine().addTrustAnchor(getTestCertificate("ca1_leafa"), "ca1_leafa"); //$NON-NLS-1$ //$NON-NLS-2$
+		Bundle testBundle = installBundle(getTestJarPath("signed")); //$NON-NLS-1$
+		AdminPermission declaredPerm = new AdminPermission("(!(signer=" + dnChain01TrueEscaped + "))", //$NON-NLS-1$ //$NON-NLS-2$
+				AdminPermission.CONTEXT);
+		AdminPermission checkedPerm = new AdminPermission(testBundle, AdminPermission.CONTEXT);
+		assertFalse("Security check failed", declaredPerm.implies(checkedPerm)); //$NON-NLS-1$
 	}
 
-	public void testAdminPermission05() {
+	public void testAdminPermission05() throws Exception {
 		// test trusted cert with prefix wildcard match pattern
-		try {
-			getTrustEngine().addTrustAnchor(getTestCertificate("ca1_leafa"), "ca1_leafa"); //$NON-NLS-1$ //$NON-NLS-2$
-			Bundle testBundle = installBundle(getTestJarPath("signed")); //$NON-NLS-1$
-			AdminPermission declaredPerm = new AdminPermission("(signer=" + dnChain02TrueEscaped + ")", AdminPermission.CONTEXT); //$NON-NLS-1$ //$NON-NLS-2$
-			AdminPermission checkedPerm = new AdminPermission(testBundle, AdminPermission.CONTEXT);
-			assertTrue("Security check failed", declaredPerm.implies(checkedPerm)); //$NON-NLS-1$
-		} catch (Exception e) {
-			fail("Unexpected exception", e); //$NON-NLS-1$
-		}
+		getTrustEngine().addTrustAnchor(getTestCertificate("ca1_leafa"), "ca1_leafa"); //$NON-NLS-1$ //$NON-NLS-2$
+		Bundle testBundle = installBundle(getTestJarPath("signed")); //$NON-NLS-1$
+		AdminPermission declaredPerm = new AdminPermission("(signer=" + dnChain02TrueEscaped + ")", //$NON-NLS-1$ //$NON-NLS-2$
+				AdminPermission.CONTEXT);
+		AdminPermission checkedPerm = new AdminPermission(testBundle, AdminPermission.CONTEXT);
+		assertTrue("Security check failed", declaredPerm.implies(checkedPerm)); //$NON-NLS-1$
 	}
 
-	public void testAdminPermission06() {
+	public void testAdminPermission06() throws Exception {
 		// test trusted cert with postfix wildcard match pattern
-		try {
-			getTrustEngine().addTrustAnchor(getTestCertificate("ca1_leafa"), "ca1_leafa"); //$NON-NLS-1$ //$NON-NLS-2$
-			Bundle testBundle = installBundle(getTestJarPath("signed")); //$NON-NLS-1$
-			AdminPermission declaredPerm = new AdminPermission("(signer=" + dnChain03TrueEscaped + ")", AdminPermission.CONTEXT); //$NON-NLS-1$ //$NON-NLS-2$
-			AdminPermission checkedPerm = new AdminPermission(testBundle, AdminPermission.CONTEXT);
-			assertTrue("Security check failed", declaredPerm.implies(checkedPerm)); //$NON-NLS-1$
-		} catch (Exception e) {
-			fail("Unexpected exception", e); //$NON-NLS-1$
-		}
+		getTrustEngine().addTrustAnchor(getTestCertificate("ca1_leafa"), "ca1_leafa"); //$NON-NLS-1$ //$NON-NLS-2$
+		Bundle testBundle = installBundle(getTestJarPath("signed")); //$NON-NLS-1$
+		AdminPermission declaredPerm = new AdminPermission("(signer=" + dnChain03TrueEscaped + ")", //$NON-NLS-1$ //$NON-NLS-2$
+				AdminPermission.CONTEXT);
+		AdminPermission checkedPerm = new AdminPermission(testBundle, AdminPermission.CONTEXT);
+		assertTrue("Security check failed", declaredPerm.implies(checkedPerm)); //$NON-NLS-1$
 	}
 
-	public void testAdminPermission07() {
+	public void testAdminPermission07() throws Exception {
 		// test trusted cert with bad postfix dn match pattern
-		try {
-			getTrustEngine().addTrustAnchor(getTestCertificate("ca1_leafa"), "ca1_leafa"); //$NON-NLS-1$ //$NON-NLS-2$
-			Bundle testBundle = installBundle(getTestJarPath("signed")); //$NON-NLS-1$
-			AdminPermission declaredPerm = new AdminPermission("(signer=" + dnChain04FalseEscaped + ")", AdminPermission.CONTEXT); //$NON-NLS-1$ //$NON-NLS-2$
-			AdminPermission checkedPerm = new AdminPermission(testBundle, AdminPermission.CONTEXT);
-			assertFalse("Security check failed", declaredPerm.implies(checkedPerm)); //$NON-NLS-1$
-		} catch (Exception e) {
-			fail("Unexpected exception", e); //$NON-NLS-1$
-		}
+		getTrustEngine().addTrustAnchor(getTestCertificate("ca1_leafa"), "ca1_leafa"); //$NON-NLS-1$ //$NON-NLS-2$
+		Bundle testBundle = installBundle(getTestJarPath("signed")); //$NON-NLS-1$
+		AdminPermission declaredPerm = new AdminPermission("(signer=" + dnChain04FalseEscaped + ")", //$NON-NLS-1$ //$NON-NLS-2$
+				AdminPermission.CONTEXT);
+		AdminPermission checkedPerm = new AdminPermission(testBundle, AdminPermission.CONTEXT);
+		assertFalse("Security check failed", declaredPerm.implies(checkedPerm)); //$NON-NLS-1$
 	}
 
-	public void testAdminPermission08() {
+	public void testAdminPermission08() throws Exception {
 		// test trusted cert with bad prefix dn match pattern
-		try {
-			getTrustEngine().addTrustAnchor(getTestCertificate("ca1_leafa"), "ca1_leafa"); //$NON-NLS-1$ //$NON-NLS-2$
-			Bundle testBundle = installBundle(getTestJarPath("signed")); //$NON-NLS-1$
-			AdminPermission declaredPerm = new AdminPermission("(signer=" + dnChain05FalseEscaped + ")", AdminPermission.CONTEXT); //$NON-NLS-1$ //$NON-NLS-2$
-			AdminPermission checkedPerm = new AdminPermission(testBundle, AdminPermission.CONTEXT);
-			assertFalse("Security check failed", declaredPerm.implies(checkedPerm)); //$NON-NLS-1$
-		} catch (Exception e) {
-			fail("Unexpected exception", e); //$NON-NLS-1$
-		}
+		getTrustEngine().addTrustAnchor(getTestCertificate("ca1_leafa"), "ca1_leafa"); //$NON-NLS-1$ //$NON-NLS-2$
+		Bundle testBundle = installBundle(getTestJarPath("signed")); //$NON-NLS-1$
+		AdminPermission declaredPerm = new AdminPermission("(signer=" + dnChain05FalseEscaped + ")", //$NON-NLS-1$ //$NON-NLS-2$
+				AdminPermission.CONTEXT);
+		AdminPermission checkedPerm = new AdminPermission(testBundle, AdminPermission.CONTEXT);
+		assertFalse("Security check failed", declaredPerm.implies(checkedPerm)); //$NON-NLS-1$
 	}
 
-	public void testAdminPermission09() {
+	public void testAdminPermission09() throws Exception {
 		// test trusted cert with RDN match pattern
-		try {
-			getTrustEngine().addTrustAnchor(getTestCertificate("ca1_leafa"), "ca1_leafa"); //$NON-NLS-1$ //$NON-NLS-2$
-			Bundle testBundle = installBundle(getTestJarPath("signed")); //$NON-NLS-1$
-			AdminPermission declaredPerm = new AdminPermission("(signer=" + dnChain06TrueEscaped + ")", AdminPermission.CONTEXT); //$NON-NLS-1$ //$NON-NLS-2$
-			AdminPermission checkedPerm = new AdminPermission(testBundle, AdminPermission.CONTEXT);
-			assertTrue("Security check failed", declaredPerm.implies(checkedPerm)); //$NON-NLS-1$
-		} catch (Exception e) {
-			fail("Unexpected exception", e); //$NON-NLS-1$
-		}
+		getTrustEngine().addTrustAnchor(getTestCertificate("ca1_leafa"), "ca1_leafa"); //$NON-NLS-1$ //$NON-NLS-2$
+		Bundle testBundle = installBundle(getTestJarPath("signed")); //$NON-NLS-1$
+		AdminPermission declaredPerm = new AdminPermission("(signer=" + dnChain06TrueEscaped + ")", //$NON-NLS-1$ //$NON-NLS-2$
+				AdminPermission.CONTEXT);
+		AdminPermission checkedPerm = new AdminPermission(testBundle, AdminPermission.CONTEXT);
+		assertTrue("Security check failed", declaredPerm.implies(checkedPerm)); //$NON-NLS-1$
 	}
 
-	public void testAdminPermission10() {
+	public void testAdminPermission10() throws Exception {
 		// test trusted cert with RDN match pattern
-		try {
-			getTrustEngine().addTrustAnchor(getTestCertificate("ca1_leafa"), "ca1_leafa"); //$NON-NLS-1$ //$NON-NLS-2$
-			Bundle testBundle = installBundle(getTestJarPath("signed")); //$NON-NLS-1$
-			AdminPermission declaredPerm = new AdminPermission("(signer=" + dnChain07TrueEscaped + ")", AdminPermission.CONTEXT); //$NON-NLS-1$ //$NON-NLS-2$
-			AdminPermission checkedPerm = new AdminPermission(testBundle, AdminPermission.CONTEXT);
-			assertTrue("Security check failed", declaredPerm.implies(checkedPerm)); //$NON-NLS-1$
-		} catch (Exception e) {
-			fail("Unexpected exception", e); //$NON-NLS-1$
-		}
+		getTrustEngine().addTrustAnchor(getTestCertificate("ca1_leafa"), "ca1_leafa"); //$NON-NLS-1$ //$NON-NLS-2$
+		Bundle testBundle = installBundle(getTestJarPath("signed")); //$NON-NLS-1$
+		AdminPermission declaredPerm = new AdminPermission("(signer=" + dnChain07TrueEscaped + ")", //$NON-NLS-1$ //$NON-NLS-2$
+				AdminPermission.CONTEXT);
+		AdminPermission checkedPerm = new AdminPermission(testBundle, AdminPermission.CONTEXT);
+		assertTrue("Security check failed", declaredPerm.implies(checkedPerm)); //$NON-NLS-1$
 	}
 
-	public void testAdminPermission11() {
+	public void testAdminPermission11() throws Exception {
 		// test trusted cert with RDN match pattern
-		try {
-			getTrustEngine().addTrustAnchor(getTestCertificate("ca1_leafa"), "ca1_leafa"); //$NON-NLS-1$ //$NON-NLS-2$
-			Bundle testBundle = installBundle(getTestJarPath("signed")); //$NON-NLS-1$
-			AdminPermission declaredPerm = new AdminPermission("(signer=" + dnChain08TrueEscaped + ")", AdminPermission.CONTEXT); //$NON-NLS-1$ //$NON-NLS-2$
-			AdminPermission checkedPerm = new AdminPermission(testBundle, AdminPermission.CONTEXT);
-			assertTrue("Security check failed", declaredPerm.implies(checkedPerm)); //$NON-NLS-1$
-		} catch (Exception e) {
-			fail("Unexpected exception", e); //$NON-NLS-1$
-		}
+		getTrustEngine().addTrustAnchor(getTestCertificate("ca1_leafa"), "ca1_leafa"); //$NON-NLS-1$ //$NON-NLS-2$
+		Bundle testBundle = installBundle(getTestJarPath("signed")); //$NON-NLS-1$
+		AdminPermission declaredPerm = new AdminPermission("(signer=" + dnChain08TrueEscaped + ")", //$NON-NLS-1$ //$NON-NLS-2$
+				AdminPermission.CONTEXT);
+		AdminPermission checkedPerm = new AdminPermission(testBundle, AdminPermission.CONTEXT);
+		assertTrue("Security check failed", declaredPerm.implies(checkedPerm)); //$NON-NLS-1$
 	}
 
 }

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/security/SignedBundleTest.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/security/SignedBundleTest.java
@@ -25,7 +25,6 @@ import org.eclipse.osgi.signedcontent.SignedContentEntry;
 import org.eclipse.osgi.signedcontent.SignerInfo;
 import org.eclipse.osgi.tests.OSGiTest;
 import org.osgi.framework.Bundle;
-import org.osgi.framework.BundleException;
 
 public class SignedBundleTest extends BaseSecurityTest {
 
@@ -72,15 +71,6 @@ public class SignedBundleTest extends BaseSecurityTest {
 
 	//private String jarName;
 	//private String[] aliases;
-	public SignedBundleTest() {
-		super();
-	}
-
-	public SignedBundleTest(String name, String jarname, String[] aliases) {
-		super(name);
-		//this.jarName = jarname;
-		//this.aliases = aliases;
-	}
 
 	public static Test suite() {
 		ConfigurationSessionTestSuite suite = new ConfigurationSessionTestSuite(BUNDLE_SECURITY_TESTS, "Unit session tests for SignedContent");
@@ -112,7 +102,7 @@ public class SignedBundleTest extends BaseSecurityTest {
 	}
 
 	//	SignedContent positive test: unsigned jar
-	public void testSignedContent01() {
+	public void testSignedContent01() throws Exception {
 
 		Bundle testBundle = null;
 		try {
@@ -124,19 +114,13 @@ public class SignedBundleTest extends BaseSecurityTest {
 			SignedContent signedContent = getSignedContentFactory().getSignedContent(testBundle);
 			assertNotNull("SignedContent is null", signedContent);
 			assertFalse("Content is signed!!", signedContent.isSigned());
-		} catch (Exception e) {
-			fail("Unexpected exception", e);
 		} finally {
-			try {
-				testBundle.uninstall();
-			} catch (BundleException e) {
-				fail("Failed to uninstall bundle", e);
-			}
+			testBundle.uninstall();
 		}
 	}
 
 	//SignedContent positive test: signed jar, 1 trusted signer
-	public void testSignedContent02() {
+	public void testSignedContent02() throws Exception {
 
 		Bundle testBundle = null;
 		try {
@@ -168,20 +152,14 @@ public class SignedBundleTest extends BaseSecurityTest {
 				assertEquals("wrong number of entry signers", 1, entryInfos.length);
 				assertEquals("Entry signer does not equal content signer", infos[0], entryInfos[0]);
 			}
-		} catch (Exception e) {
-			fail("Unexpected exception", e);
 		} finally {
-			try {
-				testBundle.uninstall();
-				getTrustEngine().removeTrustAnchor("ca1_leafa");
-			} catch (Exception e) {
-				fail("Failed to uninstall bundle", e);
-			}
+			testBundle.uninstall();
+			getTrustEngine().removeTrustAnchor("ca1_leafa");
 		}
 	}
 
 	//SignedContent positive test: signed jar, 2 trusted signers
-	public void testSignedContent03() {
+	public void testSignedContent03() throws Exception {
 
 		Bundle testBundle = null;
 		try {
@@ -217,21 +195,15 @@ public class SignedBundleTest extends BaseSecurityTest {
 				assertEquals("wrong number of entry signers", 2, entryInfos.length);
 				assertEquals("Entry signer does not equal content signer", infos[0], entryInfos[0]);
 			}
-		} catch (Exception e) {
-			fail("Unexpected exception", e);
 		} finally {
-			try {
-				testBundle.uninstall();
-				getTrustEngine().removeTrustAnchor("ca1_leafa");
-				getTrustEngine().removeTrustAnchor("ca2_leafa");
-			} catch (Exception e) {
-				fail("Failed to uninstall bundle", e);
-			}
+			testBundle.uninstall();
+			getTrustEngine().removeTrustAnchor("ca1_leafa");
+			getTrustEngine().removeTrustAnchor("ca2_leafa");
 		}
 	}
 
 	//SignedContent negative, 1 signer, 1 untrusted
-	public void testSignedContent04() {
+	public void testSignedContent04() throws Exception {
 		Bundle testBundle = null;
 		try {
 			testBundle = installBundle(getTestJarPath("signed"));
@@ -250,19 +222,13 @@ public class SignedBundleTest extends BaseSecurityTest {
 				// check the signer trust
 				assertTrue("Signer is trusted: " + info.getCertificateChain()[0], !(info.isTrusted()));
 			}
-		} catch (Exception e) {
-			fail("Unexpected exception", e);
 		} finally {
-			try {
-				testBundle.uninstall();
-			} catch (BundleException e) {
-				fail("Failed to uninstall bundle", e);
-			}
+			testBundle.uninstall();
 		}
 	}
 
 	//SignedContent negative, 2 signers, 2 untrusted
-	public void testSignedContent05() {
+	public void testSignedContent05() throws Exception {
 		Bundle testBundle = null;
 		try {
 			testBundle = installBundle(getTestJarPath("multiply_signed"));
@@ -281,19 +247,13 @@ public class SignedBundleTest extends BaseSecurityTest {
 				// check the signer trust
 				assertTrue("Signer is trusted: " + info.getCertificateChain()[0], !(info.isTrusted()));
 			}
-		} catch (Exception e) {
-			fail("Unexpected exception", e);
 		} finally {
-			try {
-				testBundle.uninstall();
-			} catch (BundleException e) {
-				fail("Failed to uninstall bundle", e);
-			}
+			testBundle.uninstall();
 		}
 	}
 
 	//SignedContent negative, 2 signers, 1 untrusted
-	public void testSignedContent06() {
+	public void testSignedContent06() throws Exception {
 		Bundle testBundle = null;
 		try {
 			testBundle = installBundle(getTestJarPath("multiply_signed"));
@@ -318,20 +278,14 @@ public class SignedBundleTest extends BaseSecurityTest {
 					assertTrue("CA1 LeafA signer is not trusted", x509Cert.getSubjectDN().getName().indexOf("CA1 LeafA") >= 0);
 				}
 			}
-		} catch (Exception e) {
-			fail("Unexpected exception", e);
 		} finally {
-			try {
-				testBundle.uninstall();
-				getTrustEngine().removeTrustAnchor("ca1_leafa");
-			} catch (Exception e) {
-				fail("Failed to uninstall bundle", e);
-			}
+			testBundle.uninstall();
+			getTrustEngine().removeTrustAnchor("ca1_leafa");
 		}
 	}
 
 	// negative, 1 signer, 1 corrupt signed_with_corrupt.jar
-	public void testSignedContent07() {
+	public void testSignedContent07() throws Exception {
 		Bundle testBundle = null;
 		try {
 			testBundle = installBundle(getTestJarPath("signed_with_corrupt"));
@@ -360,28 +314,21 @@ public class SignedBundleTest extends BaseSecurityTest {
 					assertEquals("wrong number of entry signers", 1, entryInfos.length);
 					assertEquals("Entry signer does not equal content signer", infos[0], entryInfos[0]);
 				} catch (InvalidContentException e) {
-					if (!"org/eclipse/equinox/security/junit/CorruptClass.class".equals(entry.getName())) {
-						fail("Unexpected corruption in: " + entry.getName(), e);
-					}
+					assertEquals("Unexpected corruption in '" + entry.getName() + "': " + e,
+							"org/eclipse/equinox/security/junit/CorruptClass.class", entry.getName());
 					// no signers if entry is corrupt
 					assertEquals("wrong number of entry signers", 0, entryInfos.length);
 				}
 
 			}
 
-		} catch (Exception e) {
-			fail("Unexpected exception", e);
 		} finally {
-			try {
-				testBundle.uninstall();
-				getTrustEngine().removeTrustAnchor("ca1_leafa");
-			} catch (Exception e) {
-				fail("Failed to uninstall bundle", e);
-			}
+			testBundle.uninstall();
+			getTrustEngine().removeTrustAnchor("ca1_leafa");
 		}
 	}
 
-	public void testSignedContent07a() {
+	public void testSignedContent07a() throws Exception {
 		Bundle testBundle = null;
 		try {
 			testBundle = installBundle(getTestJarPath("signed_with_corrupt"));
@@ -396,20 +343,13 @@ public class SignedBundleTest extends BaseSecurityTest {
 				Throwable t = error.getCause();
 				assertTrue("Cause is the wrong type: " + t, t instanceof InvalidContentException);
 			}
-		} catch (Exception e) {
-
-			fail("Unexpected exception", e);
 		} finally {
-			try {
-				testBundle.uninstall();
-			} catch (Exception e) {
-				// ignore
-			}
+			testBundle.uninstall();
 		}
 	}
 
 	// positve 1 signer, 1 tsa
-	public void testSignedContent08() {
+	public void testSignedContent08() throws Exception {
 		Bundle testBundle = null;
 		try {
 			testBundle = installBundle(getTestJarPath("signed_tsa"));
@@ -426,251 +366,210 @@ public class SignedBundleTest extends BaseSecurityTest {
 			assertEquals("wrong number of signers", 1, infos.length);
 
 			assertNotNull("Signing time is null!", signedContent.getSigningTime(infos[0]));
-
-		} catch (Exception e) {
-			fail("Unexpected exception", e);
 		} finally {
-			try {
-				testBundle.uninstall();
-				getTrustEngine().removeTrustAnchor("ca1_leafa");
-			} catch (Exception e) {
-				fail("Failed to uninstall bundle", e);
-			}
+			testBundle.uninstall();
+			getTrustEngine().removeTrustAnchor("ca1_leafa");
 		}
 	}
 
 	//	SignedContent positive test: unsigned jar
-	public void testSignedContent09() {
-		try {
-			File unsignedFile = getEntryFile(getTestJarPath("unsigned"));
+	public void testSignedContent09() throws Exception {
+		File unsignedFile = getEntryFile(getTestJarPath("unsigned"));
 
-			assertNotNull("Could not find unsigned file!", unsignedFile);
-			//getTrustEngine().addTrustAnchor(anchor, alias);
+		assertNotNull("Could not find unsigned file!", unsignedFile);
+		// getTrustEngine().addTrustAnchor(anchor, alias);
 
-			// get the signed content for the bundle
-			SignedContent signedContent = getSignedContentFactory().getSignedContent(unsignedFile);
-			assertNotNull("SignedContent is null", signedContent);
-			assertFalse("Content is signed!!", signedContent.isSigned());
-		} catch (Exception e) {
-			fail("Unexpected exception", e);
-		}
+		// get the signed content for the bundle
+		SignedContent signedContent = getSignedContentFactory().getSignedContent(unsignedFile);
+		assertNotNull("SignedContent is null", signedContent);
+		assertFalse("Content is signed!!", signedContent.isSigned());
 	}
 
 	//SignedContent positive test: signed jar, 1 trusted signer
-	public void testSignedContent10() {
-		try {
-			File signedFile = getEntryFile(getTestJarPath("signed"));
-			getTrustEngine().addTrustAnchor(getTestCertificate("ca1_leafa"), "ca1_leafa");
+	public void testSignedContent10() throws Exception {
+		File signedFile = getEntryFile(getTestJarPath("signed"));
+		getTrustEngine().addTrustAnchor(getTestCertificate("ca1_leafa"), "ca1_leafa");
 
-			// get the signed content for the bundle
-			SignedContent signedContent = getSignedContentFactory().getSignedContent(signedFile);
-			assertNotNull("SignedContent is null", signedContent);
-			// check if it is signed
-			assertTrue("Should be signed", signedContent.isSigned());
-			// get the signer infos
-			SignerInfo[] infos = signedContent.getSignerInfos();
-			assertNotNull("SignerInfo is null", infos);
-			assertEquals("wrong number of signers", 1, infos.length);
-			// check the signer validity
-			signedContent.checkValidity(infos[0]);
-			// check the signer trust
-			assertTrue("Signer is not trusted", infos[0].isTrusted());
-			// check the trust anchor
-			assertNotNull("Trust anchor is null", infos[0].getTrustAnchor());
-			// verify and validate the entries
-			SignedContentEntry[] entries = signedContent.getSignedEntries();
-			assertNotNull("Entries is null", entries);
-			for (SignedContentEntry entry : entries) {
-				entry.verify();
-				SignerInfo[] entryInfos = entry.getSignerInfos();
-				assertNotNull("SignerInfo is null", entryInfos);
-				assertEquals("wrong number of entry signers", 1, entryInfos.length);
-				assertEquals("Entry signer does not equal content signer", infos[0], entryInfos[0]);
-			}
-		} catch (Exception e) {
-			fail("Unexpected exception", e);
+		// get the signed content for the bundle
+		SignedContent signedContent = getSignedContentFactory().getSignedContent(signedFile);
+		assertNotNull("SignedContent is null", signedContent);
+		// check if it is signed
+		assertTrue("Should be signed", signedContent.isSigned());
+		// get the signer infos
+		SignerInfo[] infos = signedContent.getSignerInfos();
+		assertNotNull("SignerInfo is null", infos);
+		assertEquals("wrong number of signers", 1, infos.length);
+		// check the signer validity
+		signedContent.checkValidity(infos[0]);
+		// check the signer trust
+		assertTrue("Signer is not trusted", infos[0].isTrusted());
+		// check the trust anchor
+		assertNotNull("Trust anchor is null", infos[0].getTrustAnchor());
+		// verify and validate the entries
+		SignedContentEntry[] entries = signedContent.getSignedEntries();
+		assertNotNull("Entries is null", entries);
+		for (SignedContentEntry entry : entries) {
+			entry.verify();
+			SignerInfo[] entryInfos = entry.getSignerInfos();
+			assertNotNull("SignerInfo is null", entryInfos);
+			assertEquals("wrong number of entry signers", 1, entryInfos.length);
+			assertEquals("Entry signer does not equal content signer", infos[0], entryInfos[0]);
 		}
 	}
 
 	//SignedContent positive test: signed jar, 2 trusted signers
-	public void testSignedContent11() {
-		try {
-			File multipleSigned = getEntryFile(getTestJarPath("multiply_signed"));
-			this.getTrustEngine().addTrustAnchor(getTestCertificate("ca1_leafa"), "ca1_leafa");
-			this.getTrustEngine().addTrustAnchor(getTestCertificate("ca2_leafa"), "ca2_leafa");
+	public void testSignedContent11() throws Exception {
+		File multipleSigned = getEntryFile(getTestJarPath("multiply_signed"));
+		this.getTrustEngine().addTrustAnchor(getTestCertificate("ca1_leafa"), "ca1_leafa");
+		this.getTrustEngine().addTrustAnchor(getTestCertificate("ca2_leafa"), "ca2_leafa");
 
-			// get the signed content for the bundle
-			SignedContent signedContent = getSignedContentFactory().getSignedContent(multipleSigned);
-			assertNotNull("SignedContent is null", signedContent);
-			// check if it is signed
-			assertTrue("Should be signed", signedContent.isSigned());
-			// get the signer infos
-			SignerInfo[] infos = signedContent.getSignerInfos();
-			assertNotNull("SignerInfo is null", infos);
-			assertEquals("wrong number of signers", 2, infos.length);
-			// check the signer validity
-			for (SignerInfo info : infos) {
-				signedContent.checkValidity(info);
-				signedContent.checkValidity(info);
-				// check the signer trust
-				assertTrue("Signer is not trusted: " + info.getCertificateChain()[0], info.isTrusted());
-				// check the trust anchor
-				assertNotNull("Trust anchor is null", info.getTrustAnchor());
-			}
-			// verify and validate the entries
-			SignedContentEntry[] entries = signedContent.getSignedEntries();
-			assertNotNull("Entries is null", entries);
-			for (SignedContentEntry entry : entries) {
-				entry.verify();
-				SignerInfo[] entryInfos = entry.getSignerInfos();
-				assertNotNull("SignerInfo is null", entryInfos);
-				assertEquals("wrong number of entry signers", 2, entryInfos.length);
-				assertEquals("Entry signer does not equal content signer", infos[0], entryInfos[0]);
-			}
-		} catch (Exception e) {
-			fail("Unexpected exception", e);
+		// get the signed content for the bundle
+		SignedContent signedContent = getSignedContentFactory().getSignedContent(multipleSigned);
+		assertNotNull("SignedContent is null", signedContent);
+		// check if it is signed
+		assertTrue("Should be signed", signedContent.isSigned());
+		// get the signer infos
+		SignerInfo[] infos = signedContent.getSignerInfos();
+		assertNotNull("SignerInfo is null", infos);
+		assertEquals("wrong number of signers", 2, infos.length);
+		// check the signer validity
+		for (SignerInfo info : infos) {
+			signedContent.checkValidity(info);
+			signedContent.checkValidity(info);
+			// check the signer trust
+			assertTrue("Signer is not trusted: " + info.getCertificateChain()[0], info.isTrusted());
+			// check the trust anchor
+			assertNotNull("Trust anchor is null", info.getTrustAnchor());
+		}
+		// verify and validate the entries
+		SignedContentEntry[] entries = signedContent.getSignedEntries();
+		assertNotNull("Entries is null", entries);
+		for (SignedContentEntry entry : entries) {
+			entry.verify();
+			SignerInfo[] entryInfos = entry.getSignerInfos();
+			assertNotNull("SignerInfo is null", entryInfos);
+			assertEquals("wrong number of entry signers", 2, entryInfos.length);
+			assertEquals("Entry signer does not equal content signer", infos[0], entryInfos[0]);
 		}
 	}
 
 	//SignedContent negative, 1 signer, 1 untrusted
-	public void testSignedContent12() {
-		try {
-			File signedFile = getEntryFile(getTestJarPath("signed"));
-			// get the signed content for the bundle
-			SignedContent signedContent = getSignedContentFactory().getSignedContent(signedFile);
-			assertNotNull("SignedContent is null", signedContent);
-			// check if it is signed
-			assertTrue("Should be signed", signedContent.isSigned());
-			// get the signer infos
-			SignerInfo[] infos = signedContent.getSignerInfos();
-			assertNotNull("SignerInfo is null", infos);
-			assertEquals("wrong number of signers", 1, infos.length);
-			// check the signer validity
-			for (SignerInfo info : infos) {
-				// check the signer trust
-				assertTrue("Signer is trusted: " + info.getCertificateChain()[0], !(info.isTrusted()));
-			}
-		} catch (Exception e) {
-			fail("Unexpected exception", e);
+	public void testSignedContent12() throws Exception {
+		File signedFile = getEntryFile(getTestJarPath("signed"));
+		// get the signed content for the bundle
+		SignedContent signedContent = getSignedContentFactory().getSignedContent(signedFile);
+		assertNotNull("SignedContent is null", signedContent);
+		// check if it is signed
+		assertTrue("Should be signed", signedContent.isSigned());
+		// get the signer infos
+		SignerInfo[] infos = signedContent.getSignerInfos();
+		assertNotNull("SignerInfo is null", infos);
+		assertEquals("wrong number of signers", 1, infos.length);
+		// check the signer validity
+		for (SignerInfo info : infos) {
+			// check the signer trust
+			assertTrue("Signer is trusted: " + info.getCertificateChain()[0], !(info.isTrusted()));
 		}
 	}
 
 	//SignedContent negative, 2 signers, 2 untrusted
-	public void testSignedContent13() {
-		try {
-			File multipleSigned = getEntryFile(getTestJarPath("multiply_signed"));
+	public void testSignedContent13() throws Exception {
+		File multipleSigned = getEntryFile(getTestJarPath("multiply_signed"));
 
-			// get the signed content for the bundle
-			SignedContent signedContent = getSignedContentFactory().getSignedContent(multipleSigned);
-			assertNotNull("SignedContent is null", signedContent);
-			// check if it is signed
-			assertTrue("Should be signed", signedContent.isSigned());
-			// get the signer infos
-			SignerInfo[] infos = signedContent.getSignerInfos();
-			assertNotNull("SignerInfo is null", infos);
-			assertEquals("wrong number of signers", 2, infos.length);
-			// check the signer validity
-			for (SignerInfo info : infos) {
-				// check the signer trust
-				assertTrue("Signer is trusted: " + info.getCertificateChain()[0], !(info.isTrusted()));
-			}
-		} catch (Exception e) {
-			fail("Unexpected exception", e);
+		// get the signed content for the bundle
+		SignedContent signedContent = getSignedContentFactory().getSignedContent(multipleSigned);
+		assertNotNull("SignedContent is null", signedContent);
+		// check if it is signed
+		assertTrue("Should be signed", signedContent.isSigned());
+		// get the signer infos
+		SignerInfo[] infos = signedContent.getSignerInfos();
+		assertNotNull("SignerInfo is null", infos);
+		assertEquals("wrong number of signers", 2, infos.length);
+		// check the signer validity
+		for (SignerInfo info : infos) {
+			// check the signer trust
+			assertTrue("Signer is trusted: " + info.getCertificateChain()[0], !(info.isTrusted()));
 		}
 	}
 
 	//SignedContent negative, 2 signers, 1 untrusted
-	public void testSignedContent14() {
-		try {
-			File multipleSigned = getEntryFile(getTestJarPath("multiply_signed"));
-			getTrustEngine().addTrustAnchor(getTestCertificate("ca1_leafa"), "ca1_leafa");
+	public void testSignedContent14() throws Exception {
+		File multipleSigned = getEntryFile(getTestJarPath("multiply_signed"));
+		getTrustEngine().addTrustAnchor(getTestCertificate("ca1_leafa"), "ca1_leafa");
 
-			// get the signed content for the bundle
-			SignedContent signedContent = getSignedContentFactory().getSignedContent(multipleSigned);
-			assertNotNull("SignedContent is null", signedContent);
-			// check if it is signed
-			assertTrue("Should be signed", signedContent.isSigned());
-			// get the signer infos
-			SignerInfo[] infos = signedContent.getSignerInfos();
-			assertNotNull("SignerInfo is null", infos);
-			assertEquals("wrong number of signers", 2, infos.length);
+		// get the signed content for the bundle
+		SignedContent signedContent = getSignedContentFactory().getSignedContent(multipleSigned);
+		assertNotNull("SignedContent is null", signedContent);
+		// check if it is signed
+		assertTrue("Should be signed", signedContent.isSigned());
+		// get the signer infos
+		SignerInfo[] infos = signedContent.getSignerInfos();
+		assertNotNull("SignerInfo is null", infos);
+		assertEquals("wrong number of signers", 2, infos.length);
 
-			// make sure ca1 signer is trusted
-			// check the signer validity
-			for (SignerInfo info : infos) {
-				Certificate[] certs = info.getCertificateChain();
-				if (info.isTrusted()) {
-					X509Certificate x509Cert = (X509Certificate) certs[0];
-					assertTrue("CA1 LeafA signer is not trusted", x509Cert.getSubjectDN().getName().indexOf("CA1 LeafA") >= 0);
-				}
+		// make sure ca1 signer is trusted
+		// check the signer validity
+		for (SignerInfo info : infos) {
+			Certificate[] certs = info.getCertificateChain();
+			if (info.isTrusted()) {
+				X509Certificate x509Cert = (X509Certificate) certs[0];
+				assertTrue("CA1 LeafA signer is not trusted",
+						x509Cert.getSubjectDN().getName().indexOf("CA1 LeafA") >= 0);
 			}
-		} catch (Exception e) {
-			fail("Unexpected exception", e);
 		}
 	}
 
 	// negative, 1 signer, 1 corrupt signed_with_corrupt.jar
-	public void testSignedContent15() {
-		try {
-			File corruptedFile = getEntryFile(getTestJarPath("signed_with_corrupt"));
-			getTrustEngine().addTrustAnchor(getTestCertificate("ca1_leafa"), "ca1_leafa");
+	public void testSignedContent15() throws Exception {
+		File corruptedFile = getEntryFile(getTestJarPath("signed_with_corrupt"));
+		getTrustEngine().addTrustAnchor(getTestCertificate("ca1_leafa"), "ca1_leafa");
 
-			// get the signed content for the bundle
-			SignedContent signedContent = getSignedContentFactory().getSignedContent(corruptedFile);
-			assertNotNull("SignedContent is null", signedContent);
-			// check if it is signed
-			assertTrue("Should be signed", signedContent.isSigned());
-			// get the signer infos
-			SignerInfo[] infos = signedContent.getSignerInfos();
-			assertNotNull("SignerInfo is null", infos);
-			assertEquals("wrong number of signers", 1, infos.length);
+		// get the signed content for the bundle
+		SignedContent signedContent = getSignedContentFactory().getSignedContent(corruptedFile);
+		assertNotNull("SignedContent is null", signedContent);
+		// check if it is signed
+		assertTrue("Should be signed", signedContent.isSigned());
+		// get the signer infos
+		SignerInfo[] infos = signedContent.getSignerInfos();
+		assertNotNull("SignerInfo is null", infos);
+		assertEquals("wrong number of signers", 1, infos.length);
 
-			SignedContentEntry[] entries = signedContent.getSignedEntries();
-			assertNotNull("Entries is null", entries);
-			for (SignedContentEntry entry : entries) {
-				SignerInfo[] entryInfos = entry.getSignerInfos();
-				assertNotNull("SignerInfo is null", entryInfos);
-				try {
-					entry.verify();
-					if ("org/eclipse/equinox/security/junit/CorruptClass.class".equals(entry.getName())) {
-						fail("Expected a corruption for: " + entry.getName());
-					}
-					assertEquals("wrong number of entry signers", 1, entryInfos.length);
-					assertEquals("Entry signer does not equal content signer", infos[0], entryInfos[0]);
-				} catch (InvalidContentException e) {
-					if (!"org/eclipse/equinox/security/junit/CorruptClass.class".equals(entry.getName())) {
-						fail("Unexpected corruption in: " + entry.getName(), e);
-					}
-					assertEquals("wrong number of entry signers", 0, entryInfos.length);
+		SignedContentEntry[] entries = signedContent.getSignedEntries();
+		assertNotNull("Entries is null", entries);
+		for (SignedContentEntry entry : entries) {
+			SignerInfo[] entryInfos = entry.getSignerInfos();
+			assertNotNull("SignerInfo is null", entryInfos);
+			try {
+				entry.verify();
+				if ("org/eclipse/equinox/security/junit/CorruptClass.class".equals(entry.getName())) {
+					fail("Expected a corruption for: " + entry.getName());
 				}
+				assertEquals("wrong number of entry signers", 1, entryInfos.length);
+				assertEquals("Entry signer does not equal content signer", infos[0], entryInfos[0]);
+			} catch (InvalidContentException e) {
+				assertEquals("Unexpected corruption in '" + entry.getName() + "': " + e,
+						"org/eclipse/equinox/security/junit/CorruptClass.class", entry.getName());
+				assertEquals("wrong number of entry signers", 0, entryInfos.length);
 			}
-
-		} catch (Exception e) {
-			fail("Unexpected exception", e);
 		}
 	}
 
 	// positve 1 signer, 1 tsa
-	public void testSignedContent16() {
-		try {
-			File signedTsaFile = getEntryFile(getTestJarPath("signed_tsa"));
-			getTrustEngine().addTrustAnchor(getTestCertificate("ca1_leafa"), "ca1_leafa");
+	public void testSignedContent16() throws Exception {
+		File signedTsaFile = getEntryFile(getTestJarPath("signed_tsa"));
+		getTrustEngine().addTrustAnchor(getTestCertificate("ca1_leafa"), "ca1_leafa");
 
-			// get the signed content for the bundle
-			SignedContent signedContent = getSignedContentFactory().getSignedContent(signedTsaFile);
-			assertNotNull("SignedContent is null", signedContent);
-			// check if it is signed
-			assertTrue("Should be signed", signedContent.isSigned());
-			// get the signer infos
-			SignerInfo[] infos = signedContent.getSignerInfos();
-			assertNotNull("SignerInfo is null", infos);
-			assertEquals("wrong number of signers", 1, infos.length);
+		// get the signed content for the bundle
+		SignedContent signedContent = getSignedContentFactory().getSignedContent(signedTsaFile);
+		assertNotNull("SignedContent is null", signedContent);
+		// check if it is signed
+		assertTrue("Should be signed", signedContent.isSigned());
+		// get the signer infos
+		SignerInfo[] infos = signedContent.getSignerInfos();
+		assertNotNull("SignerInfo is null", infos);
+		assertEquals("wrong number of signers", 1, infos.length);
 
-			assertNotNull("Signing time is null!", signedContent.getSigningTime(infos[0]));
-
-		} catch (Exception e) {
-			fail("Unexpected exception", e);
-		}
+		assertNotNull("Signing time is null!", signedContent.getSigningTime(infos[0]));
 	}
 
 	//SignedContent positive test: signed jar, 1 trusted signer
@@ -822,11 +721,7 @@ public class SignedBundleTest extends BaseSecurityTest {
 		assertNotNull("Entries is null", entries);
 		assertEquals("Incorrect number of signed entries", 4, entries.length);
 		for (SignedContentEntry entry : entries) {
-			try {
-				entry.verify();
-			} catch (InvalidContentException e) {
-				fail("Unexpected verify error.", e);
-			}
+			entry.verify();
 			SignerInfo[] entryInfos = entry.getSignerInfos();
 			assertNotNull("SignerInfo is null", entryInfos);
 			assertEquals("wrong number of entry signers", 1, entryInfos.length);
@@ -850,32 +745,27 @@ public class SignedBundleTest extends BaseSecurityTest {
 		}
 	}
 
-	public void testBug252098() {
+	public void testBug252098() throws Exception {
 
 		Bundle testBundle = null;
 		try {
 			testBundle = installBundle(getTestJarPath("test.bug252098"));
 			assertNotNull("Test bundle not installed!", testBundle);
 			testBundle.start();
-		} catch (Exception e) {
-			fail("Unexpected exception", e);
 		} finally {
-			try {
-				if (testBundle != null)
-					testBundle.uninstall();
-			} catch (BundleException e) {
-				fail("Failed to uninstall bundle", e);
+			if (testBundle != null) {
+				testBundle.uninstall();
 			}
 		}
 	}
 
-	public void testBug378155() {
+	public void testBug378155() throws Exception {
 		doTestBug378155("SHA256withRSA");
 		doTestBug378155("SHA384withRSA");
 		doTestBug378155("SHA512withRSA");
 	}
 
-	private void doTestBug378155(String bundleName) {
+	private void doTestBug378155(String bundleName) throws Exception {
 
 		Bundle testBundle = null;
 		try {
@@ -906,35 +796,26 @@ public class SignedBundleTest extends BaseSecurityTest {
 				assertEquals("wrong number of entry signers", 1, entryInfos.length);
 				assertEquals("Entry signer does not equal content signer", infos[0], entryInfos[0]);
 			}
-		} catch (Exception e) {
-			fail("Unexpected exception", e);
 		} finally {
-			try {
-				if (testBundle != null)
-					testBundle.uninstall();
-			} catch (BundleException e) {
-				fail("Failed to uninstall bundle", e);
+			if (testBundle != null) {
+				testBundle.uninstall();
 			}
 		}
 	}
 
-	public void testBug434711() {
-		try {
-			File nonAsciiFile = getEntryFile(getTestJarPath("bundleWithNonAsciiCharsFilename"));
+	public void testBug434711() throws Exception {
+		File nonAsciiFile = getEntryFile(getTestJarPath("bundleWithNonAsciiCharsFilename"));
 
-			assertNotNull("Could not find Non Ascii Chars file!", nonAsciiFile);
-			SignedContent signedContent = getSignedContentFactory().getSignedContent(nonAsciiFile);
-			assertNotNull("SignedContent is null", signedContent);
-			assertTrue("Content is not signed!!", signedContent.isSigned());
-			for (SignedContentEntry entry : signedContent.getSignedEntries()) {
-				entry.verify();
-			}
-		} catch (Exception e) {
-			fail("Unexpected exception", e);
+		assertNotNull("Could not find Non Ascii Chars file!", nonAsciiFile);
+		SignedContent signedContent = getSignedContentFactory().getSignedContent(nonAsciiFile);
+		assertNotNull("SignedContent is null", signedContent);
+		assertTrue("Content is not signed!!", signedContent.isSigned());
+		for (SignedContentEntry entry : signedContent.getSignedEntries()) {
+			entry.verify();
 		}
 	}
 
-	public void test489686() {
+	public void test489686() throws Exception {
 		Bundle testBundle = null;
 		try {
 			testBundle = installBundle(getTestJarPath("signed_with_missing_digest"));
@@ -954,19 +835,12 @@ public class SignedBundleTest extends BaseSecurityTest {
 			SignedContentEntry[] entries = signedContent.getSignedEntries();
 			assertNotNull("Entries is null", entries);
 			assertEquals("Expected no signed entries.", 0, entries.length);
-
-		} catch (Exception e) {
-			fail("Unexpected exception", e);
 		} finally {
-			try {
-				testBundle.uninstall();
-			} catch (Exception e) {
-				fail("Failed to uninstall bundle", e);
-			}
+			testBundle.uninstall();
 		}
 	}
 
-	public void testSignedContentJava16() {
+	public void testSignedContentJava16() throws Exception {
 
 		Bundle testBundle = null;
 		try {
@@ -998,15 +872,9 @@ public class SignedBundleTest extends BaseSecurityTest {
 				assertEquals("wrong number of entry signers", 1, entryInfos.length);
 				assertEquals("Entry signer does not equal content signer", infos[0], entryInfos[0]);
 			}
-		} catch (Exception e) {
-			fail("Unexpected exception", e);
 		} finally {
-			try {
-				testBundle.uninstall();
-				getTrustEngine().removeTrustAnchor("ca2_leafa");
-			} catch (Exception e) {
-				fail("Failed to uninstall bundle", e);
-			}
+			testBundle.uninstall();
+			getTrustEngine().removeTrustAnchor("ca2_leafa");
 		}
 	}
 }

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/services/datalocation/LocationAreaSessionTest.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/services/datalocation/LocationAreaSessionTest.java
@@ -13,9 +13,11 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.services.datalocation;
 
+import static org.eclipse.osgi.tests.OSGiTest.PI_OSGI_TESTS;
+import static org.eclipse.osgi.tests.OSGiTest.addRequiredOSGiTestsBundles;
+
 import java.io.File;
 import java.io.IOException;
-import java.net.MalformedURLException;
 import junit.framework.Test;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
@@ -24,12 +26,11 @@ import org.eclipse.core.tests.session.SetupManager.SetupException;
 import org.eclipse.osgi.internal.location.LocationHelper;
 import org.eclipse.osgi.service.datalocation.Location;
 import org.eclipse.osgi.service.environment.Constants;
-import org.eclipse.osgi.tests.OSGiTest;
 import org.eclipse.osgi.tests.OSGiTestsActivator;
 import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.framework.ServiceReference;
 
-public class LocationAreaSessionTest extends OSGiTest {
+public class LocationAreaSessionTest extends TestCase {
 	private static final String JAVA_NIO = "java.nio"; //$NON-NLS-1$
 	private static final String JAVA_IO = "java.io"; //$NON-NLS-1$
 	private static final String TEST_LOCATION_DIR = "osgi.test.location.dir"; //$NON-NLS-1$
@@ -128,7 +129,8 @@ public class LocationAreaSessionTest extends OSGiTest {
 		super(name);
 	}
 
-	static void doLock(String testLocationDir, String type, boolean release, boolean succeed) {
+	static void doLock(String testLocationDir, String type, boolean release, boolean succeed)
+			throws InvalidSyntaxException, IOException {
 		String oldLockingValue = System.setProperty(LocationHelper.PROP_OSGI_LOCKING, type);
 		try {
 			doLock(testLocationDir, release, succeed);
@@ -140,15 +142,11 @@ public class LocationAreaSessionTest extends OSGiTest {
 		}
 	}
 
-	static void doLock(String testLocationDir, boolean release, boolean succeed) {
-		if (testLocationDir == null)
-			fail("The testLocationDir is not set");
-		ServiceReference[] refs = null;
-		try {
-			refs = OSGiTestsActivator.getContext().getServiceReferences(Location.class.getName(), "(type=osgi.configuration.area)");
-		} catch (InvalidSyntaxException e) {
-			fail("failed to create filter", e);
-		}
+	static void doLock(String testLocationDir, boolean release, boolean succeed)
+			throws InvalidSyntaxException, IOException {
+		assertNotNull("The testLocationDir is not set", testLocationDir);
+		ServiceReference[] refs = OSGiTestsActivator.getContext().getServiceReferences(Location.class.getName(),
+				"(type=osgi.configuration.area)");
 		// this is test code so we are not very careful; just assume there is at lease one service.  Do not copy and paste this code!!!
 		Location configLocation = (Location) OSGiTestsActivator.getContext().getService(refs[0]);
 		Location testLocation = null;
@@ -162,10 +160,6 @@ public class LocationAreaSessionTest extends OSGiTest {
 				fail((succeed ? "Could not" : "Could") + " lock location");
 			if (!testLocation.isLocked())
 				fail("location should be locked");
-		} catch (MalformedURLException e) {
-			fail("failed to create the location URL", e);
-		} catch (IOException e) {
-			fail("failed to lock with IOExcetpion", e);
 		} finally {
 			if (release && testLocation != null)
 				testLocation.release();
@@ -175,7 +169,7 @@ public class LocationAreaSessionTest extends OSGiTest {
 		}
 	}
 
-	static void doRelease() {
+	static void doRelease() throws IOException {
 		try {
 			if (lockedTestLocation == null)
 				fail("lockedTestLocation == null !!");
@@ -184,28 +178,26 @@ public class LocationAreaSessionTest extends OSGiTest {
 			lockedTestLocation.release();
 			if (lockedTestLocation.isLocked())
 				fail("lockedTestLocation is still locked!!");
-		} catch (IOException e) {
-			fail("failed to unlock lockedTestLocation", e);
 		} finally {
 			lockedTestLocation = null;
 		}
 	}
 
-	public void testSessionFailLockJavaNIO() {
+	public void testSessionFailLockJavaNIO() throws Exception {
 		doLock(System.getProperty(TEST_LOCATION_DIR), JAVA_NIO, true, false);
 	}
 
-	public void testSessionSuccessLockJavaNIO() {
+	public void testSessionSuccessLockJavaNIO() throws Exception {
 		doLock(System.getProperty(TEST_LOCATION_DIR), JAVA_NIO, true, true);
 	}
 
-	public void testSessionFailLockJavaIO() {
+	public void testSessionFailLockJavaIO() throws Exception {
 		if (!Constants.OS_WIN32.equals(System.getProperty("osgi.os")))
 			return;
 		doLock(System.getProperty(TEST_LOCATION_DIR), JAVA_IO, true, false);
 	}
 
-	public void testSessionSuccessLockJavaIO() {
+	public void testSessionSuccessLockJavaIO() throws Exception {
 		if (!Constants.OS_WIN32.equals(System.getProperty("osgi.os")))
 			return;
 		doLock(System.getProperty(TEST_LOCATION_DIR), JAVA_IO, true, true);


### PR DESCRIPTION
Several session test classes in `org.eclipse.osgi.tests` are subclasses of either `CoreTest` or the `OSGiTest` subclass of `CoreTest`. This change make the test classes directly inherit from JUnit 3's `TestCase` to become independent of the `CoreTest` class. The `TestCase` inheritance is necessary until session tests do not rely on JUnit 3 anymore.

* Remove inheritance of `CoreTest` and replace `OSGiTest` inheritance with static imports of inherited helper methods
* Replace try-catch for actual errors with making the test method throw the exception