### PR TITLE
Migrate several test classes in o.e.osgi.tests to JUnit 4

### DIFF
--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/bundles/BundleResourceTests.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/bundles/BundleResourceTests.java
@@ -13,31 +13,38 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.bundles;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import java.net.URL;
 import java.util.Enumeration;
-import org.eclipse.core.tests.harness.CoreTest;
 import org.eclipse.osgi.service.environment.EnvironmentInfo;
 import org.eclipse.osgi.tests.OSGiTestsActivator;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleException;
-import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.framework.ServiceReference;
 
-public class BundleResourceTests extends CoreTest {
+public class BundleResourceTests {
 	private BundleInstaller installer;
 
-	protected void setUp() throws Exception {
-		try {
-			installer = new BundleInstaller(OSGiTestsActivator.TEST_FILES_ROOT + "resourcetests/bundles", OSGiTestsActivator.getContext()); //$NON-NLS-1$
-		} catch (InvalidSyntaxException e) {
-			fail("Failed to create bundle installer", e); //$NON-NLS-1$
-		}
+	@Before
+	public void setUp() throws Exception {
+		installer = new BundleInstaller(OSGiTestsActivator.TEST_FILES_ROOT + "resourcetests/bundles", //$NON-NLS-1$
+				OSGiTestsActivator.getContext());
 	}
 
-	protected void tearDown() throws Exception {
+	@After
+	public void tearDown() throws Exception {
 		installer.shutdown();
 	}
 
+	@Test
 	public void testBug320546_01() throws Exception {
 		Bundle bundle = installer.installBundle("test"); //$NON-NLS-1$
 		URL result = bundle.getEntry("../../../../security");
@@ -54,6 +61,7 @@ public class BundleResourceTests extends CoreTest {
 		assertNotNull("Did not find resource!", result);
 	}
 
+	@Test
 	public void testBug320546_02() throws Exception {
 		Bundle bundle = installer.installBundle("test"); //$NON-NLS-1$
 		Enumeration paths = bundle.getEntryPaths("../");
@@ -66,12 +74,14 @@ public class BundleResourceTests extends CoreTest {
 		assertNotNull("Did not find resource!", paths);
 	}
 
+	@Test
 	public void testBreakOutDirBundle() throws Exception {
 		Bundle bundle = installer.installBundle("test"); //$NON-NLS-1$
 		URL result = bundle.getEntry("../testout/file.txt");
 		assertNull("Found resource!", result);
 	}
 
+	@Test
 	public void testBug395274() throws Exception {
 		ServiceReference<EnvironmentInfo> infoRef = OSGiTestsActivator.getContext().getServiceReference(EnvironmentInfo.class);
 		EnvironmentInfo info = OSGiTestsActivator.getContext().getService(infoRef);
@@ -96,6 +106,7 @@ public class BundleResourceTests extends CoreTest {
 		}
 	}
 
+	@Test
 	public void testBug328795() throws BundleException {
 		Bundle bundle = installer.installBundle("test"); //$NON-NLS-1$
 		checkEntries(bundle, "notFound\\", 0); // this results in invalid syntax exception which is logged because of trailing escape
@@ -130,6 +141,7 @@ public class BundleResourceTests extends CoreTest {
 		checkEntries(bundle, "*\\(*", 2);
 	}
 
+	@Test
 	public void testBug338081() throws BundleException {
 		Bundle bundle = installer.installBundle("test"); //$NON-NLS-1$
 		// Empty string same as '/' for bundle root

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/eclipseadaptor/FilePathTest.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/eclipseadaptor/FilePathTest.java
@@ -13,16 +13,17 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.eclipseadaptor;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.osgi.framework.util.FilePath;
-import org.eclipse.osgi.tests.OSGiTest;
+import org.junit.Test;
 
-public class FilePathTest extends OSGiTest {
+public class FilePathTest {
 
-	public FilePathTest(String name) {
-		super(name);
-	}
-
+	@Test
 	public void testColonOnPath() {
 		FilePath path = new FilePath("/c:b/a");
 		if (Platform.getOS().equals(Platform.OS_WIN32)) {

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/internal/plugins/InstallTests.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/internal/plugins/InstallTests.java
@@ -13,31 +13,29 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.internal.plugins;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
 import java.io.IOException;
+import junit.framework.AssertionFailedError;
 import org.eclipse.core.tests.harness.BundleTestingHelper;
-import org.eclipse.core.tests.harness.CoreTest;
 import org.eclipse.osgi.tests.OSGiTestsActivator;
 import org.eclipse.osgi.util.ManifestElement;
-import org.osgi.framework.*;
+import org.junit.Test;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleException;
+import org.osgi.framework.Constants;
+import org.osgi.framework.ServiceReference;
+import org.osgi.framework.Version;
 import org.osgi.service.packageadmin.PackageAdmin;
 
 /**
  * Provisory home for tests that install plugins.
  */
-public class InstallTests extends CoreTest {
+public class InstallTests {
 
-	public InstallTests() {
-		super();
-	}
-
-	public InstallTests(String name) {
-		super(name);
-	}
-
-	protected void setUp() throws Exception {
-		super.setUp();
-	}
-
+	@Test
 	public void testInstallNoVersionManifest01() throws BundleException, IOException {
 		// Note that this test case has changed since the removing of plugin.xml conversion
 		// Before this tested that a plugin.xml with no version specified would fail.
@@ -46,9 +44,6 @@ public class InstallTests extends CoreTest {
 		try {
 			installed = BundleTestingHelper.installBundle(OSGiTestsActivator.getContext(), OSGiTestsActivator.TEST_FILES_ROOT + "internal/plugins/installTests/bundle03"); //$NON-NLS-1$
 			// success - should allow manifests with no version.
-		} catch (BundleException be) {
-			// should not have failed with BundleException
-			fail("1.0"); //$NON-NLS-1$
 		} finally {
 			if (installed != null)
 				// clean-up - only runs if we end-up accepting an invalid manifest
@@ -59,6 +54,7 @@ public class InstallTests extends CoreTest {
 	/**
 	 * Test invalid manifest; missing Bundle-SymbolicName
 	 */
+	@Test
 	public void testInstallInvalidManifest02() throws IOException, BundleException {
 		Bundle installed = null;
 		try {
@@ -78,6 +74,7 @@ public class InstallTests extends CoreTest {
 	/**
 	 * Test invalid manifest; duplicate directive
 	 */
+	@Test
 	public void testInstallInvalidManifest03() throws IOException, BundleException {
 		Bundle installed = null;
 		try {
@@ -97,6 +94,7 @@ public class InstallTests extends CoreTest {
 	/**
 	 * Test invalid manifest; use attributes bundle-version and bundle-symbolic-name in Export-Package
 	 */
+	@Test
 	public void testInstallInvalidManifest04() throws IOException, BundleException {
 		Bundle installed = null;
 		try {
@@ -116,6 +114,7 @@ public class InstallTests extends CoreTest {
 	/**
 	 * Test invalid manifest; imports same package twice
 	 */
+	@Test
 	public void testInstallInvalidManifest05() throws IOException, BundleException {
 		Bundle installed = null;
 		try {
@@ -135,16 +134,12 @@ public class InstallTests extends CoreTest {
 	/**
 	 * Test unresolvable
 	 */
+	@Test
 	public void testStartError01() throws IOException, BundleException {
 		Bundle installed = null;
 		try {
-			try {
-				installed = BundleTestingHelper.installBundle("testStartError01", OSGiTestsActivator.getContext(), OSGiTestsActivator.TEST_FILES_ROOT + "internal/plugins/installTests/bundle15"); //$NON-NLS-1$ //$NON-NLS-2$
-				// should be able to install
-			} catch (BundleException be) {
-				// failed to install unresolvable bundle
-				fail("Unexpected installation error", be); //$NON-NLS-1$
-			}
+			installed = BundleTestingHelper.installBundle("testStartError01", OSGiTestsActivator.getContext(), //$NON-NLS-1$
+					OSGiTestsActivator.TEST_FILES_ROOT + "internal/plugins/installTests/bundle15"); //$NON-NLS-1$
 			try {
 				installed.start();
 				// expected exception starting
@@ -164,22 +159,21 @@ public class InstallTests extends CoreTest {
 	/**
 	 * Test start fragment
 	 */
+	@Test
 	public void testStartError02() throws IOException, BundleException {
 		Bundle host = null;
 		Bundle fragment = null;
 		try {
-			try {
-				host = BundleTestingHelper.installBundle("testStartError02_host", OSGiTestsActivator.getContext(), OSGiTestsActivator.TEST_FILES_ROOT + "internal/plugins/installTests/bundle16"); //$NON-NLS-1$ //$NON-NLS-2$
-				fragment = BundleTestingHelper.installBundle("testStartError02_frag", OSGiTestsActivator.getContext(), OSGiTestsActivator.TEST_FILES_ROOT + "internal/plugins/installTests/bundle17"); //$NON-NLS-1$ //$NON-NLS-2$
-				// should be able to install host
-			} catch (BundleException be) {
-				// failed to install unresolvable bundle
-				fail("Unexpected installation error", be); //$NON-NLS-1$
-			}
+			host = BundleTestingHelper.installBundle("testStartError02_host", OSGiTestsActivator.getContext(), //$NON-NLS-1$
+					OSGiTestsActivator.TEST_FILES_ROOT + "internal/plugins/installTests/bundle16"); //$NON-NLS-1$
+			fragment = BundleTestingHelper.installBundle("testStartError02_frag", OSGiTestsActivator.getContext(), //$NON-NLS-1$
+					OSGiTestsActivator.TEST_FILES_ROOT + "internal/plugins/installTests/bundle17"); //$NON-NLS-1$
 			try {
 				host.start();
 			} catch (BundleException be) {
-				fail("Unexpected start host error", be); //$NON-NLS-1$
+				AssertionFailedError error = new AssertionFailedError("Unexpected start host error");
+				error.initCause(be);
+				throw error;
 			}
 			try {
 				fragment.start();
@@ -202,6 +196,7 @@ public class InstallTests extends CoreTest {
 	/**
 	 * Test unsupported operation with boot classpath extension
 	 */
+	@Test
 	public void testUnsupportedOperation01() throws IOException, BundleException {
 		Bundle installed = null;
 		try {
@@ -218,6 +213,7 @@ public class InstallTests extends CoreTest {
 		}
 	}
 
+	@Test
 	public void testInstallLocationWithSpaces() throws BundleException, IOException {
 		Bundle installed = null;
 		installed = BundleTestingHelper.installBundle(OSGiTestsActivator.getContext(), OSGiTestsActivator.TEST_FILES_ROOT + "internal/plugins/installTests/bundle 01"); //$NON-NLS-1$
@@ -230,6 +226,7 @@ public class InstallTests extends CoreTest {
 		}
 	}
 
+	@Test
 	public void testInstallLocationWithUnderscores() throws BundleException, IOException {
 		Bundle installed = null;
 		installed = BundleTestingHelper.installBundle(OSGiTestsActivator.getContext(), OSGiTestsActivator.TEST_FILES_ROOT + "internal/plugins/installTests/bundle02_1.0.0"); //$NON-NLS-1$
@@ -244,6 +241,7 @@ public class InstallTests extends CoreTest {
 	}
 
 	/** Ensures we see a bundle with only a extension point as a singleton */
+	@Test
 	public void testInstallBundleWithExtensionPointOnly() throws BundleException, IOException {
 		Bundle installed = null;
 		installed = BundleTestingHelper.installBundle(OSGiTestsActivator.getContext(), OSGiTestsActivator.TEST_FILES_ROOT + "internal/plugins/installTests/bundle04"); //$NON-NLS-1$
@@ -264,6 +262,7 @@ public class InstallTests extends CoreTest {
 	}
 
 	/** Ensures we see a bundle with only a extension as a singleton */
+	@Test
 	public void testInstallBundleWithExtensionOnly() throws BundleException, IOException {
 		Bundle installed = null;
 		installed = BundleTestingHelper.installBundle(OSGiTestsActivator.getContext(), OSGiTestsActivator.TEST_FILES_ROOT + "internal/plugins/installTests/bundle05"); //$NON-NLS-1$
@@ -284,6 +283,7 @@ public class InstallTests extends CoreTest {
 	}
 
 	/** Ensures we see a bundle with only extension and extension point as a singleton */
+	@Test
 	public void testInstallBundleWithExtensionAndExtensionPoint() throws BundleException, IOException {
 		Bundle installed = null;
 		installed = BundleTestingHelper.installBundle(OSGiTestsActivator.getContext(), OSGiTestsActivator.TEST_FILES_ROOT + "internal/plugins/installTests/bundle06"); //$NON-NLS-1$
@@ -304,6 +304,7 @@ public class InstallTests extends CoreTest {
 	}
 
 	/** Ensures two versions of a non-singleton bundle are accepted */
+	@Test
 	public void testInstall2NonSingletonBundles() throws BundleException, IOException {
 		Bundle installed1 = org.eclipse.core.tests.harness.BundleTestingHelper.installBundle(OSGiTestsActivator.getContext(), OSGiTestsActivator.TEST_FILES_ROOT + "internal/plugins/installTests/bundle07"); //$NON-NLS-1$
 		ServiceReference packageAdminSR = OSGiTestsActivator.getContext().getServiceReference(PackageAdmin.class.getName());
@@ -327,6 +328,7 @@ public class InstallTests extends CoreTest {
 	}
 
 	/** Ensures two versions of a singleton bundle are accepted */
+	@Test
 	public void testInstall2SingletonBundles() throws BundleException, IOException {
 		Bundle installed1 = BundleTestingHelper.installBundle(OSGiTestsActivator.getContext(), OSGiTestsActivator.TEST_FILES_ROOT + "internal/plugins/installTests/bundle08"); //$NON-NLS-1$
 		ServiceReference packageAdminSR = OSGiTestsActivator.getContext().getServiceReference(PackageAdmin.class.getName());

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/perf/CaseMapPerformanceTest.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/perf/CaseMapPerformanceTest.java
@@ -18,11 +18,15 @@ import java.util.Map;
 import org.eclipse.core.tests.harness.PerformanceTestRunner;
 import org.eclipse.osgi.framework.util.CaseInsensitiveDictionaryMap;
 import org.eclipse.osgi.framework.util.Headers;
-import org.eclipse.osgi.tests.OSGiTest;
 import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.rules.TestName;
 import org.osgi.framework.Constants;
 
-public class CaseMapPerformanceTest extends OSGiTest {
+public class CaseMapPerformanceTest {
+	@Rule
+	public TestName testName = new TestName();
+
 	static final String[] KEYS;
 	static final Object VALUE = new Object();
 	static {
@@ -32,81 +36,77 @@ public class CaseMapPerformanceTest extends OSGiTest {
 		}
 	}
 
-	public CaseMapPerformanceTest(String name) {
-		super(name);
-	}
-
-	public void testHeaders004() {
+	public void testHeaders004() throws Exception {
 		final Map<String, Object> headers = new Headers<>(4);
 		doTestMap(headers, 4);
 	}
 
-	public void testHeaders005() {
+	public void testHeaders005() throws Exception {
 		final Map<String, Object> headers = new Headers<>(5);
 		doTestMap(headers, 5);
 	}
 
-	public void testHeaders006() {
+	public void testHeaders006() throws Exception {
 		final Map<String, Object> headers = new Headers<>(6);
 		doTestMap(headers, 6);
 	}
 
-	public void testHeaders010() {
+	public void testHeaders010() throws Exception {
 		final Map<String, Object> headers = new Headers<>(10);
 		doTestMap(headers, 10);
 	}
 
-	public void testHeaders020() {
+	public void testHeaders020() throws Exception {
 		final Map<String, Object> headers = new Headers<>(20);
 		doTestMap(headers, 20);
 	}
 
-	public void testHeaders100() {
+	public void testHeaders100() throws Exception {
 		final Map<String, Object> headers = new Headers<>(100);
 		doTestMap(headers, 100);
 	}
 
-	public void testXCaseMap004() {
+	public void testXCaseMap004() throws Exception {
 		final Map<String, Object> headers = new CaseInsensitiveDictionaryMap<>(4);
 		doTestMap(headers, 4);
 	}
 
-	public void testXCaseMap005() {
+	public void testXCaseMap005() throws Exception {
 		final Map<String, Object> headers = new CaseInsensitiveDictionaryMap<>(5);
 		doTestMap(headers, 5);
 	}
 
-	public void testXCaseMap006() {
+	public void testXCaseMap006() throws Exception {
 		final Map<String, Object> headers = new CaseInsensitiveDictionaryMap<>(6);
 		doTestMap(headers, 6);
 	}
 
-	public void testXCaseMap010() {
+	public void testXCaseMap010() throws Exception {
 		final Map<String, Object> headers = new CaseInsensitiveDictionaryMap<>(10);
 		doTestMap(headers, 10);
 	}
 
-	public void testXCaseMap034() {
+	public void testXCaseMap034() throws Exception {
 		final Map<String, Object> headers = new CaseInsensitiveDictionaryMap<>(34);
 		doTestMap(headers, 34);
 	}
 
-	public void testXCaseMap100() {
+	public void testXCaseMap100() throws Exception {
 		final Map<String, Object> headers = new CaseInsensitiveDictionaryMap<>(100);
 		doTestMap(headers, 100);
 	}
 
-	private void doTestMap(final Map<String, Object> map, final int numKeys) {
+	private void doTestMap(final Map<String, Object> map, final int numKeys) throws Exception {
 		new PerformanceTestRunner() {
 			protected void test() {
 				fillMap(map, numKeys);
 				doMapGet(map, numKeys);
 			}
 
-		}.run(this, 10, 10000);
+		}.run(getClass(), testName.getMethodName(), 10, 10000);
 	}
 
-	public void testCommonKeyMap() {
+	public void testCommonKeyMap() throws Exception {
 		final Map<String, Object> map = new CaseInsensitiveDictionaryMap<>(34);
 		new PerformanceTestRunner() {
 			protected void test() {
@@ -114,10 +114,10 @@ public class CaseMapPerformanceTest extends OSGiTest {
 				doCommonKeyMapGet(map);
 			}
 
-		}.run(this, 10, 10000);
+		}.run(getClass(), testName.getMethodName(), 10, 10000);
 	}
 
-	public void testCommonHashMap() {
+	public void testCommonHashMap() throws Exception {
 		final Map<String, Object> map = new HashMap<>(34);
 		new PerformanceTestRunner() {
 			protected void test() {
@@ -125,7 +125,7 @@ public class CaseMapPerformanceTest extends OSGiTest {
 				doCommonKeyMapGet(map);
 			}
 
-		}.run(this, 10, 10000);
+		}.run(getClass(), testName.getMethodName(), 10, 10000);
 	}
 
 	static void fillMap(Map<String, Object> map, int numKeys) {


### PR DESCRIPTION
This migrates all tests to JUnit 4 that are in packages containing only a single test class or only a single test not yet migrated to JUnit 4.

* Add JUnit 4 annotations `@Test`, `@Before`, `@After`
* Remove inheritance of JUnit 3 `TestCase` and `CoreTest`
* Adapt performance tests to JUnit-4-conforming API
* Replace try-catch for actual errors with making the test method throw the exception