### PR TITLE
Touch bundles affected by changed compiler generation for switch

### DIFF
--- a/bundles/org.eclipse.osgi/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.osgi/forceQualifierUpdate.txt
@@ -9,3 +9,4 @@ https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/20
 Touch for module-info updates
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation #1139
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1686


### PR DESCRIPTION
See https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1686