### PR TITLE
Proper exception in PreferencesService#setDefaultLookupOrder() #464

### DIFF
--- a/bundles/org.eclipse.equinox.preferences/src/org/eclipse/core/internal/preferences/PreferencesService.java
+++ b/bundles/org.eclipse.equinox.preferences/src/org/eclipse/core/internal/preferences/PreferencesService.java
@@ -901,7 +901,9 @@ public class PreferencesService implements IPreferencesService {
 		if (order == null) {
 			DEFAULTS_REGISTRY.remove(registryKey);
 		} else {
-			Arrays.asList(order).forEach(Objects::requireNonNull);
+			if (Arrays.stream(order).anyMatch(Objects::isNull)) {
+				throw new IllegalArgumentException();
+			}
 			DEFAULTS_REGISTRY.put(registryKey, order);
 		}
 	}


### PR DESCRIPTION
`PreferencesService#setDefaultLookupOrder(String, String, String[])` has recently been changed to now throwing a `NullPointerException` instead of an `IllegalArgumentException` in case of any of its order arguments being `null`. This is incompatible with the API documentation in `IPreferencesService`.
This change restores the existing behavior of throwing an `IllegalArgumentException` in the mentioned case.

Fixes https://github.com/eclipse-equinox/equinox/issues/464