### PR TITLE
Add a 'wires' command to allow easy investigation of bundle wires

### DIFF
--- a/bundles/org.eclipse.equinox.console/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.console/META-INF/MANIFEST.MF
@@ -8,6 +8,7 @@ Bundle-Vendor: %bundleVendor
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Import-Package: org.apache.felix.service.command;version="[1.0,2.0)",
+ org.eclipse.osgi.container;version="[1.7.0,2.0.0]",
  org.eclipse.osgi.framework.console,
  org.eclipse.osgi.report.resolution;version="[1.0,2.0)",
  org.eclipse.osgi.service.environment,

--- a/bundles/org.eclipse.equinox.console/src/org/eclipse/equinox/console/command/adapter/Activator.java
+++ b/bundles/org.eclipse.equinox.console/src/org/eclipse/equinox/console/command/adapter/Activator.java
@@ -34,6 +34,7 @@ import org.eclipse.equinox.console.commands.DisconnectCommand;
 import org.eclipse.equinox.console.commands.EquinoxCommandProvider;
 import org.eclipse.equinox.console.commands.HelpCommand;
 import org.eclipse.equinox.console.commands.ManCommand;
+import org.eclipse.equinox.console.commands.WireCommand;
 import org.eclipse.equinox.console.telnet.TelnetCommand;
 import org.eclipse.osgi.framework.console.CommandInterpreter;
 import org.eclipse.osgi.framework.console.CommandProvider;
@@ -324,6 +325,9 @@ public class Activator implements BundleActivator {
 
 		CommandsTracker commandsTracker = new CommandsTracker(context);
 		context.registerService(CommandsTracker.class.getName(), commandsTracker, null);
+		
+		WireCommand wireCommand = new WireCommand(context);
+		wireCommand.startService();
 
 		GOGO.RUNTIME.start(frameworkWiring);
 		GOGO.SHELL.start(frameworkWiring);

--- a/bundles/org.eclipse.equinox.console/src/org/eclipse/equinox/console/commands/WireCommand.java
+++ b/bundles/org.eclipse.equinox.console/src/org/eclipse/equinox/console/commands/WireCommand.java
@@ -1,0 +1,121 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Christoph Läubrich and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.equinox.console.commands;
+
+import java.io.PrintStream;
+import java.util.Comparator;
+import java.util.Dictionary;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.apache.felix.service.command.CommandProcessor;
+import org.apache.felix.service.command.CommandSession;
+import org.apache.felix.service.command.Descriptor;
+import org.eclipse.osgi.container.ModuleContainer;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.wiring.BundleRevision;
+import org.osgi.framework.wiring.BundleWire;
+import org.osgi.framework.wiring.BundleWiring;
+import org.osgi.resource.Resource;
+
+/**
+ * Provides a "wires" command to print information about the wiring of a bundle
+ */
+public class WireCommand {
+
+	private static final Comparator<BundleRevision> BUNDLE_REVISIONS_BY_NAME = Comparator.comparing(
+			BundleRevision::getSymbolicName, String.CASE_INSENSITIVE_ORDER);
+
+	private BundleContext context;
+
+	public WireCommand(BundleContext context) {
+		this.context = context;
+	}
+
+	@Descriptor("Prints information about the wiring of a particular bundle")
+	public void wires(CommandSession session, long id) {
+		PrintStream console = session.getConsole();
+		Bundle bundle = context.getBundle(id);
+		if (bundle == null) {
+			console.println(String.format("Bundle with id %d not found!", id));
+			return;
+		}
+		BundleWiring bundleWiring = bundle.adapt(BundleWiring.class);
+		if (bundleWiring == null) {
+			console.println(String.format("Bundle with id %d has no wiring!", id));
+			return;
+		}
+		console.println("Bundle " + bundle.getSymbolicName() + " " + bundle.getVersion() + ":");
+		printWiring(console, bundleWiring);
+	}
+
+	static void printWiring(PrintStream console, BundleWiring bundleWiring) {
+		BundleRevision resource = bundleWiring.getResource();
+		Map<BundleRevision, List<BundleWire>> usedWires =
+				bundleWiring.getRequiredWires(null).stream()
+						.filter(bw -> !resource.equals(bw.getProvider()))
+						.collect(Collectors.groupingBy(BundleWire::getProvider));
+		if (usedWires.isEmpty()) {
+			console.println("is not wired to any other bundle");
+		} else {
+			console.println("is wired to:");
+			usedWires.entrySet().stream().sorted(Comparator
+					.comparing(java.util.Map.Entry::getKey, BUNDLE_REVISIONS_BY_NAME))
+					.forEach(bre -> {
+						console.println("\t - " + getResource(bre.getKey()));
+						for (BundleWire bw : bre.getValue()) {
+							console.println("\t   - because of "
+									+ ModuleContainer.toString(bw.getRequirement()));
+						}
+					});
+
+		}
+		Map<BundleRevision, List<BundleWire>> consumersWires =
+				bundleWiring.getProvidedWires(null).stream()
+						.collect(Collectors.groupingBy(BundleWire::getRequirer));
+		if (consumersWires.isEmpty()) {
+			console.println("and is not consumed by any bundle");
+		} else {
+			console.println("and is consumed by:");
+			consumersWires.entrySet().stream().sorted(Comparator
+					.comparing(java.util.Map.Entry::getKey, BUNDLE_REVISIONS_BY_NAME))
+					.forEach(bre -> {
+						console.println("\t - " + getResource(bre.getKey()));
+						for (BundleWire bw : bre.getValue()) {
+							console.println("\t   - because it "
+									+ ModuleContainer.toString(bw.getRequirement()));
+						}
+					});
+		}
+	}
+
+	static String getResource(Resource resource) {
+		if (resource instanceof BundleRevision) {
+			BundleRevision bundleRevision = (BundleRevision) resource;
+			return bundleRevision.getSymbolicName() + " " + bundleRevision.getVersion();
+		}
+		return String.valueOf(resource);
+	}
+
+	public void startService() {
+		Dictionary<String, Object> dict = new Hashtable<>();
+		dict.put(CommandProcessor.COMMAND_SCOPE, "wiring");
+		dict.put(CommandProcessor.COMMAND_FUNCTION, new String[] { "wires" });
+		context.registerService(WireCommand.class, this, dict);
+	}
+
+}

--- a/bundles/org.eclipse.osgi/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.osgi/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Export-Package: org.eclipse.core.runtime.adaptor;x-friends:="org.eclipse.core.runtime",
  org.eclipse.core.runtime.internal.adaptor;x-internal:=true,
  org.eclipse.equinox.log;version="1.1";uses:="org.osgi.framework,org.osgi.service.log",
- org.eclipse.osgi.container;version="1.6";
+ org.eclipse.osgi.container;version="1.7.0";
   uses:="org.eclipse.osgi.report.resolution,
    org.osgi.framework.wiring,
    org.eclipse.osgi.framework.eventmgr,
@@ -107,7 +107,7 @@ Bundle-Activator: org.eclipse.osgi.internal.framework.SystemBundleActivator
 Bundle-Description: %systemBundle
 Bundle-Copyright: %copyright
 Bundle-Vendor: %eclipse.org
-Bundle-Version: 3.18.700.qualifier
+Bundle-Version: 3.19.0.qualifier
 Bundle-Localization: systembundle
 Bundle-DocUrl: http://www.eclipse.org
 Eclipse-ExtensibleAPI: true

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/container/ModuleCapability.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/container/ModuleCapability.java
@@ -88,6 +88,6 @@ public final class ModuleCapability implements BundleCapability {
 
 	@Override
 	public String toString() {
-		return namespace + ModuleRevision.toString(attributes, false) + ModuleRevision.toString(directives, true);
+		return namespace + ModuleContainer.toString(attributes, false) + ModuleContainer.toString(directives, true);
 	}
 }

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/container/ModuleRequirement.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/container/ModuleRequirement.java
@@ -18,7 +18,9 @@ import java.util.Map;
 import org.eclipse.osgi.internal.container.Capabilities;
 import org.eclipse.osgi.internal.framework.FilterImpl;
 import org.osgi.framework.InvalidSyntaxException;
-import org.osgi.framework.namespace.*;
+import org.osgi.framework.namespace.BundleNamespace;
+import org.osgi.framework.namespace.HostNamespace;
+import org.osgi.framework.namespace.PackageNamespace;
 import org.osgi.framework.wiring.BundleCapability;
 import org.osgi.framework.wiring.BundleRequirement;
 import org.osgi.resource.Namespace;
@@ -87,7 +89,7 @@ public class ModuleRequirement implements BundleRequirement {
 
 	@Override
 	public String toString() {
-		return namespace + ModuleRevision.toString(attributes, false) + ModuleRevision.toString(directives, true);
+		return namespace + ModuleContainer.toString(attributes, false) + ModuleContainer.toString(directives, true);
 	}
 
 	private static final String PACKAGENAME_FILTER_COMPONENT = PackageNamespace.PACKAGE_NAMESPACE + "="; //$NON-NLS-1$

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/container/ModuleResolutionReport.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/container/ModuleResolutionReport.java
@@ -20,17 +20,10 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import org.eclipse.osgi.internal.framework.FilterImpl;
 import org.eclipse.osgi.internal.messages.Msg;
 import org.eclipse.osgi.report.resolution.ResolutionReport;
-import org.osgi.framework.Constants;
-import org.osgi.framework.InvalidSyntaxException;
-import org.osgi.framework.namespace.BundleNamespace;
-import org.osgi.framework.namespace.HostNamespace;
-import org.osgi.framework.namespace.PackageNamespace;
 import org.osgi.framework.wiring.BundleRevision;
 import org.osgi.resource.Capability;
-import org.osgi.resource.Namespace;
 import org.osgi.resource.Requirement;
 import org.osgi.resource.Resource;
 import org.osgi.resource.Wire;
@@ -132,7 +125,8 @@ class ModuleResolutionReport implements ResolutionReport {
 	private static void printResolutionEntry(StringBuilder result, String prepend, ResolutionReport.Entry entry, Map<Resource, List<ResolutionReport.Entry>> reportEntries, Set<BundleRevision> visited) {
 		switch (entry.getType()) {
 			case MISSING_CAPABILITY :
-				result.append(prepend).append(Msg.ModuleResolutionReport_UnresolvedReq).append(printRequirement(entry.getData())).append('\n');
+				result.append(prepend).append(Msg.ModuleResolutionReport_UnresolvedReq)
+						.append(ModuleContainer.toString((Requirement) entry.getData())).append('\n');
 				break;
 			case SINGLETON_SELECTION :
 				result.append(prepend).append(Msg.ModuleResolutionReport_AnotherSingleton).append(entry.getData()).append('\n');
@@ -147,8 +141,11 @@ class ModuleResolutionReport implements ResolutionReport {
 						Capability unresolvedCapability = unresolvedCapabilities.iterator().next();
 						// make sure this is not a case of importing and exporting the same package
 						if (!unresolvedRequirement.getKey().getResource().equals(unresolvedCapability.getResource())) {
-							result.append(prepend).append(Msg.ModuleResolutionReport_UnresolvedReq).append(printRequirement(unresolvedRequirement.getKey())).append('\n');
-							result.append(prepend).append("  -> ").append(printCapability(unresolvedCapability)).append('\n'); //$NON-NLS-1$
+							result.append(prepend).append(Msg.ModuleResolutionReport_UnresolvedReq)
+									.append(ModuleContainer.toString(unresolvedRequirement.getKey()))
+									.append('\n');
+							result.append(prepend).append("  -> ") //$NON-NLS-1$
+									.append(ModuleContainer.toString(unresolvedCapability)).append('\n');
 							result.append(getResolutionReport0(prepend + "     ", (ModuleRevision) unresolvedCapability.getResource(), reportEntries, visited)); //$NON-NLS-1$
 						}
 					}
@@ -165,57 +162,6 @@ class ModuleResolutionReport implements ResolutionReport {
 				result.append(Msg.ModuleResolutionReport_Unknown).append("type=").append(entry.getType()).append(" data=").append(entry.getData()).append('\n'); //$NON-NLS-1$ //$NON-NLS-2$
 				break;
 		}
-	}
-
-	private static Object printCapability(Capability cap) {
-		if (PackageNamespace.PACKAGE_NAMESPACE.equals(cap.getNamespace())) {
-			return Constants.EXPORT_PACKAGE + ": " + createOSGiCapability(cap); //$NON-NLS-1$
-		} else if (BundleNamespace.BUNDLE_NAMESPACE.equals(cap.getNamespace())) {
-			return Constants.BUNDLE_SYMBOLICNAME + ": " + createOSGiCapability(cap); //$NON-NLS-1$
-		} else if (HostNamespace.HOST_NAMESPACE.equals(cap.getNamespace())) {
-			return Constants.BUNDLE_SYMBOLICNAME + ": " + createOSGiCapability(cap); //$NON-NLS-1$
-		}
-		return Constants.PROVIDE_CAPABILITY + ": " + cap.toString(); //$NON-NLS-1$
-	}
-
-	private static String createOSGiCapability(Capability cap) {
-		Map<String, Object> attributes = new HashMap<>(cap.getAttributes());
-		Map<String, String> directives = cap.getDirectives();
-		String name = String.valueOf(attributes.remove(cap.getNamespace()));
-		return name + ModuleRevision.toString(attributes, false, true) + ModuleRevision.toString(directives, true, true);
-	}
-
-	private static String printRequirement(Object data) {
-		if (!(data instanceof Requirement)) {
-			return String.valueOf(data);
-		}
-		Requirement req = (Requirement) data;
-		if (PackageNamespace.PACKAGE_NAMESPACE.equals(req.getNamespace())) {
-			return Constants.IMPORT_PACKAGE + ": " + createOSGiRequirement(req, PackageNamespace.CAPABILITY_VERSION_ATTRIBUTE, PackageNamespace.CAPABILITY_BUNDLE_VERSION_ATTRIBUTE); //$NON-NLS-1$
-		} else if (BundleNamespace.BUNDLE_NAMESPACE.equals(req.getNamespace())) {
-			return Constants.REQUIRE_BUNDLE + ": " + createOSGiRequirement(req, BundleNamespace.CAPABILITY_BUNDLE_VERSION_ATTRIBUTE); //$NON-NLS-1$
-		} else if (HostNamespace.HOST_NAMESPACE.equals(req.getNamespace())) {
-			return Constants.FRAGMENT_HOST + ": " + createOSGiRequirement(req, HostNamespace.CAPABILITY_BUNDLE_VERSION_ATTRIBUTE); //$NON-NLS-1$
-		}
-		return Constants.REQUIRE_CAPABILITY + ": " + req.toString(); //$NON-NLS-1$
-	}
-
-	private static String createOSGiRequirement(Requirement requirement, String... versions) {
-		Map<String, String> directives = new HashMap<>(requirement.getDirectives());
-		String filter = directives.remove(Namespace.REQUIREMENT_FILTER_DIRECTIVE);
-		if (filter == null)
-			throw new IllegalArgumentException("No filter directive found:" + requirement); //$NON-NLS-1$
-		FilterImpl filterImpl;
-		try {
-			filterImpl = FilterImpl.newInstance(filter);
-		} catch (InvalidSyntaxException e) {
-			throw new IllegalArgumentException("Invalid filter directive", e); //$NON-NLS-1$
-		}
-		Map<String, String> matchingAttributes = filterImpl.getStandardOSGiAttributes(versions);
-		String name = matchingAttributes.remove(requirement.getNamespace());
-		if (name == null)
-			throw new IllegalArgumentException("Invalid requirement: " + requirement); //$NON-NLS-1$
-		return name + ModuleRevision.toString(matchingAttributes, false, true) + ModuleRevision.toString(directives, true, true);
 	}
 
 	@Override

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/container/ModuleRevision.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/container/ModuleRevision.java
@@ -17,8 +17,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
 import java.util.function.Function;
 import org.eclipse.osgi.container.ModuleRevisionBuilder.GenericInfo;
 import org.eclipse.osgi.container.namespaces.EquinoxModuleDataNamespace;
@@ -200,45 +198,6 @@ public final class ModuleRevision implements BundleRevision {
 		if (identities.isEmpty())
 			return super.toString();
 		return identities.get(0).toString();
-	}
-
-	static <V> String toString(Map<String, V> map, boolean directives) {
-		return toString(map, directives, false);
-	}
-
-	static <V> String toString(Map<String, V> map, boolean directives, boolean stringsOnly) {
-		if (map.size() == 0)
-			return ""; //$NON-NLS-1$
-		String assignment = directives ? ":=" : "="; //$NON-NLS-1$ //$NON-NLS-2$
-		Set<Entry<String, V>> set = map.entrySet();
-		StringBuilder sb = new StringBuilder();
-		for (Entry<String, V> entry : set) {
-			sb.append("; "); //$NON-NLS-1$
-			String key = entry.getKey();
-			Object value = entry.getValue();
-			if (value instanceof List) {
-				@SuppressWarnings("unchecked")
-				List<Object> list = (List<Object>) value;
-				if (list.isEmpty())
-					continue;
-				Object component = list.get(0);
-				String className = component.getClass().getName();
-				String type = className.substring(className.lastIndexOf('.') + 1);
-				sb.append(key).append(':').append("List<").append(type).append(">").append(assignment).append('"'); //$NON-NLS-1$ //$NON-NLS-2$
-				for (Object object : list)
-					sb.append(object).append(',');
-				sb.setLength(sb.length() - 1);
-				sb.append('"');
-			} else {
-				String type = ""; //$NON-NLS-1$
-				if (!(value instanceof String) && !stringsOnly) {
-					String className = value.getClass().getName();
-					type = ":" + className.substring(className.lastIndexOf('.') + 1); //$NON-NLS-1$
-				}
-				sb.append(key).append(type).append(assignment).append('"').append(value).append('"');
-			}
-		}
-		return sb.toString();
 	}
 
 	NamespaceList<ModuleCapability> getCapabilities() {

--- a/bundles/org.eclipse.osgi/pom.xml
+++ b/bundles/org.eclipse.osgi/pom.xml
@@ -19,7 +19,7 @@
 </parent>
   <groupId>org.eclipse.osgi</groupId>
   <artifactId>org.eclipse.osgi</artifactId>
-  <version>3.18.700-SNAPSHOT</version>
+  <version>3.19.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   <properties>
 	  <!-- The actual TCKs are executed in the org.eclipse.osgi.tck module because of reference to other service implementations -->


### PR DESCRIPTION
Currently it is quite hard to find out if/why a certain bundle is using some other bundles or are used by others.

This adds a new 'wires' command that when executed against a given bundle prints all wires that are used by the bundle and any wires it provides to other bundles. This results in a very powerful tool to analyze dependency problems and find out why a bundle is actually used.

An example output looks like this:
```
Bundle org.eclipse.ui.workbench 3.131.100.qualifier:
is wired to:
	 - com.ibm.icu 74.1.0
	   - because of Import-Package: com.ibm.icu.util
	 - jakarta.annotation-api 2.1.1
	   - because of Import-Package: jakarta.annotation; version="[2.1.0,3.0.0)"
	 - jakarta.inject.jakarta.inject-api 2.0.1
	   - because of Import-Package: jakarta.inject; version="[2.0.0,3.0.0)"
	 - org.apache.felix.scr 2.2.6
	   - because of Require-Capability: osgi.extender; filter:="(&(osgi.extender=osgi.component)(version>=1.2)(!(version>=2.0)))"
	 - org.eclipse.core.databinding.observable 1.13.200.qualifier
	   - because of Require-Bundle: org.eclipse.core.databinding.observable; bundle-version="[1.2.0,2.0.0)"
	 - org.eclipse.core.databinding.property 1.10.200.qualifier
	   - because of Require-Bundle: org.eclipse.core.databinding.property; bundle-version="[1.2.0,2.0.0)"
	 - org.eclipse.core.runtime 3.31.0.qualifier
	   - because of Require-Bundle: org.eclipse.core.runtime; bundle-version="[3.29.0,4.0.0)"
	 - org.eclipse.e4.core.commands 1.1.300.qualifier
	   - because of Import-Package: org.eclipse.e4.core.commands
	   - because of Import-Package: org.eclipse.e4.core.commands.internal
	 - org.eclipse.e4.core.contexts 1.12.500.qualifier
	   - because of Require-Bundle: org.eclipse.e4.core.contexts; bundle-version="1.0.0"
	 - org.eclipse.e4.core.di 1.9.300.qualifier
	   - because of Require-Bundle: org.eclipse.e4.core.di; bundle-version="1.1.0"
	 - org.eclipse.e4.core.di.extensions 0.18.200.qualifier
	   - because of Require-Bundle: org.eclipse.e4.core.di.extensions; bundle-version="0.13.0"
	 - org.eclipse.e4.core.services 2.4.300.qualifier
	   - because of Require-Bundle: org.eclipse.e4.core.services; bundle-version="2.2.0"
	 - org.eclipse.e4.ui.bindings 0.14.300.qualifier
	   - because of Require-Bundle: org.eclipse.e4.ui.bindings; bundle-version="0.9.0"
	 - org.eclipse.e4.ui.css.swt 0.15.300.qualifier
	   - because of Require-Bundle: org.eclipse.e4.ui.css.swt; bundle-version="0.9.1"
	 - org.eclipse.e4.ui.css.swt.theme 0.14.300.qualifier
	   - because of Require-Bundle: org.eclipse.e4.ui.css.swt.theme; bundle-version="0.9.0"
	 - org.eclipse.e4.ui.di 1.5.300.qualifier
	   - because of Require-Bundle: org.eclipse.e4.ui.di; bundle-version="0.9.0"
	 - org.eclipse.e4.ui.model.workbench 2.4.200.qualifier
	   - because of Require-Bundle: org.eclipse.e4.ui.model.workbench; bundle-version="0.9.1"
	 - org.eclipse.e4.ui.services 1.6.300.qualifier
	   - because of Import-Package: org.eclipse.e4.ui.services
	   - because of Require-Bundle: org.eclipse.e4.ui.services; bundle-version="1.3.0"
	 - org.eclipse.e4.ui.workbench 1.15.300.qualifier
	   - because of Import-Package: org.eclipse.e4.ui.internal.workbench
	   - because of Import-Package: org.eclipse.e4.ui.internal.workbench.addons
	   - because of Import-Package: org.eclipse.e4.ui.workbench
	   - because of Import-Package: org.eclipse.e4.ui.workbench.modeling
	 - org.eclipse.e4.ui.workbench.addons.swt 1.5.300.qualifier
	   - because of Require-Bundle: org.eclipse.e4.ui.workbench.addons.swt; bundle-version="0.10.0"
	 - org.eclipse.e4.ui.workbench.renderers.swt 0.16.300.qualifier
	   - because of Import-Package: org.eclipse.e4.ui.internal.workbench.renderers.swt
	   - because of Import-Package: org.eclipse.e4.ui.workbench.renderers.swt
	 - org.eclipse.e4.ui.workbench.swt 0.17.300.qualifier
	   - because of Import-Package: org.eclipse.e4.ui.internal.workbench.swt
	   - because of Require-Bundle: org.eclipse.e4.ui.workbench.swt; bundle-version="0.9.1"
	 - org.eclipse.e4.ui.workbench3 0.17.300.qualifier
	   - because of Require-Bundle: org.eclipse.e4.ui.workbench3; bundle-version="0.15.0"; visibility:="reexport"
	 - org.eclipse.emf.ecore.xmi 2.37.0.qualifier
	   - because of Require-Bundle: org.eclipse.emf.ecore.xmi; bundle-version="2.11.0"
	 - org.eclipse.help 3.10.300.qualifier
	   - because of Require-Bundle: org.eclipse.help; bundle-version="[3.2.0,4.0.0)"
	 - org.eclipse.jface 3.33.0.qualifier
	   - because of Require-Bundle: org.eclipse.jface; bundle-version="[3.31.0,4.0.0)"
	 - org.eclipse.jface.databinding 1.15.200.qualifier
	   - because of Require-Bundle: org.eclipse.jface.databinding; bundle-version="[1.3.0,2.0.0)"
	 - org.eclipse.osgi 3.19.0.qualifier
	   - because of Import-Package: javax.xml.parsers
	   - because of Import-Package: org.w3c.dom
	   - because of Import-Package: org.xml.sax
	   - because of Require-Capability: osgi.ee; filter:="(&(osgi.ee=JavaSE)(version=17))"
	 - org.osgi.service.event 1.4.1.202109301733
	   - because of Import-Package: org.osgi.service.event; version="[1.2.0,2.0.0)"
and is consumed by:
	 - org.eclipse.jdt.ui 3.31.100.qualifier
	   - because it Require-Bundle: org.eclipse.ui.workbench; bundle-version="[3.131.0,4.0.0)"
	 - org.eclipse.ui 3.205.100.qualifier
	   - because it Require-Bundle: org.eclipse.ui.workbench; bundle-version="[3.130.0,4.0.0)"; visibility:="reexport"
	 - org.eclipse.ui.editors 3.17.200.qualifier
	   - because it Require-Bundle: org.eclipse.ui.workbench; bundle-version="[3.130.0,4.0.0)"
	 - org.eclipse.ui.genericeditor 1.3.300.qualifier
	   - because it Require-Bundle: org.eclipse.ui.workbench; bundle-version="3.109.0"
	 - org.eclipse.ui.intro.quicklinks 1.2.300.qualifier
	   - because it Require-Bundle: org.eclipse.ui.workbench; bundle-version="3.108.0"
```