### PR TITLE
Add a command to export the module database into a file

### DIFF
--- a/bundles/org.eclipse.equinox.console/src/org/eclipse/equinox/console/command/adapter/Activator.java
+++ b/bundles/org.eclipse.equinox.console/src/org/eclipse/equinox/console/command/adapter/Activator.java
@@ -32,6 +32,7 @@ import org.apache.felix.service.command.CommandSession;
 import org.eclipse.equinox.console.commands.CommandsTracker;
 import org.eclipse.equinox.console.commands.DisconnectCommand;
 import org.eclipse.equinox.console.commands.EquinoxCommandProvider;
+import org.eclipse.equinox.console.commands.ExportStateCommand;
 import org.eclipse.equinox.console.commands.HelpCommand;
 import org.eclipse.equinox.console.commands.ManCommand;
 import org.eclipse.equinox.console.commands.WireCommand;
@@ -328,6 +329,9 @@ public class Activator implements BundleActivator {
 		
 		WireCommand wireCommand = new WireCommand(context);
 		wireCommand.startService();
+
+		ExportStateCommand exportResourcesCommand = new ExportStateCommand(context);
+		exportResourcesCommand.startService();
 
 		GOGO.RUNTIME.start(frameworkWiring);
 		GOGO.SHELL.start(frameworkWiring);

--- a/bundles/org.eclipse.equinox.console/src/org/eclipse/equinox/console/commands/ExportStateCommand.java
+++ b/bundles/org.eclipse.equinox.console/src/org/eclipse/equinox/console/commands/ExportStateCommand.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Christoph Läubrich and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.equinox.console.commands;
+
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.Dictionary;
+import java.util.Hashtable;
+
+import org.apache.felix.service.command.CommandProcessor;
+import org.apache.felix.service.command.CommandSession;
+import org.apache.felix.service.command.Descriptor;
+import org.eclipse.osgi.container.Module;
+import org.osgi.framework.BundleContext;
+
+public class ExportStateCommand {
+
+	private BundleContext context;
+
+	public ExportStateCommand(BundleContext context) {
+		this.context = context;
+	}
+
+	public void startService() {
+		Dictionary<String, Object> dict = new Hashtable<>();
+		dict.put(CommandProcessor.COMMAND_SCOPE, "export");
+		dict.put(CommandProcessor.COMMAND_FUNCTION, new String[] { "exportFrameworkState" });
+		context.registerService(ExportStateCommand.class, this, dict);
+	}
+
+	@Descriptor("Exports the current framework state including the wiring information")
+	public void exportFrameworkState(CommandSession session, String path) throws IOException {
+		exportFrameworkState(session, path, true);
+	}
+
+	@Descriptor("Exports the current framework state, with or without the wiring information")
+	public void exportFrameworkState(CommandSession session, String path, boolean persistWirings) throws IOException {
+		Module module = context.getBundle(0).adapt(Module.class);
+		PrintStream console = session.getConsole();
+		if (module != null) {
+			File file = new File(path);
+			console.println("Exporting ModuleDatabase to " + file.getAbsolutePath() + "...");
+			try (DataOutputStream stream = new DataOutputStream(new FileOutputStream(file))) {
+				module.getContainer().store(stream, persistWirings);
+			}
+		} else {
+			console.println("Can't determine ModuleDatabase!");
+		}
+	}
+
+}

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/container/ModuleContainer.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/container/ModuleContainer.java
@@ -14,6 +14,8 @@
 package org.eclipse.osgi.container;
 
 import java.io.Closeable;
+import java.io.DataOutputStream;
+import java.io.IOException;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.ArrayList;
@@ -2155,5 +2157,18 @@ public final class ModuleContainer implements DebugOptionsListener {
 			Bundle b = m.getBundle();
 			return b != null ? b.toString() : m.toString();
 		}
+	}
+
+	/**
+	 * Stores the module into the given stream
+	 * 
+	 * @param stream         the stream to use
+	 * @param persistWirings controls if wirings should be persisted or not
+	 * @throws IOException if there is any problem storing to the stream
+	 * 
+	 * @since 3.19
+	 */
+	public void store(DataOutputStream stream, boolean persistWirings) throws IOException {
+		moduleDatabase.store(stream, persistWirings);
 	}
 }


### PR DESCRIPTION
Currently if one has a problematic resolver state it is very hard to provide a reproducing test case for analysis.

This adds a new command exportFrameworkState that allows to export the module database (optional with its wiring state) into a file that later can be loaded for example in a test case to analyze it further.