### PR TITLE
Version bump of launcher fragments

### DIFF
--- a/bundles/org.eclipse.equinox.launcher.cocoa.macosx.aarch64/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.launcher.cocoa.macosx.aarch64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.equinox.launcher.cocoa.macosx.aarch64;singleton:=true
-Bundle-Version: 1.2.800.qualifier
+Bundle-Version: 1.2.900.qualifier
 Fragment-Host: org.eclipse.equinox.launcher;bundle-version="[1.5.0,1.7.0)"
 Eclipse-PlatformFilter: (& (osgi.ws=cocoa) (osgi.os=macosx) (osgi.arch=aarch64) )
 Bundle-Localization: launcher.cocoa.macosx.aarch64

--- a/bundles/org.eclipse.equinox.launcher.cocoa.macosx.x86_64/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.launcher.cocoa.macosx.x86_64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.equinox.launcher.cocoa.macosx.x86_64;singleton:=true
-Bundle-Version: 1.2.800.qualifier
+Bundle-Version: 1.2.900.qualifier
 Fragment-Host: org.eclipse.equinox.launcher;bundle-version="[1.5.0,1.7.0)"
 Eclipse-PlatformFilter: (& (osgi.ws=cocoa) (osgi.os=macosx) (osgi.arch=x86_64) )
 Bundle-Localization: launcher.cocoa.macosx.x86_64

--- a/bundles/org.eclipse.equinox.launcher.cocoa.macosx/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.launcher.cocoa.macosx/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.equinox.launcher.cocoa.macosx;singleton:=true
-Bundle-Version: 1.2.800.qualifier
+Bundle-Version: 1.2.900.qualifier
 Fragment-Host: org.eclipse.equinox.launcher;bundle-version="[1.5.0,1.7.0)"
 Eclipse-PlatformFilter: (& (osgi.ws=cocoa) (osgi.os=macosx) (osgi.arch=aarch64) )
 Bundle-Localization: launcher.cocoa.macosx.aarch64

--- a/bundles/org.eclipse.equinox.launcher.gtk.linux.aarch64/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.launcher.gtk.linux.aarch64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.equinox.launcher.gtk.linux.aarch64;singleton:=true
-Bundle-Version: 1.2.800.qualifier
+Bundle-Version: 1.2.900.qualifier
 Fragment-Host: org.eclipse.equinox.launcher;bundle-version="[1.5.0,1.7.0)"
 Eclipse-PlatformFilter: (& (osgi.ws=gtk) (osgi.os=linux) (osgi.arch=aarch64))
 Bundle-Localization: launcher.gtk.linux.aarch64

--- a/bundles/org.eclipse.equinox.launcher.gtk.linux.loongarch64/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.launcher.gtk.linux.loongarch64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.equinox.launcher.gtk.linux.loongarch64;singleton:=true
-Bundle-Version: 1.2.800.qualifier
+Bundle-Version: 1.2.900.qualifier
 Fragment-Host: org.eclipse.equinox.launcher;bundle-version="[1.5.0,1.7.0)"
 Eclipse-PlatformFilter: (& (osgi.ws=gtk) (osgi.os=linux) (osgi.arch=loongarch64))
 Bundle-Localization: launcher.gtk.linux.loongarch64

--- a/bundles/org.eclipse.equinox.launcher.gtk.linux.ppc64le/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.launcher.gtk.linux.ppc64le/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.equinox.launcher.gtk.linux.ppc64le;singleton:=true
-Bundle-Version: 1.2.800.qualifier
+Bundle-Version: 1.2.900.qualifier
 Fragment-Host: org.eclipse.equinox.launcher;bundle-version="[1.5.0,1.7.0)"
 Eclipse-PlatformFilter: (& (osgi.ws=gtk) (osgi.os=linux) (osgi.arch=ppc64le))
 Bundle-Localization: launcher.gtk.linux.ppc64le

--- a/bundles/org.eclipse.equinox.launcher.gtk.linux.x86_64/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.launcher.gtk.linux.x86_64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.equinox.launcher.gtk.linux.x86_64;singleton:=true
-Bundle-Version: 1.2.800.qualifier
+Bundle-Version: 1.2.900.qualifier
 Fragment-Host: org.eclipse.equinox.launcher;bundle-version="[1.5.0,1.7.0)"
 Eclipse-PlatformFilter: (& (osgi.ws=gtk) (osgi.os=linux) (osgi.arch=x86_64))
 Bundle-Localization: launcher.gtk.linux.x86_64

--- a/bundles/org.eclipse.equinox.launcher.win32.win32.x86_64/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.launcher.win32.win32.x86_64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.equinox.launcher.win32.win32.x86_64;singleton:=true
-Bundle-Version: 1.2.800.qualifier
+Bundle-Version: 1.2.900.qualifier
 Fragment-Host: org.eclipse.equinox.launcher;bundle-version="[1.5.0,1.7.0)"
 Eclipse-PlatformFilter: (& (osgi.ws=win32) (osgi.os=win32) (osgi.arch=x86_64))
 Bundle-Localization: launcher.win32.win32.x86_64


### PR DESCRIPTION
This rendered the build unstable - fail with comparator errors. It comes due to natives rebuild for
https://github.com/eclipse-equinox/equinox/pull/474 .