### PR TITLE
Use <additionalFileSets> to include files in the feature

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,1 +1,3 @@
 -Pbuild-individual-bundles
+-Dtycho.localArtifacts=ignore
+-Dcompare-version-with-baselines.skip=false

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,6 @@ pipeline {
 				sh """
 				mvn clean verify --batch-mode --fail-at-end -Dmaven.repo.local=$WORKSPACE/.m2/repository \
 					-Pbree-libs -Papi-check -Pjavadoc\
-					-Dcompare-version-with-baselines.skip=false \
 					-Dproject.build.sourceEncoding=UTF-8 \
 					-Drt.equinox.binaries.loc=$WORKSPACE/rt.equinox.binaries 
 				"""

--- a/features/org.eclipse.equinox.executable.feature/pom.xml
+++ b/features/org.eclipse.equinox.executable.feature/pom.xml
@@ -25,23 +25,21 @@
   <build>
     <plugins>
       <plugin>
-        <artifactId>maven-antrun-plugin</artifactId>
+		<groupId>org.eclipse.tycho</groupId>
+        <artifactId>tycho-packaging-plugin</artifactId>
         <executions>
           <execution>
-            <id>repack</id>
-            <phase>package</phase>
-            <goals>
-              <goal>run</goal>
-            </goals>
+            <id>default-package-feature</id>
             <configuration>
-              <target>
-                <!-- note that here we reference previously declared dependency -->
-                <unzip src="${project.build.directory}/${project.build.finalName}.jar" dest="${project.build.directory}/tmp"/>
-                <copy file="resources/build.properties" todir="${project.build.directory}/tmp"/>
-                <copy file="resources/build.xml" todir="${project.build.directory}/tmp"/>
-                <zip basedir="${project.build.directory}/tmp" destfile="${project.build.directory}/${project.build.finalName}.jar"/>
-                <!-- now the modified jar is available -->
-              </target>
+				<additionalFileSets>
+				 <fileSet>
+				  <directory>${project.basedir}/resources</directory>
+				  <includes>
+				   <include>build.properties</include>
+				   <include>build.xml</include>
+				  </includes>
+				 </fileSet>
+				</additionalFileSets>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
Currently an ant task is used to unpack the produced jar, then copy some files and repack it again what requires an extra execution.

Instead we can use <additionalFileSets> to include the resources in the first place when the jar is packed.