### PR TITLE
Touch bundles affected by compiler implementation change

### DIFF
--- a/bundles/org.eclipse.equinox.preferences/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.preferences/forceQualifierUpdate.txt
@@ -3,3 +3,4 @@ Bug 403352 - Update all parent versions to match our build stream
 Bug 509973 - Comparator errors in I20170105-0320
 Incorrect org.osgi.service.prefs dependency in org.eclipse.equinox.preferences-3.10.0 #54
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation #1139
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1781


### PR DESCRIPTION
See https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1781