### PR TITLE
Getting java.lang.NoSuchMethodException: org.eclipse.equinox.http.servlet.HttpServiceServlet.sessionDestroyed(java.lang.String)

### DIFF
--- a/bundles/org.eclipse.equinox.http.jetty/src/org/eclipse/equinox/http/jetty/internal/HttpServerManager.java
+++ b/bundles/org.eclipse.equinox.http.jetty/src/org/eclipse/equinox/http/jetty/internal/HttpServerManager.java
@@ -285,22 +285,13 @@ public class HttpServerManager implements ManagedServiceFactory {
 		// private static final long serialVersionUID = 7477982882399972088L;
 		private final Servlet httpServiceServlet = new HttpServiceServlet();
 		private ClassLoader contextLoader;
-		private final Method sessionDestroyed;
-		private final Method sessionIdChanged;
+		
+		//removing the final keyword
+		private Method sessionDestroyed;
+		private Method sessionIdChanged;
 
 		public InternalHttpServiceServlet() {
-			Class<?> clazz = httpServiceServlet.getClass();
-
-			try {
-				sessionDestroyed = clazz.getMethod("sessionDestroyed", new Class<?>[] { String.class }); //$NON-NLS-1$
-			} catch (Exception e) {
-				throw new IllegalStateException(e);
-			}
-			try {
-				sessionIdChanged = clazz.getMethod("sessionIdChanged", new Class<?>[] { String.class }); //$NON-NLS-1$
-			} catch (Exception e) {
-				throw new IllegalStateException(e);
-			}
+			//removed the constructor code because it wasn't correct , method object was created using reflaction but wrong parameters were getting passed to it.
 		}
 
 		@Override


### PR DESCRIPTION
My usecase is , i had created a keystore certificate with multiple DNS and when i was running my application using that certificate, i was getting an expection as multiple keystore certificate are not supported.

I was getting this error because jetty has changed the way it was creating the object of SslContextFactory , earlier it was creating the object as new SslContextFactory() , but now they have modified it as new SslContextFactory().Server() or new SsslContextFactory().Client().

We are using a thirdparty maven jar to create and start the jetty server and that jar is org.eclipse.equinox.http.jetty , we had version 3.4 so we have upgraded this jar , because in  org.eclipse.equinox.http.jetty.3.4 , the object of  SslContextFactory is getting created as new SslContextFactory().

I have upgraded it to version 3.7.600 , but after upgrading it to 3.7 i was getting an error as java.lang.NoSuchMethodException: org.eclipse.equinox.http.servlet.HttpServiceServlet.sessionDestroyed(java.lang.String).

The root cause of this error is, in HttpServerManager class there is no such method named sessionDestroyed which takes string as a parameter. In HttpServerManager there is one inner class named InternalHttpServiceServlet which contains a method called sessionDestoryed and this method  takes javax.servlet.HttpSessionEvent object as a parameter. 

So there is some parameter mismatch. so i have used an approch to solve this issue as instead of declaring the Method type of variable as final i have made them non-fianl so that i don't need to inialize them in the inner class constructor. Becuase in the inner class constructor jetty has initalized them using java reflaction. Jetty is trying to get the method object but in both the method initalization wrong parameter is getting used.
