### PR TITLE
replace deprecated X509Certificate methods

### DIFF
--- a/bundles/org.eclipse.equinox.security.ui/src/org/eclipse/equinox/internal/security/ui/wizard/CertificateImportCertSelectPage.java
+++ b/bundles/org.eclipse.equinox.security.ui/src/org/eclipse/equinox/internal/security/ui/wizard/CertificateImportCertSelectPage.java
@@ -92,7 +92,7 @@ public class CertificateImportCertSelectPage extends WizardPage implements Liste
 
 		for (Certificate certificate : certList) {
 			X509Certificate x509Cert = (X509Certificate) certificate;
-			String subjectDN = x509Cert.getSubjectDN().getName();
+			String subjectDN = x509Cert.getSubjectX500Principal().getName();
 			certDropDown.add(subjectDN);
 		}
 		certDropDown.addListener(SWT.Selection, this);

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/security/SignedBundleTest.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/security/SignedBundleTest.java
@@ -268,7 +268,7 @@ public class SignedBundleTest extends BaseSecurityTest {
 				if (info.isTrusted()) {
 					X509Certificate x509Cert = (X509Certificate) certs[0];
 					assertTrue("CA1 LeafA signer is not trusted",
-							x509Cert.getSubjectDN().getName().indexOf("CA1 LeafA") >= 0);
+							x509Cert.getSubjectX500Principal().getName().indexOf("CA1 LeafA") >= 0);
 				}
 			}
 		} finally {
@@ -508,7 +508,7 @@ public class SignedBundleTest extends BaseSecurityTest {
 			if (info.isTrusted()) {
 				X509Certificate x509Cert = (X509Certificate) certs[0];
 				assertTrue("CA1 LeafA signer is not trusted",
-						x509Cert.getSubjectDN().getName().indexOf("CA1 LeafA") >= 0);
+						x509Cert.getSubjectX500Principal().getName().indexOf("CA1 LeafA") >= 0);
 			}
 		}
 	}

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/service/security/KeyStoreTrustEngine.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/service/security/KeyStoreTrustEngine.java
@@ -13,12 +13,25 @@
  *******************************************************************************/
 package org.eclipse.osgi.internal.service.security;
 
-import java.io.*;
-import java.security.*;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.security.GeneralSecurityException;
+import java.security.InvalidKeyException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.SignatureException;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
 import org.eclipse.osgi.framework.log.FrameworkLogEntry;
 import org.eclipse.osgi.internal.signedcontent.SignedBundleHook;
 import org.eclipse.osgi.internal.signedcontent.SignedContentMessages;
@@ -129,7 +142,7 @@ public class KeyStoreTrustEngine extends TrustEngine {
 						// this is the last certificate in the chain
 						// determine if we have a valid root
 						X509Certificate cert = (X509Certificate) certChain[i];
-						if (cert.getSubjectDN().equals(cert.getIssuerDN())) {
+						if (cert.getSubjectX500Principal().equals(cert.getIssuerX500Principal())) {
 							cert.verify(cert.getPublicKey());
 							rootCert = cert; // this is a self-signed certificate
 						} else {
@@ -176,8 +189,8 @@ public class KeyStoreTrustEngine extends TrustEngine {
 		synchronized (store) {
 			for (Enumeration<String> e = store.aliases(); e.hasMoreElements();) {
 				Certificate nextCert = store.getCertificate(e.nextElement());
-				if (nextCert instanceof X509Certificate
-						&& ((X509Certificate) nextCert).getSubjectDN().equals(cert.getIssuerDN())) {
+				if (nextCert instanceof X509Certificate && ((X509Certificate) nextCert).getSubjectX500Principal()
+						.equals(cert.getIssuerX500Principal())) {
 					cert.verify(nextCert.getPublicKey());
 					return nextCert;
 				}


### PR DESCRIPTION
The method getSubjectDN() from the type X509Certificate is deprecated The method getIssuerDN() from the type X509Certificate is deprecated