### PR TITLE
CloseableURLClassLoader: replace deprecated getPackage()

### DIFF
--- a/bundles/org.eclipse.equinox.servletbridge/src/org/eclipse/equinox/servletbridge/CloseableURLClassLoader.java
+++ b/bundles/org.eclipse.equinox.servletbridge/src/org/eclipse/equinox/servletbridge/CloseableURLClassLoader.java
@@ -321,7 +321,7 @@ public class CloseableURLClassLoader extends URLClassLoader {
 		if (lastDot != -1) {
 			String packageName = name.substring(0, lastDot);
 			synchronized (pkgLock) {
-				Package pkg = getPackage(packageName);
+				Package pkg = getDefinedPackage(packageName);
 				if (pkg != null) {
 					checkForSealedPackage(pkg, packageName, manifest, connection.getJarFileURL());
 				} else {


### PR DESCRIPTION
The method getPackage(String) from the type ClassLoader is deprecated since version 9