### PR TITLE
remove call to deprecated for removal ThreadGroup.setDaemon()

### DIFF
--- a/bundles/org.eclipse.equinox.event/src/org/eclipse/equinox/internal/event/EventAdminImpl.java
+++ b/bundles/org.eclipse.equinox.event/src/org/eclipse/equinox/internal/event/EventAdminImpl.java
@@ -50,7 +50,6 @@ public class EventAdminImpl implements EventAdmin {
 	void start() {
 		log.open();
 		ThreadGroup eventGroup = new ThreadGroup("Equinox Event Admin"); //$NON-NLS-1$
-		eventGroup.setDaemon(true);
 		eventManager = new EventManager(EventAdminMsg.EVENT_ASYNC_THREAD_NAME, eventGroup);
 		handlers.open();
 	}

--- a/bundles/org.eclipse.equinox.useradmin/src/org/eclipse/equinox/internal/useradmin/UserAdminEventProducer.java
+++ b/bundles/org.eclipse.equinox.useradmin/src/org/eclipse/equinox/internal/useradmin/UserAdminEventProducer.java
@@ -41,7 +41,6 @@ public class UserAdminEventProducer extends ServiceTracker implements EventDispa
 		this.userAdmin = userAdmin;
 		this.log = log;
 		ThreadGroup eventGroup = new ThreadGroup("Equinox User Admin"); //$NON-NLS-1$
-		eventGroup.setDaemon(true);
 		eventManager = new EventManager("UserAdmin Event Dispatcher", eventGroup); //$NON-NLS-1$
 		listeners = new CopyOnWriteIdentityMap<>();
 
@@ -76,17 +75,17 @@ public class UserAdminEventProducer extends ServiceTracker implements EventDispa
 	 *
 	 * <p>
 	 * This method is called before a service which matched the search parameters of
-	 * the <code>ServiceTracker</code> object is added to it. This method should return
-	 * the service object to be tracked for this <code>ServiceReference</code> object.
-	 * The returned service object is stored in the <code>ServiceTracker</code> object
-	 * and is available from the <code>getService</code> and <code>getServices</code>
-	 * methods.
+	 * the <code>ServiceTracker</code> object is added to it. This method should
+	 * return the service object to be tracked for this
+	 * <code>ServiceReference</code> object. The returned service object is stored
+	 * in the <code>ServiceTracker</code> object and is available from the
+	 * <code>getService</code> and <code>getServices</code> methods.
 	 *
 	 * @param reference Reference to service being added to the
 	 *                  <code>ServiceTracker</code> object.
-	 * @return The service object to be tracked for the <code>ServiceReference</code>
-	 *         object or <code>null</code> if the <code>ServiceReference</code> object
-	 *         should not be tracked.
+	 * @return The service object to be tracked for the
+	 *         <code>ServiceReference</code> object or <code>null</code> if the
+	 *         <code>ServiceReference</code> object should not be tracked.
 	 */
 	@Override
 	public Object addingService(ServiceReference reference) {


### PR DESCRIPTION
"The daemon status is not used for anything"
The method setDaemon(boolean) from the type ThreadGroup has been deprecated since version 16 and marked for removal

EventManager.EventThread.EventThread(ThreadGroup, String) starts threads as daemon