### PR TITLE
DeviceTracker: get rid of raw Vector

### DIFF
--- a/bundles/org.eclipse.equinox.device/src/org/eclipse/equinox/device/DeviceTracker.java
+++ b/bundles/org.eclipse.equinox.device/src/org/eclipse/equinox/device/DeviceTracker.java
@@ -157,7 +157,7 @@ public class DeviceTracker extends ServiceTracker {
 
 			manager.locators.loadDrivers(properties, drivers);
 
-			Vector exclude = new Vector(drivers.size());
+			Vector<ServiceReference> exclude = new Vector<>(drivers.size());
 
 			while (running) {
 				ServiceReference driver = drivers.match(device, exclude);

--- a/bundles/org.eclipse.equinox.device/src/org/eclipse/equinox/device/DriverTracker.java
+++ b/bundles/org.eclipse.equinox.device/src/org/eclipse/equinox/device/DriverTracker.java
@@ -233,7 +233,7 @@ public class DriverTracker extends ServiceTracker {
 	 *
 	 * @return ServiceReference to best matched Driver or null of their is no match.
 	 */
-	public ServiceReference match(ServiceReference device, Vector exclude) {
+	public ServiceReference match(ServiceReference device, Vector<ServiceReference> exclude) {
 		if (Activator.DEBUG) {
 			log.log(device, LogService.LOG_DEBUG, this + ": Driver match called"); //$NON-NLS-1$
 		}
@@ -338,7 +338,7 @@ public class DriverTracker extends ServiceTracker {
 	 * @param device Device to be attached
 	 * @return true is the Driver successfully attached.
 	 */
-	public boolean attach(ServiceReference driver, ServiceReference device, Vector exclude) {
+	public boolean attach(ServiceReference driver, ServiceReference device, Vector<ServiceReference> exclude) {
 		if (Activator.DEBUG) {
 			log.log(driver, LogService.LOG_DEBUG, this + ": Driver attach called: " + drivers.get(driver)); //$NON-NLS-1$
 		}


### PR DESCRIPTION
Vector is a raw type. References to generic type Vector<E> should be parameterized