### PR TITLE
Fix ModuleCapability/ModuleRequirement hashcode/equals according to API

### DIFF
--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/container/ModuleCapability.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/container/ModuleCapability.java
@@ -16,8 +16,10 @@ package org.eclipse.osgi.container;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import org.osgi.framework.namespace.NativeNamespace;
 import org.osgi.framework.wiring.BundleCapability;
+import org.osgi.resource.Capability;
 
 /**
  * An implementation of {@link BundleCapability}.
@@ -30,6 +32,7 @@ public final class ModuleCapability implements BundleCapability {
 	private final Map<String, Object> attributes;
 	private final Map<String, Object> transientAttrs;
 	private final ModuleRevision revision;
+	private transient int hashCode;
 
 	ModuleCapability(String namespace, Map<String, String> directives, Map<String, Object> attributes,
 			ModuleRevision revision) {
@@ -92,5 +95,27 @@ public final class ModuleCapability implements BundleCapability {
 	@Override
 	public String toString() {
 		return namespace + ModuleContainer.toString(attributes, false) + ModuleContainer.toString(directives, true);
+	}
+
+	@Override
+	public int hashCode() {
+		if (hashCode != 0) {
+			return hashCode;
+		}
+		return hashCode = Objects.hash(namespace, directives, attributes, revision);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj instanceof Capability) {
+			Capability other = (Capability) obj;
+			return Objects.equals(namespace, other.getNamespace()) && Objects.equals(directives, other.getDirectives())
+					&& Objects.equals(attributes, other.getAttributes())
+					&& Objects.equals(revision, other.getResource());
+		}
+		return false;
 	}
 }

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/container/ModuleRequirement.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/container/ModuleRequirement.java
@@ -15,6 +15,7 @@ package org.eclipse.osgi.container;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import org.eclipse.osgi.internal.container.Capabilities;
 import org.eclipse.osgi.internal.framework.FilterImpl;
 import org.osgi.framework.InvalidSyntaxException;
@@ -24,6 +25,7 @@ import org.osgi.framework.namespace.PackageNamespace;
 import org.osgi.framework.wiring.BundleCapability;
 import org.osgi.framework.wiring.BundleRequirement;
 import org.osgi.resource.Namespace;
+import org.osgi.resource.Requirement;
 
 /**
  * An implementation of {@link BundleRequirement}. This requirement implements
@@ -38,6 +40,7 @@ public class ModuleRequirement implements BundleRequirement {
 	private final Map<String, String> directives;
 	private final Map<String, Object> attributes;
 	private final ModuleRevision revision;
+	private transient int hashCode;
 
 	ModuleRequirement(String namespace, Map<String, String> directives, Map<String, ?> attributes,
 			ModuleRevision revision) {
@@ -151,6 +154,28 @@ public class ModuleRequirement implements BundleRequirement {
 		ModuleRequirement getOriginal() {
 			return ModuleRequirement.this;
 		}
+	}
+
+	@Override
+	public int hashCode() {
+		if (hashCode != 0) {
+			return hashCode;
+		}
+		return hashCode = Objects.hash(namespace, directives, attributes, revision);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj instanceof Requirement) {
+			Requirement other = (Requirement) obj;
+			return Objects.equals(namespace, other.getNamespace()) && Objects.equals(directives, other.getDirectives())
+					&& Objects.equals(attributes, other.getAttributes())
+					&& Objects.equals(revision, other.getResource());
+		}
+		return false;
 	}
 
 }


### PR DESCRIPTION
The API of Capability/Requirement currently defines the contract to be: This Capability/Requirement is equal to another Capability/Requirement if they have the same namespace, directives and attributes and are declared by the same resource.

But Equinox currently implements hashCode/equals in terms of object identity.

A similar problem might be in `ModuleRevision` where it says two resources are equal if:

> This Resource is equal to another Resource if both have the same content and come from the same location. Location may be defined as the bundle location if the resource is an installed bundle or the repository location if the resource is in a repository.

I find this a bit unclear what "content" means, in the context of a repository it might be the hashsum but for a Bundle(Revision) I think this is hard to answer.