### PR TITLE
Expose the permutation data through the felix resolver logger

### DIFF
--- a/bundles/org.eclipse.osgi/.settings/.api_filters
+++ b/bundles/org.eclipse.osgi/.settings/.api_filters
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<component id="org.eclipse.osgi" version="2">
+    <resource path="supplement/src/org/eclipse/osgi/report/resolution/ResolutionReport.java" type="org.eclipse.osgi.report.resolution.ResolutionReport">
+        <filter id="403853384">
+            <message_arguments>
+                <message_argument value="@noimplement"/>
+                <message_argument value="org.eclipse.osgi.report.resolution.ResolutionReport"/>
+            </message_arguments>
+        </filter>
+    </resource>
+</component>

--- a/bundles/org.eclipse.osgi/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.osgi/META-INF/MANIFEST.MF
@@ -36,7 +36,7 @@ Export-Package: org.eclipse.core.runtime.adaptor;x-friends:="org.eclipse.core.ru
  org.eclipse.osgi.internal.signedcontent;x-internal:=true,
  org.eclipse.osgi.internal.url;x-internal:=true,
  org.eclipse.osgi.launch;version="1.1";uses:="org.osgi.framework,org.osgi.framework.launch,org.osgi.framework.connect",
- org.eclipse.osgi.report.resolution;version="1.0";uses:="org.osgi.service.resolver,org.osgi.resource",
+ org.eclipse.osgi.report.resolution;version="1.1.0";uses:="org.osgi.service.resolver,org.osgi.resource",
  org.eclipse.osgi.service.datalocation;version="1.4.0",
  org.eclipse.osgi.service.debug;version="1.2",
  org.eclipse.osgi.service.environment;version="1.4",
@@ -107,7 +107,7 @@ Bundle-Activator: org.eclipse.osgi.internal.framework.SystemBundleActivator
 Bundle-Description: %systemBundle
 Bundle-Copyright: %copyright
 Bundle-Vendor: %eclipse.org
-Bundle-Version: 3.19.100.qualifier
+Bundle-Version: 3.20.0.qualifier
 Bundle-Localization: systembundle
 Bundle-DocUrl: http://www.eclipse.org
 Eclipse-ExtensibleAPI: true

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/container/ModuleContainer.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/container/ModuleContainer.java
@@ -38,7 +38,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-
 import org.eclipse.osgi.container.Module.StartOptions;
 import org.eclipse.osgi.container.Module.State;
 import org.eclipse.osgi.container.Module.StopOptions;
@@ -651,7 +650,8 @@ public final class ModuleContainer implements DebugOptionsListener {
 	private ResolutionReport resolve(Collection<Module> triggers, boolean triggersMandatory, boolean restartTriggers) {
 		if (isRefreshingSystemModule()) {
 			return new ModuleResolutionReport(null, Collections.emptyMap(),
-					new ResolutionException("Unable to resolve while shutting down the framework.")); //$NON-NLS-1$
+					new ResolutionException("Unable to resolve while shutting down the framework."), -1, -1, -1, -1, //$NON-NLS-1$
+					-1);
 		}
 		ResolutionReport report = null;
 		try (ResolutionLock.Permits resolutionPermits = _resolutionLock.acquire(1)) {
@@ -664,7 +664,7 @@ public final class ModuleContainer implements DebugOptionsListener {
 						if (be.getType() == BundleException.REJECTED_BY_HOOK
 								|| be.getType() == BundleException.STATECHANGE_ERROR) {
 							return new ModuleResolutionReport(null, Collections.emptyMap(),
-									new ResolutionException(be));
+									new ResolutionException(be), -1, -1, -1, -1, -1);
 						}
 					}
 					throw e;
@@ -672,7 +672,8 @@ public final class ModuleContainer implements DebugOptionsListener {
 			} while (report == null);
 		} catch (ResolutionLockException e) {
 			return new ModuleResolutionReport(null, Collections.emptyMap(),
-					new ResolutionException("Timeout acquiring lock for resolution", e, Collections.emptyList())); //$NON-NLS-1$
+					new ResolutionException("Timeout acquiring lock for resolution", e, Collections.emptyList()), -1, //$NON-NLS-1$
+					-1, -1, -1, -1);
 		}
 		return report;
 	}
@@ -1341,7 +1342,7 @@ public final class ModuleContainer implements DebugOptionsListener {
 		if (!isRefreshingSystemModule()) {
 			return resolve(refreshTriggers, false, true);
 		}
-		return new ModuleResolutionReport(null, null, null);
+		return new ModuleResolutionReport(null, null, null, -1, -1, -1, -1, -1);
 	}
 
 	/**

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/container/ModuleResolutionReport.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/container/ModuleResolutionReport.java
@@ -20,6 +20,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.eclipse.osgi.container.ModuleResolver.ResolveProcess.ResolveLogger;
 import org.eclipse.osgi.internal.messages.Msg;
 import org.eclipse.osgi.report.resolution.ResolutionReport;
 import org.osgi.framework.wiring.BundleRevision;
@@ -49,9 +50,12 @@ class ModuleResolutionReport implements ResolutionReport {
 			entries.add(new EntryImpl(type, data));
 		}
 
-		public ModuleResolutionReport build(Map<Resource, List<Wire>> resolutionResult, ResolutionException cause) {
-			return new ModuleResolutionReport(resolutionResult, resourceToEntries, cause);
+		public ModuleResolutionReport build(Map<Resource, List<Wire>> resolutionResult, ResolutionException cause,
+				ResolveLogger logger) {
+			return new ModuleResolutionReport(resolutionResult, resourceToEntries, cause, logger.totalPerm,
+					logger.processedPerm, logger.usesPerm, logger.subPerm, logger.importPerm);
 		}
+
 	}
 
 	static class EntryImpl implements Entry {
@@ -77,9 +81,19 @@ class ModuleResolutionReport implements ResolutionReport {
 	private final Map<Resource, List<Entry>> entries;
 	private final ResolutionException resolutionException;
 	private final Map<Resource, List<Wire>> resolutionResult;
+	private int totalPerm;
+	private int processedPerm;
+	private int usesPerm;
+	private int subPerm;
+	private int importPerm;
 
 	ModuleResolutionReport(Map<Resource, List<Wire>> resolutionResult, Map<Resource, List<Entry>> entries,
-			ResolutionException cause) {
+			ResolutionException cause, int totalPerm, int processedPerm, int usesPerm, int subPerm, int importPerm) {
+		this.totalPerm = totalPerm;
+		this.processedPerm = processedPerm;
+		this.usesPerm = usesPerm;
+		this.subPerm = subPerm;
+		this.importPerm = importPerm;
 		this.entries = entries == null ? Collections.emptyMap() : Collections.unmodifiableMap(new HashMap<>(entries));
 		this.resolutionResult = resolutionResult == null ? Collections.emptyMap()
 				: Collections.unmodifiableMap(resolutionResult);
@@ -175,5 +189,30 @@ class ModuleResolutionReport implements ResolutionReport {
 	@Override
 	public String getResolutionReportMessage(Resource resource) {
 		return getResolutionReport0(null, (ModuleRevision) resource, getEntries(), null);
+	}
+
+	@Override
+	public int getTotalPermutations() {
+		return totalPerm;
+	}
+
+	@Override
+	public int getProcessedPermutations() {
+		return processedPerm;
+	}
+
+	@Override
+	public int getUsesPermutations() {
+		return usesPerm;
+	}
+
+	@Override
+	public int getImportPermutations() {
+		return importPerm;
+	}
+
+	@Override
+	public int getSubstitutionPermutations() {
+		return subPerm;
 	}
 }

--- a/bundles/org.eclipse.osgi/felix/src/org/apache/felix/resolver/Candidates.java
+++ b/bundles/org.eclipse.osgi/felix/src/org/apache/felix/resolver/Candidates.java
@@ -22,7 +22,6 @@ import java.util.*;
 import java.util.Map.Entry;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.apache.felix.resolver.ResolverImpl.PermutationType;
 import org.apache.felix.resolver.ResolverImpl.ResolveSession;
 import org.apache.felix.resolver.reason.ReasonException;
 import org.apache.felix.resolver.util.*;

--- a/bundles/org.eclipse.osgi/felix/src/org/apache/felix/resolver/Logger.java
+++ b/bundles/org.eclipse.osgi/felix/src/org/apache/felix/resolver/Logger.java
@@ -131,4 +131,29 @@ public class Logger
     {
         // do nothing by default
     }
+
+    /**
+     * Called whenever a new permutation is added by the resolver.
+     * 
+     * @param type      the type of the permutation
+     * @param remaining a function that can be used to query the now current number
+     *                  of permutation types
+     */
+    public void logPermutationAdded(PermutationType type)
+    {
+        // do nothing by default
+    }
+
+    /**
+     * Called whenever a permutation is removed and about to be processed by the
+     * resolver.
+     * 
+     * @param type      the type of permutation that will be processed
+     * @param remaining a function that can be used to query the now current number
+     *                  of permutation types
+     */
+    public void logProcessPermutation(PermutationType type) 
+    {
+        // do nothing by default
+    }
 }

--- a/bundles/org.eclipse.osgi/felix/src/org/apache/felix/resolver/PermutationType.java
+++ b/bundles/org.eclipse.osgi/felix/src/org/apache/felix/resolver/PermutationType.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.felix.resolver;
+public enum PermutationType {
+    USES,
+    IMPORT,
+    SUBSTITUTE
+}

--- a/bundles/org.eclipse.osgi/pom.xml
+++ b/bundles/org.eclipse.osgi/pom.xml
@@ -19,7 +19,7 @@
 </parent>
   <groupId>org.eclipse.osgi</groupId>
   <artifactId>org.eclipse.osgi</artifactId>
-  <version>3.19.100-SNAPSHOT</version>
+  <version>3.20.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   <properties>
 	  <!-- The actual TCKs are executed in the org.eclipse.osgi.tck module because of reference to other service implementations -->
@@ -31,7 +31,6 @@
       <plugin>
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>tycho-compiler-plugin</artifactId>
-        <version>${tycho.version}</version>
         <configuration>
           <compilerArgs>
             <arg>-nowarn:[${project.basedir}/osgi/src${path.separator}${project.basedir}/felix/src]</arg>

--- a/bundles/org.eclipse.osgi/supplement/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.osgi/supplement/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.supplement
-Bundle-Version: 1.10.800.qualifier
+Bundle-Version: 1.10.900.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.equinox.log;version="1.1",

--- a/bundles/org.eclipse.osgi/supplement/src/org/eclipse/osgi/report/resolution/ResolutionReport.java
+++ b/bundles/org.eclipse.osgi/supplement/src/org/eclipse/osgi/report/resolution/ResolutionReport.java
@@ -15,6 +15,8 @@ package org.eclipse.osgi.report.resolution;
 
 import java.util.List;
 import java.util.Map;
+import org.eclipse.pde.api.tools.annotations.NoImplement;
+import org.osgi.annotation.versioning.ProviderType;
 import org.osgi.framework.hooks.resolver.ResolverHook;
 import org.osgi.resource.Resource;
 import org.osgi.service.resolver.ResolutionException;
@@ -96,6 +98,8 @@ import org.osgi.service.resolver.ResolutionException;
  * 
  * @since 3.10
  */
+@ProviderType
+@NoImplement
 public interface ResolutionReport {
 	public interface Entry {
 		enum Type {
@@ -193,4 +197,38 @@ public interface ResolutionReport {
 	 * @return a resolution report message.
 	 */
 	String getResolutionReportMessage(Resource resource);
+
+	/**
+	 * @return the number of permutations created to solve the problem or -1 if
+	 *         unknown
+	 * @since 3.20
+	 */
+	int getTotalPermutations();
+
+	/**
+	 * @return the number of processed permutations -1 if unknown
+	 * @since 3.20
+	 */
+	int getProcessedPermutations();
+
+	/**
+	 * @return the number of permutations cause by a use-constraint violation -1 if
+	 *         unknown
+	 * @since 3.20
+	 */
+	int getUsesPermutations();
+
+	/**
+	 * @return the number of permutations cause by a package substitution or -1 if
+	 *         unknown
+	 * @since 3.20
+	 */
+	int getSubstitutionPermutations();
+
+	/**
+	 * @return the number of permutations cause by a different package provider
+	 *         selected or -1 if unknown
+	 * @since 3.20
+	 */
+	int getImportPermutations();
 }


### PR DESCRIPTION
Currently it is not really possible to write a test that asserts something about the complexity of a problem that the resolver has performed. This has the risk of undetected performance regressions but also means performance improvements can not be easily investigated. Also in general code (like for example console commands) it could be useful to gather some statistics.

This now adds two new methods to the logger, one that is performing a log each time when a permutation is added or processed to either log this by the caller or perform any statistics on them.