### PR TITLE
Update version number in Mac's Eclipse.app for 4.32

### DIFF
--- a/features/org.eclipse.equinox.executable.feature/bin/cocoa/macosx/aarch64/Eclipse.app/Contents/Info.plist
+++ b/features/org.eclipse.equinox.executable.feature/bin/cocoa/macosx/aarch64/Eclipse.app/Contents/Info.plist
@@ -8,7 +8,7 @@
 	<key>CFBundleExecutable</key>
 		<string>eclipse</string>
 	<key>CFBundleGetInfoString</key>
-		<string>Eclipse 4.31 for Mac OS X, Copyright IBM Corp. and others 2002, 2024. All rights reserved.</string>
+		<string>Eclipse 4.32 for Mac OS X, Copyright IBM Corp. and others 2002, 2024. All rights reserved.</string>
 	<key>CFBundleIconFile</key>
 		<string>Eclipse.icns</string>
 	<key>CFBundleIdentifier</key>
@@ -20,11 +20,11 @@
 	<key>CFBundlePackageType</key>
 		<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-		<string>4.31</string>
+		<string>4.32</string>
 	<key>CFBundleSignature</key>
 		<string>????</string>
 	<key>CFBundleVersion</key>
-		<string>4.31</string>
+		<string>4.32</string>
 	<key>NSHighResolutionCapable</key>
 		<true/>
 	<key>CFBundleDevelopmentRegion</key>

--- a/features/org.eclipse.equinox.executable.feature/bin/cocoa/macosx/x86_64/Eclipse.app/Contents/Info.plist
+++ b/features/org.eclipse.equinox.executable.feature/bin/cocoa/macosx/x86_64/Eclipse.app/Contents/Info.plist
@@ -8,7 +8,7 @@
 	<key>CFBundleExecutable</key>
 		<string>eclipse</string>
 	<key>CFBundleGetInfoString</key>
-		<string>Eclipse 4.31 for Mac OS X, Copyright IBM Corp. and others 2002, 2024. All rights reserved.</string>
+		<string>Eclipse 4.32 for Mac OS X, Copyright IBM Corp. and others 2002, 2024. All rights reserved.</string>
 	<key>CFBundleIconFile</key>
 		<string>Eclipse.icns</string>
 	<key>CFBundleIdentifier</key>
@@ -20,11 +20,11 @@
 	<key>CFBundlePackageType</key>
 		<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-		<string>4.31</string>
+		<string>4.32</string>
 	<key>CFBundleSignature</key>
 		<string>????</string>
 	<key>CFBundleVersion</key>
-		<string>4.31</string>
+		<string>4.32</string>
 	<key>NSHighResolutionCapable</key>
 		<true/>
 	<key>CFBundleDevelopmentRegion</key>


### PR DESCRIPTION
Tracked in
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1859