### PR TITLE
Pull down the replace method from ShadowList to Candidates

### DIFF
--- a/bundles/org.eclipse.osgi/felix/src/org/apache/felix/resolver/util/CandidateSelector.java
+++ b/bundles/org.eclipse.osgi/felix/src/org/apache/felix/resolver/util/CandidateSelector.java
@@ -22,8 +22,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
-
 import org.osgi.resource.Capability;
+import org.osgi.service.resolver.HostedCapability;
 
 public class CandidateSelector {
     protected final AtomicBoolean isUnmodifiable;
@@ -82,9 +82,22 @@ public class CandidateSelector {
         return index;
     }
 
+    public void replaceHostedCapability(HostedCapability c) {
+        checkModifiable();
+        Capability origCap = c.getDeclaredCapability();
+        int idx = unmodifiable.indexOf(origCap);
+        if (idx < 0) {
+            return;
+        }
+        unmodifiable.set(idx, new ShadowedCapability(c, origCap));
+    }
+
     protected void checkModifiable() {
         if (isUnmodifiable.get()) {
             throw new IllegalStateException("Trying to mutate after candidates have been prepared.");
+        }
+        if (currentIndex > 0) {
+            throw new IllegalStateException("Trying to mutate after candidates have been removed already.");
         }
     }
 }

--- a/bundles/org.eclipse.osgi/felix/src/org/apache/felix/resolver/util/ShadowList.java
+++ b/bundles/org.eclipse.osgi/felix/src/org/apache/felix/resolver/util/ShadowList.java
@@ -64,13 +64,19 @@ public class ShadowList extends CandidateSelector
             m_original.remove(removeIdx);
             unmodifiable.remove(removeIdx);
         }
-        int insertIdx = context.insertHostedCapability(m_original, toInsertCapability);
+        List<Capability> copy = new ArrayList<>(m_original); // make a copy here
+        for (int i = 0; i < copy.size(); i++) {
+            Capability capability = copy.get(i);
+            if (capability instanceof ShadowedCapability) {
+                // we unwrap the ShadowedCapability here as we always must pass only what we
+                // have got from the ResolveContext#findProviders.
+                copy.set(i, ((ShadowedCapability) capability).getShadowed());
+            }
+        }
+        int insertIdx = context.insertHostedCapability(copy, toInsertCapability);
+        // now insert at the given position into our internal data structure
         unmodifiable.add(insertIdx, wrappedCapability);
+        m_original.add(insertIdx, toInsertCapability);
     }
 
-    public void replace(Capability origCap, Capability c) {
-        checkModifiable();
-        int idx = unmodifiable.indexOf(origCap);
-        unmodifiable.set(idx, c);
-    }
 }

--- a/bundles/org.eclipse.osgi/felix/src/org/apache/felix/resolver/util/ShadowedCapability.java
+++ b/bundles/org.eclipse.osgi/felix/src/org/apache/felix/resolver/util/ShadowedCapability.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.felix.resolver.util;
+
+import java.util.Map;
+import java.util.Objects;
+import org.osgi.resource.Capability;
+import org.osgi.resource.Resource;
+import org.osgi.service.resolver.HostedCapability;
+
+/**
+ * A {@link Capability} that is shadowed by a {@link HostedCapability}, this is
+ * done when we merge the fragments capabilities with its host, but to insert
+ * {@link HostedCapability} we need to make sure we always pass the original so
+ * this class keeps track of the fact that we have replaced it with something
+ * else.
+ */
+class ShadowedCapability implements HostedCapability {
+
+    private HostedCapability hosted;
+    private int hashCode;
+    private Capability shadowed;
+
+    public ShadowedCapability(HostedCapability hosted, Capability shadowed) {
+        this.hosted = hosted;
+        this.shadowed = shadowed;
+    }
+
+    @Override
+    public String getNamespace() {
+        return hosted.getNamespace();
+    }
+
+    @Override
+    public Map<String, String> getDirectives() {
+        return hosted.getDirectives();
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return hosted.getAttributes();
+    }
+
+    @Override
+    public Resource getResource() {
+        return hosted.getResource();
+    }
+
+    @Override
+    public Capability getDeclaredCapability() {
+        return hosted.getDeclaredCapability();
+    }
+
+    public Capability getShadowed() {
+        return shadowed;
+    }
+
+    @Override
+    public int hashCode() {
+        if (hashCode != 0) {
+            return hashCode;
+        }
+        return hashCode = Objects.hash(getNamespace(), getDirectives(), getAttributes(), getResource());
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj instanceof Capability) {
+            Capability other = (Capability) obj;
+            return Objects.equals(getNamespace(), other.getNamespace())
+                    && Objects.equals(getDirectives(), other.getDirectives())
+                    && Objects.equals(getAttributes(), other.getAttributes())
+                    && Objects.equals(getResource(), other.getResource());
+        }
+        return false;
+    }
+
+}


### PR DESCRIPTION
The replace method is currently used on one place and the reason we construct a new ShadowList, to remove references to this class the method can simply pulls down to Candidates as it only operates on the internal unmodifiable list.

This also adds a check that if the Capability to replace does not exits it is a noop to call this method instead of running into IndexOutOfBoundsException.

@tjwatson one small step to get rid of direct references to `ShadowList` as a preliminary step for further refactorings.