### PR TITLE
Do not copy the list returned by findCandidates

### DIFF
--- a/bundles/org.eclipse.osgi/felix/src/org/apache/felix/resolver/util/CandidateSelector.java
+++ b/bundles/org.eclipse.osgi/felix/src/org/apache/felix/resolver/util/CandidateSelector.java
@@ -32,7 +32,7 @@ public class CandidateSelector {
 
     public CandidateSelector(List<Capability> candidates, AtomicBoolean isUnmodifiable) {
         this.isUnmodifiable = isUnmodifiable;
-        this.unmodifiable = new ArrayList<Capability>(candidates);
+        this.unmodifiable = candidates;
     }
 
     protected CandidateSelector(CandidateSelector candidateSelector) {

--- a/bundles/org.eclipse.osgi/felix/src/org/apache/felix/resolver/util/ShadowList.java
+++ b/bundles/org.eclipse.osgi/felix/src/org/apache/felix/resolver/util/ShadowList.java
@@ -48,8 +48,8 @@ public class ShadowList extends CandidateSelector
     }
 
     private ShadowList(List<Capability> unmodifiable, List<Capability> original, AtomicBoolean isUnmodifiable) {
-        super(unmodifiable, isUnmodifiable);
-        m_original = new ArrayList<Capability>(original);
+        super(new ArrayList<Capability>(unmodifiable), isUnmodifiable);
+        m_original = original;
     }
 
     public ShadowList copy() {


### PR DESCRIPTION
The specification requires that we pass in the original list of candidates to the insertHostedCapability but currently always a copy is performed.

This replaces the copy by directly keeping the reference given as the resolver is woning the list anyways.

See
- https://github.com/osgi/osgi/pull/690