### PR TITLE
added jdk.net to the JavaSE-1.8.profile

### DIFF
--- a/bundles/org.eclipse.osgi/JavaSE-1.8.profile
+++ b/bundles/org.eclipse.osgi/JavaSE-1.8.profile
@@ -192,6 +192,7 @@ org.osgi.framework.system.packages = \
  javax.xml.ws.spi.http,\
  javax.xml.ws.wsaddressing,\
  javax.xml.xpath,\
+ jdk.net,\
  org.ietf.jgss,\
  org.omg.CORBA,\
  org.omg.CORBA_2_3,\


### PR DESCRIPTION
Java 8 has jdk.net as a package. However, it is missing from the Java 8 profile of the org.eclipse.osgi system bundle. This, in turn, causes other bundles that import the jdk.net package to fail resolve properly under Java 8. Shouldn't jdk.net therefore be declared in the profile?

See also https://docs.oracle.com/javase/8/docs/jre/api/net/socketoptions/spec/jdk/net/package-summary.html