### PR TITLE
Add support for Windows on Arm64 (WoA).

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,6 +48,18 @@ spec:
 
 /** Returns the download URL of the JDK against whoose C headers (in the 'include/' folder) and native libaries the natives are compiled.*/
 def getNativeJdkUrl(String os, String arch) { // To update the used JDK version update the URL template below
+	if('win32'.equals(os) && 'aarch64'.equals(arch)) {
+		// Temporary workaround until there are official Temurin GA releases for Windows on ARM that can be consumed through JustJ
+		dir("${WORKSPACE}/repackage-win32.aarch64-jdk") {
+			sh """
+				curl -L 'https://github.com/adoptium/temurin17-binaries/releases/download/jdk17u-2024-02-07-14-14-beta/OpenJDK17U-jdk_aarch64_windows_hotspot_2024-02-07-14-14.zip' > jdk.zip
+				unzip -q jdk.zip jdk-17.0.11+1/include/** jdk-17.0.11+1/lib/**
+				cd jdk-17.0.11+1
+				tar -czf ../jdk.tar.gz include/ lib/
+			"""
+		}
+		return "file://${WORKSPACE}/repackage-win32.aarch64-jdk/jdk.tar.gz"
+	}
 	return "https://download.eclipse.org/justj/jres/17/downloads/20230428_1804/org.eclipse.justj.openjdk.hotspot.jre.minimal.stripped-17.0.7-${os}-${arch}.tar.gz"
 }
 
@@ -169,7 +181,7 @@ pipeline {
 				axes {
 					axis {
 						name 'PLATFORM'
-						values 'cocoa.macosx.aarch64' , 'cocoa.macosx.x86_64', 'gtk.linux.aarch64', 'gtk.linux.ppc64le', 'gtk.linux.x86_64', 'win32.win32.x86_64'
+						values 'cocoa.macosx.aarch64' , 'cocoa.macosx.x86_64', 'gtk.linux.aarch64', 'gtk.linux.ppc64le', 'gtk.linux.x86_64', 'win32.win32.aarch64', 'win32.win32.x86_64'
 					}
 				}
 				stages {

--- a/bundles/org.eclipse.equinox.launcher.win32.win32.aarch64/.project
+++ b/bundles/org.eclipse.equinox.launcher.win32.win32.aarch64/.project
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.eclipse.equinox.launcher.win32.win32.aarch64</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+	</natures>
+</projectDescription>

--- a/bundles/org.eclipse.equinox.launcher.win32.win32.aarch64/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.eclipse.equinox.launcher.win32.win32.aarch64/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/bundles/org.eclipse.equinox.launcher.win32.win32.aarch64/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.launcher.win32.win32.aarch64/META-INF/MANIFEST.MF
@@ -1,0 +1,10 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: %pluginName
+Bundle-Vendor: %providerName
+Bundle-SymbolicName: org.eclipse.equinox.launcher.win32.win32.aarch64;singleton:=true
+Bundle-Version: 1.2.1000.qualifier
+Fragment-Host: org.eclipse.equinox.launcher;bundle-version="[1.5.0,1.7.0)"
+Eclipse-PlatformFilter: (& (osgi.ws=win32) (osgi.os=win32) (osgi.arch=aarch64))
+Bundle-Localization: launcher.win32.win32.aarch64
+Eclipse-BundleShape: dir

--- a/bundles/org.eclipse.equinox.launcher.win32.win32.aarch64/about.html
+++ b/bundles/org.eclipse.equinox.launcher.win32.win32.aarch64/about.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1" />
+<title>About</title>
+</head>
+<body lang="EN-US">
+	<h2>About This Content</h2>
+
+	<p>November 30, 2017</p>
+	<h3>License</h3>
+
+	<p>
+		The Eclipse Foundation makes available all content in this plug-in
+		(&quot;Content&quot;). Unless otherwise indicated below, the Content
+		is provided to you under the terms and conditions of the Eclipse
+		Public License Version 2.0 (&quot;EPL&quot;). A copy of the EPL is
+		available at <a href="http://www.eclipse.org/legal/epl-2.0">http://www.eclipse.org/legal/epl-2.0</a>.
+		For purposes of the EPL, &quot;Program&quot; will mean the Content.
+	</p>
+
+	<p>
+		If you did not receive this Content directly from the Eclipse
+		Foundation, the Content is being redistributed by another party
+		(&quot;Redistributor&quot;) and different terms and conditions may
+		apply to your use of any object code in the Content. Check the
+		Redistributor's license that was provided with the Content. If no such
+		license exists, contact the Redistributor. Unless otherwise indicated
+		below, the terms and conditions of the EPL still apply to any source
+		code in the Content and such source code may be obtained at <a
+			href="http://www.eclipse.org/">http://www.eclipse.org</a>.
+	</p>
+
+</body>
+</html>

--- a/bundles/org.eclipse.equinox.launcher.win32.win32.aarch64/build.properties
+++ b/bundles/org.eclipse.equinox.launcher.win32.win32.aarch64/build.properties
@@ -1,0 +1,25 @@
+###############################################################################
+# Copyright (c) 2023, 2024 Eclipse Foundation.
+#
+# This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     Tue Ton - initial API and implementation
+###############################################################################
+bin.includes = META-INF/,\
+               launcher.win32.win32.aarch64.properties,\
+               about.html
+
+generateSourceBundle=false
+binaryTag=LBv1-1901
+
+# Maven properties, see https://github.com/eclipse/tycho/wiki/Tycho-Pomless
+tycho.pomless.parent = ../../launcher-binary-parent
+pom.model.property.os = win32
+pom.model.property.ws = win32
+pom.model.property.arch = aarch64

--- a/bundles/org.eclipse.equinox.launcher.win32.win32.aarch64/launcher.win32.win32.aarch64.properties
+++ b/bundles/org.eclipse.equinox.launcher.win32.win32.aarch64/launcher.win32.win32.aarch64.properties
@@ -1,0 +1,15 @@
+###############################################################################
+# Copyright (c) 2023, 2024 Eclipse Foundation.
+#
+# This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+# 
+# Contributors:
+#     Tue Ton - initial API and implementation
+###############################################################################
+pluginName = Equinox Launcher Win32 Arm64 Fragment
+providerName = Eclipse.org - Equinox

--- a/features/org.eclipse.equinox.executable.feature/build.properties
+++ b/features/org.eclipse.equinox.executable.feature/build.properties
@@ -21,6 +21,9 @@ bin.includes = bin/,\
 ####Even though marked as custom, the content of the build.properties needs to be updated to ensure correctness of RCP app exported 
 #root.permissions.755=${launcherName}
 
+root.win32.win32.aarch64=bin/win32/win32/aarch64
+root.win32.win32.aarch64.permissions.755=launcher.exe
+
 root.win32.win32.x86_64=bin/win32/win32/x86_64
 root.win32.win32.x86_64.permissions.755=launcher.exe
 

--- a/features/org.eclipse.equinox.executable.feature/feature.xml
+++ b/features/org.eclipse.equinox.executable.feature/feature.xml
@@ -66,6 +66,13 @@
          version="0.0.0"/>
 
    <plugin
+         id="org.eclipse.equinox.launcher.win32.win32.aarch64"
+         os="win32"
+         ws="win32"
+         arch="aarch64"
+         version="0.0.0"/>
+
+   <plugin
          id="org.eclipse.equinox.launcher.win32.win32.x86_64"
          os="win32"
          ws="win32"

--- a/features/org.eclipse.equinox.executable.feature/pom.xml
+++ b/features/org.eclipse.equinox.executable.feature/pom.xml
@@ -91,6 +91,20 @@
           </execution>
         </executions>
       </plugin>
+      <!-- Temporary work-around until win32.win32.aarch64 environment is enabled in general. -->
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>target-platform-configuration</artifactId>
+        <configuration>
+          <environments combine.children="append">
+            <environment>
+              <os>win32</os>
+              <ws>win32</ws>
+              <arch>aarch64</arch>
+            </environment>
+          </environments>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 
@@ -125,6 +139,7 @@
                         <include name="gtk/linux/ppc64le/**/*"/>
                         <include name="gtk/linux/aarch64/**/*"/>
                         <include name="gtk/linux/x86_64/**/*"/>
+                        <include name="win32/win32/aarch64/**/*"/>
                         <include name="win32/win32/x86_64/**/*"/>
                       </fileset>
                     </copy>

--- a/features/org.eclipse.equinox.executable.feature/resources/build.properties
+++ b/features/org.eclipse.equinox.executable.feature/resources/build.properties
@@ -17,6 +17,9 @@ custom = true
 ####Even though marked as custom, the content of the build.properties needs to be updated to ensure correctness of RCP app exported 
 root.permissions.755=${launcherName}
 
+root.win32.win32.aarch64=file:bin/win32/win32/aarch64/launcher.exe
+root.win32.win32.aarch64.permissions.755=launcher.exe
+
 root.win32.win32.x86_64=file:bin/win32/win32/x86_64/launcher.exe
 root.win32.win32.x86_64.permissions.755=launcher.exe
 

--- a/features/org.eclipse.equinox.executable.feature/resources/build.xml
+++ b/features/org.eclipse.equinox.executable.feature/resources/build.xml
@@ -48,6 +48,16 @@
 		<subant target="rootFiles${os}_${ws}_${arch}" buildpath="." failonerror="false" inheritall="true"/>
 	</target>
 
+	<target name="rootFileswin32_win32_aarch64">
+		<mkdir dir="${feature.base}/win32.win32.aarch64/${collectingFolder}"/>
+		<copy todir="${feature.base}/win32.win32.aarch64/${collectingFolder}" failonerror="true" overwrite="true">
+			<fileset dir="${basedir}/bin/win32/win32/aarch64">
+				<include name="launcher.exe"/>
+			</fileset>
+		</copy>
+		<chmod perm="755" dir="${feature.base}/win32.win32.aarch64/${collectingFolder}" includes="launcher.exe" />
+	</target>
+
 	<target name="rootFileswin32_win32_x86_64">
 		<mkdir dir="${feature.base}/win32.win32.x86_64/${collectingFolder}"/>
 		<copy todir="${feature.base}/win32.win32.x86_64/${collectingFolder}" failonerror="true" overwrite="true">
@@ -152,6 +162,7 @@
 		<chmod perm="755" dir="${feature.base}/hpux.gtk.ia64/${collectingFolder}" includes="launcher" />
 	</target>
 	<target name="rootFilesgroup_group_group">
+		<antcall target="rootFileswin32_win32_aarch64"/>
 		<antcall target="rootFileswin32_win32_x86_64"/>
 		<antcall target="rootFilesmacosx_cocoa_x86_64"/>
 		<antcall target="rootFileslinux_gtk_ppc64le"/>

--- a/pom.xml
+++ b/pom.xml
@@ -219,6 +219,7 @@
 		    <module>bundles/org.eclipse.equinox.launcher.gtk.linux.aarch64</module>
 		    <module>bundles/org.eclipse.equinox.launcher.gtk.linux.ppc64le</module>
 		    <module>bundles/org.eclipse.equinox.launcher.gtk.linux.x86_64</module>
+		    <module>bundles/org.eclipse.equinox.launcher.win32.win32.aarch64</module>
 		    <module>bundles/org.eclipse.equinox.launcher.win32.win32.x86_64</module>
 		    <module>bundles/org.eclipse.equinox.launcher.tests</module>
 		


### PR DESCRIPTION
## Add support for Windows on Arm64 (WoA)

A new launcher fragment for WoA is added: `org.eclipse.equinox.launcher.win32.win32.aarch64`

Various features are also updated to include the new fragment.

## To manually build the Equinox launcher binaries for WoA
On a WoA box, run the following command at the root directory of this repo:
```
mvn clean generate-resources -Dnative=win32.win32.aarch64
```
and the following launcher binaries for WoA are generated:
```
eclipse.exe
eclipse_11900.dll
eclipsec.exe
```
which are moved over to the `rt.equinox.binaries` repo which is supposedly at the same directory level as that of this repo, i.e. at `..\rt.equinox.binaries`, and to their corresponding sub-directories there as followed:
```
..\rt.equinox.binaries\org.eclipse.equinox.executable\bin\win32\win32\aarch64\eclipse.exe
..\rt.equinox.binaries\org.eclipse.equinox.executable\bin\win32\win32\aarch64\eclipsec.exe
..\rt.equinox.binaries\org.eclipse.equinox.launcher.win32.win32.aarch64\eclipse_11900.dll
```
