### PR TITLE
Clean-up and simplify LinuxPasswordProvider and WinCrypto

### DIFF
--- a/bundles/org.eclipse.equinox.security.linux/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.security.linux/META-INF/MANIFEST.MF
@@ -10,5 +10,4 @@ Bundle-Localization: fragment
 Eclipse-PlatformFilter: (osgi.os=linux)
 Export-Package: org.eclipse.equinox.internal.security.linux;x-internal:=true
 Automatic-Module-Name: org.eclipse.equinox.security.linux
-Eclipse-BundleShape: dir
 Require-Bundle: com.sun.jna;bundle-version="[5.8.0,6.0.0)"

--- a/bundles/org.eclipse.equinox.security.win32.x86_64/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.security.win32.x86_64/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %fragmentName
 Bundle-SymbolicName: org.eclipse.equinox.security.win32.x86_64;singleton:=true
-Bundle-Version: 1.2.200.qualifier
+Bundle-Version: 1.2.300.qualifier
 Bundle-Vendor: %providerName
 Fragment-Host: org.eclipse.equinox.security;bundle-version="[1.0.0,2.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/bundles/org.eclipse.equinox.security.win32.x86_64/pom.xml
+++ b/bundles/org.eclipse.equinox.security.win32.x86_64/pom.xml
@@ -18,7 +18,7 @@
     <relativePath>../../</relativePath>
   </parent>
   <artifactId>org.eclipse.equinox.security.win32.x86_64</artifactId>
-  <version>1.2.200-SNAPSHOT</version>
+  <version>1.2.300-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <properties>

--- a/bundles/org.eclipse.equinox.security.win32.x86_64/src/org/eclipse/equinox/internal/security/win32/WinCrypto.java
+++ b/bundles/org.eclipse.equinox.security.win32.x86_64/src/org/eclipse/equinox/internal/security/win32/WinCrypto.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2017 IBM Corporation and others.
+ * Copyright (c) 2008, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -7,7 +7,7 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
@@ -41,21 +41,22 @@ public class WinCrypto extends PasswordProvider {
 		System.loadLibrary("jnicrypt64");
 	}
 
-	private final static String WIN_PROVIDER_NODE = "/org.eclipse.equinox.secure.storage/windows64";
-	private final static String PASSWORD_KEY = "encryptedPassword";
+	private static final String WIN_PROVIDER_NODE = "/org.eclipse.equinox.secure.storage/windows64";
+	private static final String PASSWORD_KEY = "encryptedPassword";
 
 	/**
 	 * The length of the randomly generated password in bytes
 	 */
-	private final static int PASSWORD_LENGTH = 250;
+	private static final int PASSWORD_LENGTH = 250;
 
 	@Override
 	public PBEKeySpec getPassword(IPreferencesContainer container, int passwordType) {
 		byte[] encryptedPassword;
-		if ((passwordType & CREATE_NEW_PASSWORD) == 0)
+		if ((passwordType & CREATE_NEW_PASSWORD) == 0) {
 			encryptedPassword = getEncryptedPassword(container);
-		else
+		} else {
 			encryptedPassword = null;
+		}
 
 		if (encryptedPassword != null) {
 			byte[] decryptedPassword = windecrypt(encryptedPassword);
@@ -78,24 +79,24 @@ public class WinCrypto extends PasswordProvider {
 		random.setSeed(System.currentTimeMillis());
 		random.nextBytes(rawPassword);
 		String password = Base64.encode(rawPassword);
-		if (savePassword(password, container))
+		if (savePassword(password, container)) {
 			return new PBEKeySpec(password.toCharArray());
-		else
+		} else {
 			return null;
+		}
 	}
 
 	private byte[] getEncryptedPassword(IPreferencesContainer container) {
 		ISecurePreferences node = container.getPreferences().node(WIN_PROVIDER_NODE);
-		String passwordHint;
 		try {
-			passwordHint = node.get(PASSWORD_KEY, null);
+			String passwordHint = node.get(PASSWORD_KEY, null);
+			if (passwordHint != null) {
+				return Base64.decode(passwordHint);
+			}
 		} catch (StorageException e) { // should never happen in this scenario
 			AuthPlugin.getDefault().logError(WinCryptoMessages.decryptPasswordFailed, e);
-			return null;
 		}
-		if (passwordHint == null)
-			return null;
-		return Base64.decode(passwordHint);
+		return null;
 	}
 
 	private boolean savePassword(String password, IPreferencesContainer container) {

--- a/bundles/org.eclipse.equinox.security/src/org/eclipse/equinox/security/storage/provider/PasswordProvider.java
+++ b/bundles/org.eclipse.equinox.security/src/org/eclipse/equinox/security/storage/provider/PasswordProvider.java
@@ -31,7 +31,7 @@ import javax.crypto.spec.PBEKeySpec;
  * password provider module to the secure storage system.
  * </p>
  */
-abstract public class PasswordProvider {
+public abstract class PasswordProvider {
 
 	/**
 	 * Bit mask for the password type field of the
@@ -40,7 +40,7 @@ abstract public class PasswordProvider {
 	 * otherwise this is a request for the password previously used for this secure
 	 * storage.
 	 */
-	final public static int CREATE_NEW_PASSWORD = 1 << 0;
+	public static final int CREATE_NEW_PASSWORD = 1 << 0;
 
 	/**
 	 * Bit mask for the password type field of the
@@ -48,7 +48,7 @@ abstract public class PasswordProvider {
 	 * set to <code>1</code>, it indicates that a new password is requested as a
 	 * part of the password change operation.
 	 */
-	final public static int PASSWORD_CHANGE = 1 << 1;
+	public static final int PASSWORD_CHANGE = 1 << 1;
 
 	/**
 	 * This method should return the password used to encrypt entries in the secure
@@ -63,14 +63,7 @@ abstract public class PasswordProvider {
 	 * @return password used to encrypt entries in the secure preferences,
 	 *         <code>null</code> if unable to obtain password
 	 */
-	abstract public PBEKeySpec getPassword(IPreferencesContainer container, int passwordType);
-
-	/**
-	 * Constructor.
-	 */
-	public PasswordProvider() {
-		// placeholder
-	}
+	public abstract PBEKeySpec getPassword(IPreferencesContainer container, int passwordType);
 
 	/**
 	 * The framework might call this method if it suspects that the password is

--- a/features/org.eclipse.equinox.core.sdk/feature.xml
+++ b/features/org.eclipse.equinox.core.sdk/feature.xml
@@ -86,13 +86,11 @@
    <plugin
          id="org.eclipse.equinox.security.linux"
          os="linux"
-         arch="x86_64"
          version="0.0.0"/>
 
    <plugin
          id="org.eclipse.equinox.security.linux.source"
          os="linux"
-         arch="x86_64"
          version="0.0.0"/>
 
    <plugin


### PR DESCRIPTION
And remove 'arch' attribute of 'o.e.equinox.security.linux' in the 'o.e.equinox.core.sdk' feature to reflect that the fragment is architecture-independent.