### PR TITLE
Enforce encapsulation of equinox-launcher Constants and JNIBridge

### DIFF
--- a/bundles/org.eclipse.equinox.launcher/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.launcher/META-INF/MANIFEST.MF
@@ -8,6 +8,5 @@ Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Localization: launcher
 Export-Package: org.eclipse.core.launcher;x-internal:=true,
- org.eclipse.equinox.internal.launcher;x-internal:=true,
  org.eclipse.equinox.launcher;x-internal:=true
 Automatic-Module-Name: org.eclipse.equinox.launcher

--- a/bundles/org.eclipse.equinox.launcher/src/org/eclipse/equinox/launcher/Constants.java
+++ b/bundles/org.eclipse.equinox.launcher/src/org/eclipse/equinox/launcher/Constants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2009 IBM Corporation and others.
+ * Copyright (c) 2006, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -11,12 +11,12 @@
  * Contributors:
  *     Andrew Niefer - IBM Corporation - initial API and implementation
  *******************************************************************************/
-package org.eclipse.equinox.internal.launcher;
+package org.eclipse.equinox.launcher;
 
 /**
  * @author aniefer
  */
-public class Constants {
+class Constants {
 	public static final String INTERNAL_AMD64 = "amd64"; //$NON-NLS-1$
 	public static final String INTERNAL_OS_SUNOS = "SunOS"; //$NON-NLS-1$
 	public static final String INTERNAL_OS_LINUX = "Linux"; //$NON-NLS-1$

--- a/bundles/org.eclipse.equinox.launcher/src/org/eclipse/equinox/launcher/JNIBridge.java
+++ b/bundles/org.eclipse.equinox.launcher/src/org/eclipse/equinox/launcher/JNIBridge.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2015 IBM Corporation and others.
+ * Copyright (c) 2006, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -23,8 +23,7 @@ package org.eclipse.equinox.launcher;
  * @noextend This class is not intended to be subclassed by clients.
  * @noinstantiate This class is not intended to be instantiated by clients.
  */
-public class JNIBridge {
-	//TODO: This class should not be public
+class JNIBridge {
 	private native void _set_exit_data(String sharedId, String data);
 
 	private native void _set_launcher_info(String launcher, String name);

--- a/bundles/org.eclipse.equinox.launcher/src/org/eclipse/equinox/launcher/Main.java
+++ b/bundles/org.eclipse.equinox.launcher/src/org/eclipse/equinox/launcher/Main.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -58,8 +58,6 @@ import java.util.StringJoiner;
 import java.util.StringTokenizer;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
-
-import org.eclipse.equinox.internal.launcher.Constants;
 
 /**
  * The launcher for Eclipse.

--- a/features/org.eclipse.equinox.executable.feature/library/org.eclipse.launcher.tests/pom.xml
+++ b/features/org.eclipse.equinox.executable.feature/library/org.eclipse.launcher.tests/pom.xml
@@ -37,7 +37,7 @@
 						<configuration>
 							<archive>
 								<manifest>
-									<mainClass>main.TestLauncherApp</mainClass>
+									<mainClass>org.eclipse.equinox.launcher.TestLauncherApp</mainClass>
 								</manifest>
 							</archive>
 						</configuration>

--- a/features/org.eclipse.equinox.executable.feature/library/org.eclipse.launcher.tests/src/org/eclipse/equinox/launcher/TestLauncherApp.java
+++ b/features/org.eclipse.equinox.executable.feature/library/org.eclipse.launcher.tests/src/org/eclipse/equinox/launcher/TestLauncherApp.java
@@ -11,7 +11,7 @@
  * Contributors:
  *     Umair Sair - initial API and implementation
  *******************************************************************************/
-package main;
+package org.eclipse.equinox.launcher;
 
 import java.io.BufferedReader;
 import java.io.DataOutputStream;
@@ -21,8 +21,6 @@ import java.net.Socket;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.eclipse.equinox.launcher.JNIBridge;
-
 /**
  * Dummy test application used for eclipse launcher testing. JUnit tests
  * launches the eclipse launcher with startup application pointing to the jar file
@@ -31,11 +29,11 @@ import org.eclipse.equinox.launcher.JNIBridge;
  * port and accepts following queries
  * - -args - returns the arguments passed to this application. Test verify if the
  * arguments are passed to application correctly by the launcher.
- * 
+ *
  * And accepts following information
  * - -exitdata - The exit data this application should set before exiting
  * - -exitcode - The exit code with which this application should exit
- * 
+ *
  * @author umairsair
  *
  */
@@ -98,8 +96,9 @@ public class TestLauncherApp {
 					out.flush();
 				} else if (TestLauncherConstants.EXITDATA_PARAMETER.equals(line)) {
 					while ((line = in.readLine()) != null) {
-						if (TestLauncherConstants.MULTILINE_ARG_VALUE_TERMINATOR.equals(line))
+						if (TestLauncherConstants.MULTILINE_ARG_VALUE_TERMINATOR.equals(line)) {
 							break;
+						}
 						exitData.add(line);
 					}
 				} else if (TestLauncherConstants.EXITCODE_PARAMETER.equals(line)) {

--- a/features/org.eclipse.equinox.executable.feature/library/org.eclipse.launcher.tests/src/org/eclipse/equinox/launcher/TestLauncherConstants.java
+++ b/features/org.eclipse.equinox.executable.feature/library/org.eclipse.launcher.tests/src/org/eclipse/equinox/launcher/TestLauncherConstants.java
@@ -11,7 +11,7 @@
  * Contributors:
  *     Umair Sair - initial API and implementation
  *******************************************************************************/
-package main;
+package org.eclipse.equinox.launcher;
 
 public interface TestLauncherConstants {
 	public static final String ARGS_PARAMETER = "-args"; //$NON-NLS-1$

--- a/features/org.eclipse.equinox.executable.feature/library/org.eclipse.launcher.tests/src/test/java/LauncherTests.java
+++ b/features/org.eclipse.equinox.executable.feature/library/org.eclipse.launcher.tests/src/test/java/LauncherTests.java
@@ -32,11 +32,10 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
+import org.eclipse.equinox.launcher.TestLauncherConstants;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import main.TestLauncherConstants;
 
 public class LauncherTests {
 	private static final String ECLIPSE_INI_PATH_KEY = "ECLIPSE_INI_PATH";


### PR DESCRIPTION
In the Eclipse SDK there are neither references to `org.eclipse.equinox.internal.launcher.Constants` nor to `org.eclipse.equinox.launcher.JNIBridge`.
@tjwatson or anybody else are you aware of external users that need those two classes public at the places where they are?