### PR TITLE
Remove now unsuitable arch attributes in equinox.core.sdk feature

### DIFF
--- a/features/org.eclipse.equinox.core.sdk/feature.xml
+++ b/features/org.eclipse.equinox.core.sdk/feature.xml
@@ -74,13 +74,11 @@
    <plugin
          id="org.eclipse.equinox.security.win32"
          os="win32"
-         arch="x86_64"
          version="0.0.0"/>
 
    <plugin
          id="org.eclipse.equinox.security.win32.source"
          os="win32"
-         arch="x86_64"
          version="0.0.0"/>
 
    <plugin


### PR DESCRIPTION
Now that the o.e.equinox.security.win32 fragment is architecture independent (because it is implemented through JNA) restricting it to one arch when including it in features is not necessary anymore.

This was forgotten in PR https://github.com/eclipse-equinox/equinox/pull/564