### PR TITLE
Fix version-ranges to have exclusive upper-bounds

### DIFF
--- a/bundles/org.eclipse.equinox.cm/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.cm/META-INF/MANIFEST.MF
@@ -8,7 +8,7 @@ Bundle-Version: 1.6.100.qualifier
 Bundle-Activator: org.eclipse.equinox.internal.cm.Activator
 Import-Package: org.osgi.framework;version="1.7.0",
  org.osgi.service.cm;version="[1.6,1.7)",
- org.osgi.service.coordinator;version="[1.0.0,2.0.0]",
+ org.osgi.service.coordinator;version="[1.0.0,2.0.0)",
  org.osgi.service.event;version="1.0";resolution:=optional,
  org.osgi.service.log;version="1.3.0",
  org.osgi.util.tracker;version="1.3.1"

--- a/bundles/org.eclipse.equinox.console/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.console/META-INF/MANIFEST.MF
@@ -2,13 +2,13 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-SymbolicName: org.eclipse.equinox.console
-Bundle-Version: 1.4.700.qualifier
+Bundle-Version: 1.4.800.qualifier
 Bundle-Activator: org.eclipse.equinox.console.command.adapter.Activator
 Bundle-Vendor: %bundleVendor
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Import-Package: org.apache.felix.service.command;version="[1.0,2.0)",
- org.eclipse.osgi.container;version="[1.7.0,2.0.0]",
+ org.eclipse.osgi.container;version="[1.7.0,2.0.0)",
  org.eclipse.osgi.framework.console,
  org.eclipse.osgi.report.resolution;version="[1.0,2.0)",
  org.eclipse.osgi.service.environment,


### PR DESCRIPTION
This was introduced due to a bug in PDE where the auto-mated suggestion unintentionally made the upper-bound inclusive.
See https://github.com/eclipse-pde/eclipse.pde/pull/1212