### PR TITLE
[Build] Clean-up win32/build.bat and fix its argument processing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,12 +57,6 @@ jobs:
         path: '**/target/*-reports/*.xml'
   build-launcher-win64:
     runs-on: windows-2019
-    env:
-      PROGRAM_OUTPUT: eclipse.exe
-      PROGRAM_LIBRARY: eclipse.dll
-      DEFAULT_OS: win32
-      DEFAULT_OS_ARCH: x86_64
-      DEFAULT_WS: win32
     steps:
     - uses: actions/checkout@v4
       with:
@@ -83,7 +77,7 @@ jobs:
         arch: x64
     - name: Build
       working-directory: features/org.eclipse.equinox.executable.feature/library/win32
-      run: nmake -f make_win64.mak test
+      run: .\build.bat test
       shell: pwsh
     - name: Upload artifacts
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
The argument processing was fixed by removing an superfluous 'shift'-command.
This allows to use the win32/build.bat in the GH-workflow which in turn makes it possible to remove the explicit specification of environment variables which are set in the build.bat.

Also remove obsolete variables and machine specific paths, update defaults listed in the explanations of the optional switches and remove trivial labels+jumps.
Also remove specification of environment variable PROCESSOR_ARCHITECTURE that is set by the hosting computer.
