### PR TITLE
[Build] Remove superfluous explicit definition sourceEncoding

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,6 @@ jobs:
         -Pbree-libs
         -Papi-check
         -Dcompare-version-with-baselines.skip=false
-        -Dproject.build.sourceEncoding=UTF-8
         -Dmaven.test.failure.ignore=true
         -Drt.equinox.binaries.loc=${{ github.workspace }}/rt.equinox.binaries
         clean verify
@@ -202,7 +201,6 @@ jobs:
         -Pbree-libs
         -Ptck
         -Dskip-default-modules=true
-        -Dproject.build.sourceEncoding=UTF-8
         -Dtycho.resolver.classic=false
         -fn
         clean verify

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -68,7 +68,6 @@ jobs:
         -Pbree-libs
         -Papi-check
         -Dcompare-version-with-baselines.skip=false
-        -Dproject.build.sourceEncoding=UTF-8
         -Dmaven.test.failure.ignore=true
         -Drt.equinox.binaries.loc=${{ github.workspace }}/rt.equinox.binaries
         -DskipTests=true

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,6 @@ pipeline {
 				sh """
 				mvn clean verify --batch-mode --fail-at-end -Dmaven.repo.local=$WORKSPACE/.m2/repository \
 					-Pbree-libs -Papi-check -Pjavadoc\
-					-Dproject.build.sourceEncoding=UTF-8 \
 					-Drt.equinox.binaries.loc=$WORKSPACE/rt.equinox.binaries 
 				"""
 			}


### PR DESCRIPTION
The eclipse-platform-parent/pom.xml already defines the property 'project.build.sourceEncoding=UTF-8':
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/blob/a32f2fd79a26182b2c64ad88134ac64abb8e6f39/eclipse-platform-parent/pom.xml#L87