### PR TITLE
[Build] Add auto-serach for MSVC compiler in native win32/build.bat

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -30,7 +30,7 @@ packageinfo crlf=input
 Makefile crlf=input
 
 # No EOL translation
-*.bat -crlf
+*.bat text eol=crlf
 
 # Binary. No EOL translation, no diff
 *.ico binary

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,10 +71,6 @@ jobs:
       uses: stCarolas/setup-maven@v5
       with:
         maven-version: 3.9.6
-    - name: Visual Studio shell
-      uses: egor-tensin/vs-shell@v2
-      with:
-        arch: x64
     - name: Build
       working-directory: features/org.eclipse.equinox.executable.feature/library/win32
       run: .\build.bat test


### PR DESCRIPTION
The auto-search is based on the one implemented in SWT to build the Windows binaries:
https://github.com/eclipse-platform/eclipse.platform.swt/blob/182518f95f4179b0e0d3205167a5d5eef8e61bb2/bundles/org.eclipse.swt/Eclipse%20SWT%20PI/win32/library/build.bat#L108-L169

This permits to use MSVC 2022 and 2019 to build the Equinox binaries for Windows.
It also makes it possible to use the Microsoft Visual Studio pre-installed on GitHub action runners.
