### PR TITLE
Add --launcher.noRestart option to launcher.

### DIFF
--- a/bundles/org.eclipse.equinox.app/src/org/eclipse/equinox/app/IApplication.java
+++ b/bundles/org.eclipse.equinox.app/src/org/eclipse/equinox/app/IApplication.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2018 IBM Corporation and others.
+ * Copyright (c) 2005, 2024 IBM Corporation and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -7,7 +7,7 @@
  *  https://www.eclipse.org/legal/epl-2.0/
  *
  *  SPDX-License-Identifier: EPL-2.0
- * 
+ *
  *  Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
@@ -23,7 +23,7 @@ package org.eclipse.equinox.app;
  * <p>
  * Clients may implement this interface.
  * </p>
- * 
+ *
  * @since 1.0
  */
 public interface IApplication {
@@ -34,7 +34,12 @@ public interface IApplication {
 	public static final Integer EXIT_OK = Integer.valueOf(0);
 
 	/**
-	 * Exit object requesting platform restart
+	 * Exit object requesting platform restart.
+	 *
+	 * <p>
+	 * Note: The handling of this special exit code may be disabled by launcher
+	 * argument {@code --launcher.noRestart}.
+	 * </p>
 	 */
 	public static final Integer EXIT_RESTART = Integer.valueOf(23);
 
@@ -44,6 +49,11 @@ public interface IApplication {
 	 * the executable is relaunched the command line will be retrieved from the
 	 * {@link IApplicationContext#EXIT_DATA_PROPERTY eclipse.exitdata} system
 	 * property.
+	 *
+	 * <p>
+	 * Note: The handling of this special exit code may be disabled by launcher
+	 * argument {@code --launcher.noRestart}.
+	 * </p>
 	 */
 	public static final Integer EXIT_RELAUNCH = Integer.valueOf(24);
 
@@ -64,7 +74,7 @@ public interface IApplication {
 	 * Note: This method is called by the platform; it is not intended to be called
 	 * directly by clients.
 	 * </p>
-	 * 
+	 *
 	 * @return the return value of the application
 	 * @see #EXIT_OK
 	 * @see #EXIT_RESTART
@@ -80,7 +90,7 @@ public interface IApplication {
 	 * running application is ready to exit. The {@link #start(IApplicationContext)}
 	 * should already have exited or should exit very soon after this method exits
 	 * <p>
-	 * 
+	 *
 	 * This method is only called to force an application to exit. This method will
 	 * not be called if an application exits normally from the
 	 * {@link #start(IApplicationContext)} method.

--- a/features/org.eclipse.equinox.compendium.sdk/feature.xml
+++ b/features/org.eclipse.equinox.compendium.sdk/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.equinox.compendium.sdk"
       label="%featureName"
-      version="3.23.200.qualifier"
+      version="3.23.300.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/features/org.eclipse.equinox.executable.feature/library/eclipse.c
+++ b/features/org.eclipse.equinox.executable.feature/library/eclipse.c
@@ -702,7 +702,7 @@ static int _run(int argc, _TCHAR* argv[], _TCHAR* vmArgs[])
 					}
 				}
 			} else {
-				 if (debug) {
+				if (debug) {
 					if (!suppressErrors)
 						displayMessage( title, shareMsg );
 					else
@@ -1103,12 +1103,15 @@ static void getVMCommand( int launchMode, int argc, _TCHAR* argv[], _TCHAR **vmA
 	(*vmArgv)[dst] = NULL;
 
 	/* Program arguments */
-    /*  OS <os> + WS <ws> + ARCH <arch> + LAUNCHER <launcher> + NAME <officialName> +
-     *  + LIBRARY <library> + SHOWSPLASH <cmd> + EXITDATA <cmd> + STARTUP <jar> + OVERRIDE/APPEND + argv[] + VM + <vm> +
-     * VMARGS + vmArg + requiredVMargs
+    /*  OS <os> + WS <ws> + ARCH <arch> + SHOWSPLASH <cmd> + LAUNCHER <program> + NAME <officialName>
+     *  + LIBRARY <eclipseLibrary> + STARTUP <jarFile> + PROTECT <protectMode> + APPEND/OVERRIDE
+     *  + EXITDATA <sharedId> + argv[] + VM <jniLib/javaVM> + VMARGS + vmArg[] + eeVMarg[] + reqVMarg[]
      *  + NULL)
      */
-    totalProgArgs  = 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 1 + argc + 2 + 1 + nVMarg + nEEargs + nReqVMarg + 1;
+    totalProgArgs = 2 + 2 + 2 + 2 + 2 + 2
+                  + 2 + 2 + 2 + 1
+                  + 2 + argc + 2 + 1 + nVMarg + nEEargs + nReqVMarg
+                  + 1;
 	*progArgv = malloc( totalProgArgs * sizeof( _TCHAR* ) );
     dst = 0;
 

--- a/features/org.eclipse.equinox.executable.feature/library/eclipseCommon.h
+++ b/features/org.eclipse.equinox.executable.feature/library/eclipseCommon.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2009 IBM Corporation and others.
+ * Copyright (c) 2006, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -47,6 +47,7 @@
 #define INI                _T_ECLIPSE("--launcher.ini")
 #define APPEND_VMARGS      _T_ECLIPSE("--launcher.appendVmargs")
 #define OVERRIDE_VMARGS    _T_ECLIPSE("--launcher.overrideVmargs")
+#define NORESTART          _T_ECLIPSE("--launcher.noRestart")
 #define SECOND_THREAD      _T_ECLIPSE("--launcher.secondThread")
 #define PERM_GEN           _T_ECLIPSE("--launcher.XXMaxPermSize")
 #define OLD_ARGS_START     _T_ECLIPSE("--launcher.oldUserArgsStart")

--- a/features/org.eclipse.equinox.sdk/feature.xml
+++ b/features/org.eclipse.equinox.sdk/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.equinox.sdk"
       label="%featureName"
-      version="3.23.1300.qualifier"
+      version="3.23.1400.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">


### PR DESCRIPTION
This adds a `-norestart` option to the launcher. When the option is used, it suppresses the restart behavior of exit codes 23 and 24, such that an `IApplication` can return all exit codes if the restart behavior is not desired.

The diff looks more complicated than it needs to. In `eclipse.c`, the changes to the switch statement only involve an extra `if` around the body of two `case`s, with a comment at the end to explain the fall-through. The bodies of these two new `if` statements contain the original unmodified original code of the `case`s, indented one extra level.

See also the discussion at https://github.com/eclipse-equinox/equinox/discussions/378.