### PR TITLE
Revert removal of JRE-1.1 execution environment profile and add its system-packages

### DIFF
--- a/bundles/org.eclipse.osgi/JRE-1.1.profile
+++ b/bundles/org.eclipse.osgi/JRE-1.1.profile
@@ -1,0 +1,27 @@
+###############################################################################
+# Copyright (c) 2003, 2012 IBM Corporation and others.
+#
+# This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+# 
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+org.osgi.framework.system.packages = 
+org.osgi.framework.bootdelegation = \
+ sun.*,\
+ com.sun.*
+org.osgi.framework.executionenvironment = \
+ JRE-1.1
+org.osgi.framework.system.capabilities = \
+ osgi.ee; osgi.ee="JRE"; version:List<Version>="1.0, 1.1"
+osgi.java.profile.name = JRE-1.1
+org.eclipse.jdt.core.compiler.compliance=1.3
+org.eclipse.jdt.core.compiler.source=1.3
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.1
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=ignore
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=ignore

--- a/bundles/org.eclipse.osgi/JRE-1.1.profile
+++ b/bundles/org.eclipse.osgi/JRE-1.1.profile
@@ -11,7 +11,31 @@
 # Contributors:
 #     IBM Corporation - initial API and implementation
 ###############################################################################
-org.osgi.framework.system.packages = 
+org.osgi.framework.system.packages = \
+java.applet,\
+java.awt,\
+java.awt.datatransfer,\
+java.awt.event,\
+java.awt.image,\
+java.awt.peer,\
+java.beans,\
+java.io,\
+java.lang,\
+java.lang.reflect,\
+java.math,\
+java.net,\
+java.rmi,\
+java.rmi.dgc,\
+java.rmi.registry,\
+java.rmi.server,\
+java.security,\
+java.security.acl,\
+java.security.interfaces,\
+java.sql,\
+java.text,\
+java.text.resources,\
+java.util,\
+java.util.zip
 org.osgi.framework.bootdelegation = \
  sun.*,\
  com.sun.*

--- a/bundles/org.eclipse.osgi/profile.list
+++ b/bundles/org.eclipse.osgi/profile.list
@@ -20,6 +20,7 @@ java.profiles = \
  J2SE-1.4.profile,\
  J2SE-1.3.profile,\
  J2SE-1.2.profile,\
+ JRE-1.1.profile,\
  JavaSE_compact1-1.8.profile,\
  JavaSE_compact2-1.8.profile,\
  JavaSE_compact3-1.8.profile,\


### PR DESCRIPTION
This reverts https://github.com/eclipse-equinox/equinox/pull/572 and instead instead adds the system-packages for the JRE-1.1 execution environment profile that where derived from ancient Java-1.1 JREs as described in https://github.com/eclipse-pde/eclipse.pde/pull/693#issuecomment-1673903650.

Fixes https://github.com/eclipse-equinox/equinox/issues/571
Part of https://github.com/eclipse-pde/eclipse.pde/issues/1231 (fixing that completely requires the reversion of https://github.com/eclipse-jdt/eclipse.jdt.debug/pull/425)

Once this is merged, we can remove the hard-coded system-packages from PDE:
https://github.com/eclipse-pde/eclipse.pde/blob/860100e5b0d57bca42cbe26078ea5c3093828c60/build/org.eclipse.pde.build/src/org/eclipse/pde/internal/build/site/PDEState.java#L580-L603