### PR TITLE
Fix ServiceCaller to use highest rank service

### DIFF
--- a/bundles/org.eclipse.equinox.common.tests/src/org/eclipse/equinox/common/tests/ServiceCallerTest.java
+++ b/bundles/org.eclipse.equinox.common.tests/src/org/eclipse/equinox/common/tests/ServiceCallerTest.java
@@ -251,6 +251,18 @@ public class ServiceCallerTest {
 
 			reg1.setProperties(asDictionary(singletonMap(Constants.SERVICE_RANKING, 1)));
 			assertHighestRankedCalled(caller, s2, s1, s3, reg2, reg1, reg3);
+
+			// re-register a new service with highest rank
+			reg3.unregister();
+			reg3 = context.registerService(IServiceExample.class, s3,
+					asDictionary(singletonMap(Constants.SERVICE_RANKING, 200)));
+			assertHighestRankedCalled(caller, s3, s2, s1, reg3, reg2, reg1);
+
+			// re-register another service with lower rank
+			reg1.unregister();
+			reg1 = context.registerService(IServiceExample.class, s1,
+					asDictionary(singletonMap(Constants.SERVICE_RANKING, 200)));
+			assertHighestRankedCalled(caller, s3, s2, s1, reg3, reg2, reg1);
 		} finally {
 			if (reg1 != null) {
 				reg1.unregister();

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/ServiceCaller.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/ServiceCaller.java
@@ -19,7 +19,17 @@ import java.security.PrivilegedAction;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
-import org.osgi.framework.*;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.BundleEvent;
+import org.osgi.framework.Constants;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.framework.ServiceEvent;
+import org.osgi.framework.ServiceListener;
+import org.osgi.framework.ServiceReference;
+import org.osgi.framework.SynchronousBundleListener;
 import org.osgi.util.tracker.ServiceTracker;
 
 /**
@@ -210,13 +220,15 @@ public class ServiceCaller<S> {
 		}
 
 		private boolean requiresUnget(ServiceEvent e) {
+			int eventType = e.getType();
 			if (e.getServiceReference().equals(ref)) {
-				return (e.getType() == ServiceEvent.UNREGISTERING)
-						|| (filter != null && e.getType() == ServiceEvent.MODIFIED_ENDMATCH)
-						|| (e.getType() == ServiceEvent.MODIFIED && getRank(ref) != rank);
+				return (eventType == ServiceEvent.UNREGISTERING)
+						|| (filter != null && eventType == ServiceEvent.MODIFIED_ENDMATCH)
+						|| (eventType == ServiceEvent.MODIFIED && getRank(ref) != rank);
 				// if rank changed: untrack to force a new ReferenceAndService with new rank
 			}
-			return e.getType() == ServiceEvent.MODIFIED && getRank(e.getServiceReference()) > rank;
+			return (eventType == ServiceEvent.MODIFIED || eventType == ServiceEvent.REGISTERED)
+					&& getRank(e.getServiceReference()) > rank;
 		}
 
 		// must hold monitor on ServiceCaller.this when calling track


### PR DESCRIPTION
When new services with a higher rank are registered than the current service being used by ServiceCaller then the ServiceCaller should unget the current service and future calls should use the newly highest ranked service.