### PR TITLE
[Build] Ensure GH-workflow for MacOS runs on x86_64 image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
         config: 
           - { name: Linux, runner-os: ubuntu-latest, ws: gtk, os: linux, native-extension: so }
           - { name: Windows, runner-os: windows-2019, ws: win32, os: win32, native-extension: dll }
-          - { name: MacOS, runner-os: macos-latest, ws: cocoa, os: macosx, native-extension: so }
+          - { name: MacOS, runner-os: macos-latest-large, ws: cocoa, os: macosx, native-extension: so }
     steps:
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
GitHub Actions changed their 'latest' images for MacOS to use the 'aarch64' instead of the 'x86_64' architecture:
https://github.com/actions/runner-images/blob/7bb1d84f7071bfa9c350d7552d9631d9a69bfdb0/README.md

But for macosx.aarch64 no JDK-8 is available.

This is similar to https://github.com/eclipse-platform/eclipse.platform.swt/pull/1201.