### PR TITLE
Use NIO Files API to set POSIX file permissions

### DIFF
--- a/bundles/org.eclipse.equinox.launcher/src/org/eclipse/equinox/launcher/Main.java
+++ b/bundles/org.eclipse.equinox.launcher/src/org/eclipse/equinox/launcher/Main.java
@@ -40,6 +40,9 @@ import java.net.URLStreamHandlerFactory;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.security.AllPermission;
 import java.security.CodeSource;
 import java.security.Permission;
@@ -54,6 +57,7 @@ import java.util.Enumeration;
 import java.util.List;
 import java.util.Locale;
 import java.util.Properties;
+import java.util.Set;
 import java.util.StringJoiner;
 import java.util.StringTokenizer;
 import java.util.zip.ZipEntry;
@@ -296,6 +300,8 @@ public class Main {
 	private static final String BASE_TIMESTAMP_FILE_CONFIGINI = ".baseConfigIniTimestamp"; //$NON-NLS-1$
 	private static final String KEY_CONFIGINI_TIMESTAMP = "configIniTimestamp"; //$NON-NLS-1$
 	private static final String PROP_IGNORE_USER_CONFIGURATION = "eclipse.ignoreUserConfiguration"; //$NON-NLS-1$
+
+	private static final Set<PosixFilePermission> PERMISSION_755 = PosixFilePermissions.fromString("rwxr-xr-x"); //$NON-NLS-1$
 
 	/**
 	 * A structured form for a version identifier.
@@ -550,7 +556,7 @@ public class Main {
 				String lib = extractFromJAR(fragment, entry);
 				if (!getOS().equals("win32")) { //$NON-NLS-1$
 					try {
-						Runtime.getRuntime().exec(new String[] {"chmod", "755", lib}).waitFor(); //$NON-NLS-1$ //$NON-NLS-2$
+						Files.setPosixFilePermissions(Paths.get(lib), PERMISSION_755);
 					} catch (Throwable e) {
 						//ignore
 					}

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/storage/NativeCodeFinder.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/storage/NativeCodeFinder.java
@@ -15,11 +15,15 @@
 package org.eclipse.osgi.storage;
 
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.eclipse.osgi.container.ModuleRevision;
 import org.eclipse.osgi.container.ModuleWire;
 import org.eclipse.osgi.container.ModuleWiring;
@@ -38,6 +42,7 @@ public class NativeCodeFinder {
 	public static final String REQUIREMENT_NATIVE_PATHS_ATTRIBUTE = "native.paths"; //$NON-NLS-1$
 	private static final String[] EMPTY_STRINGS = new String[0];
 	public static final String EXTERNAL_LIB_PREFIX = "external:"; //$NON-NLS-1$
+	private static final Set<PosixFilePermission> PERMISSIONS_755 = PosixFilePermissions.fromString("rwxr-xr-x"); //$NON-NLS-1$
 	private final Generation generation;
 	private final Debug debug;
 	// This is only used to keep track of when the same native library is loaded
@@ -131,8 +136,7 @@ public class NativeCodeFinder {
 				if (org.eclipse.osgi.service.environment.Constants.OS_HPUX
 						.equals(generation.getBundleInfo().getStorage().getConfiguration().getOS())) {
 					try {
-						// use the string array method in case there is a space in the path
-						Runtime.getRuntime().exec(new String[] { "chmod", "755", libFile.getAbsolutePath() }).waitFor(); //$NON-NLS-1$ //$NON-NLS-2$
+						Files.setPosixFilePermissions(libFile.toPath(), PERMISSIONS_755);
 					} catch (Exception e) {
 						e.printStackTrace();
 					}


### PR DESCRIPTION
This avoids running another process to modify the permissions.

@tjwatson or is there a reason that speaks against using the Files API?