### PR TITLE
Add ManifestElement.parseBundleManifest without map parameter

### DIFF
--- a/bundles/org.eclipse.osgi/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.osgi/META-INF/MANIFEST.MF
@@ -51,7 +51,7 @@ Export-Package: org.eclipse.core.runtime.adaptor;x-friends:="org.eclipse.core.ru
  org.eclipse.osgi.storage.bundlefile;x-internal:=true,
  org.eclipse.osgi.storage.url.reference;x-internal:=true,
  org.eclipse.osgi.storagemanager;version="1.0",
- org.eclipse.osgi.util;version="1.1",
+ org.eclipse.osgi.util;version="1.2.0",
  org.osgi.dto;version="1.1.1",
  org.osgi.framework;version="1.10",
  org.osgi.framework.connect;version="1.0";uses:="org.osgi.framework.launch",
@@ -107,7 +107,7 @@ Bundle-Activator: org.eclipse.osgi.internal.framework.SystemBundleActivator
 Bundle-Description: %systemBundle
 Bundle-Copyright: %copyright
 Bundle-Vendor: %eclipse.org
-Bundle-Version: 3.20.100.qualifier
+Bundle-Version: 3.21.0.qualifier
 Bundle-Localization: systembundle
 Bundle-DocUrl: http://www.eclipse.org
 Eclipse-ExtensibleAPI: true

--- a/bundles/org.eclipse.osgi/pom.xml
+++ b/bundles/org.eclipse.osgi/pom.xml
@@ -19,7 +19,7 @@
 </parent>
   <groupId>org.eclipse.osgi</groupId>
   <artifactId>org.eclipse.osgi</artifactId>
-  <version>3.20.100-SNAPSHOT</version>
+  <version>3.21.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   <properties>
 	  <!-- The actual TCKs are executed in the org.eclipse.osgi.tck module because of reference to other service implementations -->

--- a/bundles/org.eclipse.osgi/supplement/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.osgi/supplement/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.supplement
-Bundle-Version: 1.10.900.qualifier
+Bundle-Version: 1.11.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.equinox.log;version="1.1",

--- a/bundles/org.eclipse.osgi/supplement/src/org/eclipse/osgi/util/ManifestElement.java
+++ b/bundles/org.eclipse.osgi/supplement/src/org/eclipse/osgi/util/ManifestElement.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.StringTokenizer;
+import java.util.TreeMap;
 import org.eclipse.osgi.internal.messages.Msg;
 import org.eclipse.osgi.internal.util.SupplementDebug;
 import org.eclipse.osgi.internal.util.Tokenizer;
@@ -483,6 +484,27 @@ public class ManifestElement {
 				list.add(token);
 		}
 		return list.toArray(new String[list.size()]);
+	}
+
+	/**
+	 * Parses a bundle manifest and returns the header/value pairs into as case
+	 * insensitive map. Only the main section of the manifest is parsed (up to the
+	 * first blank line). All other sections are ignored. If a header is duplicated
+	 * then only the last value is stored in the map.
+	 * <p>
+	 * The supplied input stream is consumed by this method and will be closed.
+	 * </p>
+	 * 
+	 * @param manifest an input stream for a bundle manifest.
+	 * @throws BundleException if the manifest has an invalid syntax
+	 * @throws IOException     if an error occurs while reading the manifest
+	 * @return the map with the header/value pairs from the bundle manifest
+	 * @since 3.21
+	 */
+	public static Map<String, String> parseBundleManifest(InputStream manifest) throws IOException, BundleException {
+		Map<String, String> headers = new TreeMap<>(String::compareToIgnoreCase);
+		parseBundleManifest(manifest, headers);
+		return headers;
 	}
 
 	/**


### PR DESCRIPTION
Currently the existing ManifestElement.parseBundleManifest with a wild mixture of parameters, some using access restricted maps, some use null some use a hashmap (what likely causes issue if case of headers is different than expected).

This adds a new method that simply removes the map parameter and uses a CaseInsensitiveDictionaryMap that is also used internally in the framework and is most likely the most natural choice for this usecase.