### PR TITLE
[Build] Use generalized 'native.builder' Jenkins node labels

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,7 +42,7 @@ spec:
 		if (platform == 'cocoa.macosx.x86_64') {
 			platform = 'cocoa.macosx.aarch64'
 		}
-		return node('swt.natives-' + platform) { stage(nativeBuildStageName) { body() } } //TODO: generalize labels
+		return node('native.builder-' + platform) { stage(nativeBuildStageName) { body() } }
 	}
 }
 


### PR DESCRIPTION
Use the new labels added to the 'Eclipse-RelEng' Jenkins instance via https://github.com/eclipse-cbi/jiro/pull/366.