### PR TITLE
[Build] Only archive just built jars and launcher binaries in Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -314,7 +314,7 @@ pipeline {
 			}
 			post {
 				always {
-					archiveArtifacts artifacts: '**/*.log, **/*.jar', allowEmptyArchive: true
+					archiveArtifacts artifacts: '**/*.log, equinox/**/target/*.jar, equinox.binaries/**', allowEmptyArchive: true
 					junit '**/target/surefire-reports/TEST-*.xml'
 					discoverGitReferenceBuild referenceJob: 'equinox/master'
 					recordIssues publishAllIssues: true, tools: [eclipse(name: 'Compiler and API Tools', pattern: '**/target/compilelogs/*.xml'), mavenConsole(), javaDoc()]


### PR DESCRIPTION
Currently all jars in the workspace of a Jenkins build run are archived, which also includes the entire local Maven repository and all baseline jars. This leads to a total archive size of about 670MB (compressed).

With this only the built jars plus the native binaries are archived, leading to a much smaller storage demands and a shorter runtime of the archive step.