### PR TITLE
[Build] Speed-up recording of compiler- and test-logs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -315,9 +315,9 @@ pipeline {
 			post {
 				always {
 					archiveArtifacts artifacts: '**/*.log, equinox/**/target/*.jar, equinox.binaries/**', allowEmptyArchive: true
-					junit '**/target/surefire-reports/TEST-*.xml'
+					junit 'equinox/**/target/surefire-reports/TEST-*.xml'
 					discoverGitReferenceBuild referenceJob: 'equinox/master'
-					recordIssues publishAllIssues: true, tools: [eclipse(name: 'Compiler and API Tools', pattern: '**/target/compilelogs/*.xml'), mavenConsole(), javaDoc()]
+					recordIssues publishAllIssues: true, tools: [eclipse(name: 'Compiler and API Tools', pattern: 'equinox/**/target/compilelogs/*.xml'), mavenConsole(), javaDoc()]
 				}
 			}
 		}


### PR DESCRIPTION
Make the log-file patterns more specific to speed up the search. This is possible since the equinox and equinox.binaries repository are checkout side-by-side and avoids search the local Maven repository in the workspace.