### PR TITLE
Remove temporary win32.aarch64 environment from exe-feature

### DIFF
--- a/features/org.eclipse.equinox.executable.feature/pom.xml
+++ b/features/org.eclipse.equinox.executable.feature/pom.xml
@@ -91,20 +91,6 @@
           </execution>
         </executions>
       </plugin>
-      <!-- Temporary work-around until win32.win32.aarch64 environment is enabled in general. -->
-      <plugin>
-        <groupId>org.eclipse.tycho</groupId>
-        <artifactId>target-platform-configuration</artifactId>
-        <configuration>
-          <environments combine.children="append">
-            <environment>
-              <os>win32</os>
-              <ws>win32</ws>
-              <arch>aarch64</arch>
-            </environment>
-          </environments>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
Because the win32.aarch64 environment is now generally activated for the entire SDK (see https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/1917) it is not necessary anymore to activate it only for the equinox.executable feature.

Part of https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/577