### PR TITLE
Remove unused leftovers of WPF launcher in JNIBridge

### DIFF
--- a/bundles/org.eclipse.equinox.launcher/src/org/eclipse/equinox/launcher/JNIBridge.java
+++ b/bundles/org.eclipse.equinox.launcher/src/org/eclipse/equinox/launcher/JNIBridge.java
@@ -36,10 +36,6 @@ class JNIBridge {
 
 	private native String _get_os_recommended_folder();
 
-	private native int OleInitialize(int reserved);
-
-	private native void OleUninitialize();
-
 	private String library;
 	private boolean libraryLoaded = false;
 
@@ -53,15 +49,6 @@ class JNIBridge {
 	private void loadLibrary() {
 		if (library != null) {
 			try {
-				if (library.contains("wpf")) { //$NON-NLS-1$
-					int idx = library.indexOf("eclipse_"); //$NON-NLS-1$
-					if (idx != -1) {
-						String comLibrary = library.substring(0, idx) + "com_"; //$NON-NLS-1$
-						comLibrary += library.substring(idx + 8, library.length());
-						Runtime.getRuntime().load(comLibrary);
-						OleInitialize(0);
-					}
-				}
 				Runtime.getRuntime().load(library);
 			} catch (UnsatisfiedLinkError e) {
 				//failed
@@ -156,20 +143,6 @@ class JNIBridge {
 			}
 			return false;
 		}
-	}
-
-	public boolean uninitialize() {
-		if (libraryLoaded && library != null) {
-			if (library.contains("wpf")) { //$NON-NLS-1$
-				try {
-					OleUninitialize();
-				} catch (UnsatisfiedLinkError e) {
-					// library not loaded
-					return false;
-				}
-			}
-		}
-		return true;
 	}
 
 	public String getOSRecommendedFolder() {

--- a/bundles/org.eclipse.equinox.launcher/src/org/eclipse/equinox/launcher/Main.java
+++ b/bundles/org.eclipse.equinox.launcher/src/org/eclipse/equinox/launcher/Main.java
@@ -1526,8 +1526,6 @@ public class Main {
 		} finally {
 			// always try putting down the splash screen just in case the application failed to do so
 			takeDownSplash();
-			if (bridge != null)
-				bridge.uninitialize();
 		}
 		// Return an int exit code and ensure the system property is set.
 		System.setProperty(PROP_EXITCODE, Integer.toString(result));


### PR DESCRIPTION
For the equinox launcher for Windows WPF launcher the native methods OleInitialize() and OleUninitialize() where introduced that where only implemented in the native library available for Windows WPF, see [Bug 172367](https://bugs.eclipse.org/bugs/show_bug.cgi?id=172367) / 3cf8518912fb064f582a5fa3b7ef020b2155e1b6. But during the removal of the WPF launcher in [Bug 479180](https://bugs.eclipse.org/bugs/show_bug.cgi?id=479180) / 121b7c5b2cb5f7a130720d382a3eac8c0e290a05 these methods have not been removed.

Since the native implementation is not available anymore these native methods cannot be used.