### PR TITLE
Javadoc warning fixes

### DIFF
--- a/bundles/org.eclipse.equinox.common.tests/src/org/eclipse/equinox/common/tests/SubMonitorTest.java
+++ b/bundles/org.eclipse.equinox.common.tests/src/org/eclipse/equinox/common/tests/SubMonitorTest.java
@@ -768,7 +768,7 @@ public class SubMonitorTest {
 	 * Tests progress monitor creation and cleanup time, and ensures that excess
 	 * progress is being collected when IProgressMonitor.done() is called.
 	 *
-	 * @param monitor  progress monitor (callers are responsible for calling done()
+	 * @param parent   progress monitor (callers are responsible for calling done()
 	 *                 if necessary)
 	 * @param loopSize total size of the recursion tree
 	 */
@@ -821,7 +821,7 @@ public class SubMonitorTest {
 	 * using internalWorked and half is reported using worked, to simulate mixed
 	 * usage of the progress monitor.
 	 *
-	 * @param monitor  progress monitor (callers are responsible for calling done()
+	 * @param parent   progress monitor (callers are responsible for calling done()
 	 *                 if necessary)
 	 * @param loopSize total size of the recursion tree
 	 */

--- a/bundles/org.eclipse.equinox.console/src/org/eclipse/equinox/console/commands/EquinoxCommandProvider.java
+++ b/bundles/org.eclipse.equinox.console/src/org/eclipse/equinox/console/commands/EquinoxCommandProvider.java
@@ -195,8 +195,6 @@ public class EquinoxCommandProvider implements SynchronousBundleListener {
 	 * Constructor.
 	 *
 	 * start() must be called after creating this object.
-	 *
-	 * @param framework The current instance of the framework
 	 */
 	public EquinoxCommandProvider(BundleContext context, Activator activator) {
 		this.context = context;
@@ -1874,7 +1872,6 @@ public class EquinoxCommandProvider implements SynchronousBundleListener {
 	 * Given a string containing a startlevel value, validate it and convert it to
 	 * an int
 	 *
-	 * @param intp  A CommandInterpreter object used for printing out error messages
 	 * @param value A string containing a potential startlevel
 	 * @return The start level or an int <0 if it was invalid
 	 */

--- a/bundles/org.eclipse.equinox.device/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.device/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
-Bundle-Version: 1.2.0.qualifier
+Bundle-Version: 1.2.100.qualifier
 Bundle-Activator: org.eclipse.equinox.device.Activator
 Bundle-SymbolicName: org.eclipse.equinox.device;deprecated:="Deprecated without any direct replacement, please use a different implementation or get in contact with the Equinox team to fix up this one"
 Bundle-Vendor: %bundleVendor

--- a/bundles/org.eclipse.equinox.device/src/org/eclipse/equinox/device/DriverLocatorTracker.java
+++ b/bundles/org.eclipse.equinox.device/src/org/eclipse/equinox/device/DriverLocatorTracker.java
@@ -39,8 +39,7 @@ public class DriverLocatorTracker extends ServiceTracker {
 	/**
 	 * Create the DriverLocatorTracker.
 	 *
-	 * @param context Device manager bundle context.
-	 * @param log     LogService object
+	 * @param manager Device manager bundle context.
 	 */
 	public DriverLocatorTracker(Activator manager) {
 		super(manager.context, clazz, null);
@@ -112,8 +111,7 @@ public class DriverLocatorTracker extends ServiceTracker {
 	 * Call the DriverLocator services in an attempt to locate and install driver
 	 * bundles to refine the device service.
 	 *
-	 * @param locators Array of DriverLocator objects
-	 * @param drivers  Dictionary of drivers with key=DRIVER_ID, value=Driver object
+	 * @param drivers Dictionary of drivers with key=DRIVER_ID, value=Driver object
 	 */
 	public void loadDrivers(Dictionary<String, ?> properties, DriverTracker drivers) {
 		if (Activator.DEBUG) {

--- a/bundles/org.eclipse.equinox.device/src/org/eclipse/equinox/device/DriverSelectorTracker.java
+++ b/bundles/org.eclipse.equinox.device/src/org/eclipse/equinox/device/DriverSelectorTracker.java
@@ -35,7 +35,6 @@ public class DriverSelectorTracker extends ServiceTracker {
 	 * Create the DriverTracker.
 	 *
 	 * @param manager DeviceManager object.
-	 * @param device  DeviceTracker we are working for.
 	 */
 	public DriverSelectorTracker(Activator manager) {
 		super(manager.context, clazz, null);

--- a/bundles/org.eclipse.equinox.device/src/org/eclipse/equinox/device/DriverTracker.java
+++ b/bundles/org.eclipse.equinox.device/src/org/eclipse/equinox/device/DriverTracker.java
@@ -55,7 +55,6 @@ public class DriverTracker extends ServiceTracker {
 	 * Create the DriverTracker.
 	 *
 	 * @param manager DeviceManager object.
-	 * @param device  DeviceTracker we are working for.
 	 */
 	public DriverTracker(Activator manager) {
 		super(manager.context, clazz, null);

--- a/bundles/org.eclipse.equinox.metatype/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.metatype/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
-Bundle-Version: 1.6.500.qualifier
+Bundle-Version: 1.6.600.qualifier
 Bundle-SymbolicName: org.eclipse.equinox.metatype
 Bundle-Activator: org.eclipse.equinox.metatype.impl.Activator
 Import-Package: javax.xml.parsers,

--- a/bundles/org.eclipse.equinox.metatype/src/org/eclipse/equinox/metatype/impl/MetaTypeProviderTracker.java
+++ b/bundles/org.eclipse.equinox.metatype/src/org/eclipse/equinox/metatype/impl/MetaTypeProviderTracker.java
@@ -34,9 +34,8 @@ public class MetaTypeProviderTracker implements EquinoxMetaTypeInformation {
 	 * Constructs a MetaTypeProviderTracker which tracks all MetaTypeProviders
 	 * registered by the specified bundle.
 	 * 
-	 * @param context The BundleContext of the MetaTypeService implementation
-	 * @param bundle  The bundle to track all MetaTypeProviders for.
-	 * @param log     The {@code LogService} to use for logging messages.
+	 * @param bundle The bundle to track all MetaTypeProviders for.
+	 * @param log    The {@code LogService} to use for logging messages.
 	 */
 	public MetaTypeProviderTracker(Bundle bundle, LogTracker log, ServiceTracker<Object, Object> tracker) {
 		this._bundle = bundle;

--- a/bundles/org.eclipse.equinox.security.ui/src/org/eclipse/equinox/internal/provisional/security/ui/X500PrincipalHelper.java
+++ b/bundles/org.eclipse.equinox.security.ui/src/org/eclipse/equinox/internal/provisional/security/ui/X500PrincipalHelper.java
@@ -15,7 +15,8 @@
 
 package org.eclipse.equinox.internal.provisional.security.ui;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
 import javax.security.auth.x500.X500Principal;
 
 /**
@@ -61,7 +62,6 @@ public class X500PrincipalHelper {
 
 	/**
 	 * Set the X500Principal name object to be parsed.
-	 * <p>
 	 * 
 	 * @param principal - X500Principal
 	 */
@@ -73,7 +73,6 @@ public class X500PrincipalHelper {
 	 * Gets the most significant common name (CN) attribute from the given
 	 * X500Principal object. For names that contains multiple attributes of this
 	 * type. The first (most significant) one will be returned
-	 * <p>
 	 * 
 	 * @return the Most significant common name attribute.
 	 */
@@ -85,7 +84,6 @@ public class X500PrincipalHelper {
 	 * Gets the most significant Organizational Unit (OU) attribute from the given
 	 * X500Principal object. For names that contains multiple attributes of this
 	 * type. The first (most significant) one will be returned
-	 * <p>
 	 * 
 	 * @return the Most significant OU attribute.
 	 */
@@ -99,7 +97,6 @@ public class X500PrincipalHelper {
 	 * Gets the most significant Organization (O) attribute from the given
 	 * X500Principal object. For names that contains multiple attributes of this
 	 * type. The first (most significant) one will be returned
-	 * <p>
 	 * 
 	 * @return the Most significant O attribute.
 	 */
@@ -111,7 +108,6 @@ public class X500PrincipalHelper {
 
 	/**
 	 * Gets the Country (C) attribute from the given X500Principal object.
-	 * <p>
 	 * 
 	 * @return the C attribute.
 	 */
@@ -121,7 +117,6 @@ public class X500PrincipalHelper {
 
 	/**
 	 * Gets the Locale (L) attribute from the given X500Principal object.
-	 * <p>
 	 * 
 	 * @return the L attribute.
 	 */
@@ -131,7 +126,6 @@ public class X500PrincipalHelper {
 
 	/**
 	 * Gets the State (ST) attribute from the given X500Principal object.
-	 * <p>
 	 * 
 	 * @return the ST attribute.
 	 */
@@ -141,7 +135,6 @@ public class X500PrincipalHelper {
 
 	/**
 	 * Gets the Street (STREET) attribute from the given X500Principal object.
-	 * <p>
 	 * 
 	 * @return the STREET attribute.
 	 */
@@ -152,7 +145,6 @@ public class X500PrincipalHelper {
 	/**
 	 * Gets the Email Address (EMAILADDRESS) attribute from the given X500Principal
 	 * object.
-	 * <p>
 	 * 
 	 * @return the EMAILADDRESS attribute.
 	 */
@@ -217,7 +209,6 @@ public class X500PrincipalHelper {
 	/**
 	 * Returns an ArrayList containing all the values for the given attribute
 	 * identifier.
-	 * <p>
 	 * 
 	 * @param attributeID String containing the X500 name attribute whose values are
 	 *                    to be returned

--- a/bundles/org.eclipse.equinox.transforms.hook/src/org/eclipse/equinox/internal/transforms/TransformedBundleFile.java
+++ b/bundles/org.eclipse.equinox.transforms.hook/src/org/eclipse/equinox/internal/transforms/TransformedBundleFile.java
@@ -46,7 +46,7 @@ public class TransformedBundleFile extends BundleFileWrapper {
 	 * the transformed entity is returned instead of the original.
 	 * 
 	 * @param transformerHook the transformer hook
-	 * @param data            the original data
+	 * @param generation      the original data
 	 * @param delegate        the original file
 	 */
 	public TransformedBundleFile(TransformerHook transformerHook, Generation generation, BundleFile delegate) {

--- a/bundles/org.eclipse.equinox.weaving.caching/src/org/eclipse/equinox/weaving/internal/caching/BundleCachingService.java
+++ b/bundles/org.eclipse.equinox.weaving.caching/src/org/eclipse/equinox/weaving/internal/caching/BundleCachingService.java
@@ -35,11 +35,8 @@ import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 
 /**
- * <p>
  * {@link ICachingService} instantiated by {@link CachingServiceFactory} for
  * each bundle.
- * </p>
- * <p>
  *
  * @author Heiko Seeberger
  * @author Martin Lippert
@@ -112,18 +109,11 @@ public class BundleCachingService implements ICachingService {
 		}
 	}
 
-	/**
-	 * @see org.eclipse.equinox.service.weaving.ICachingService#canCacheGeneratedClasses()
-	 */
 	@Override
 	public boolean canCacheGeneratedClasses() {
 		return true;
 	}
 
-	/**
-	 * @see org.eclipse.equinox.service.weaving.ICachingService#findStoredClass(java.lang.String,
-	 *      java.net.URL, java.lang.String)
-	 */
 	@Override
 	public CacheEntry findStoredClass(final String namespace, final URL sourceFileURL, final String name) {
 
@@ -239,10 +229,6 @@ public class BundleCachingService implements ICachingService {
 	public void stop() {
 	}
 
-	/**
-	 * @see org.eclipse.equinox.service.weaving.ICachingService#storeClass(java.lang.String,
-	 *      java.net.URL, java.lang.Class, byte[])
-	 */
 	@Override
 	public boolean storeClass(final String namespace, final URL sourceFileURL, final Class<?> clazz,
 			final byte[] classbytes) {
@@ -266,10 +252,6 @@ public class BundleCachingService implements ICachingService {
 		return queued;
 	}
 
-	/**
-	 * @see org.eclipse.equinox.service.weaving.ICachingService#storeClassAndGeneratedClasses(java.lang.String,
-	 *      java.net.URL, java.lang.Class, byte[], java.util.Map)
-	 */
 	@Override
 	public boolean storeClassAndGeneratedClasses(final String namespace, final URL sourceFileUrl, final Class<?> clazz,
 			final byte[] classbytes, final Map<String, byte[]> generatedClasses) {


### PR DESCRIPTION
As reported in the build:
* wrong params
* unclosed tags
* useless see tags