### PR TITLE
Force signing of split package bundles to use new certificate

### DIFF
--- a/bundles/org.eclipse.equinox.common/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.common/forceQualifierUpdate.txt
@@ -5,3 +5,4 @@ Bug 529356 - Build failure in I20180102-2215
 Bug 566471 - I20200828-0150 - Comparator Errors Found
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation #1139
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2044

--- a/bundles/org.eclipse.equinox.registry/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.registry/forceQualifierUpdate.txt
@@ -5,3 +5,4 @@ Bug 531640 - New certificate conflict
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation #1139
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1923
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2044


### PR DESCRIPTION
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2044