### PR TITLE
[Build] Derive TARGET_ARCH from -arch argument in make_win64.mak

### DIFF
--- a/bundles/org.eclipse.equinox.launcher.win32.win32.aarch64/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.launcher.win32.win32.aarch64/META-INF/MANIFEST.MF
@@ -3,8 +3,8 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.equinox.launcher.win32.win32.aarch64;singleton:=true
-Bundle-Version: 1.2.1000.qualifier
-Fragment-Host: org.eclipse.equinox.launcher;bundle-version="[1.5.0,1.7.0)"
+Bundle-Version: 1.2.1100.qualifier
+Fragment-Host: org.eclipse.equinox.launcher;bundle-version="[1.6.0,1.7.0)"
 Eclipse-PlatformFilter: (& (osgi.ws=win32) (osgi.os=win32) (osgi.arch=aarch64))
 Bundle-Localization: launcher.win32.win32.aarch64
 Eclipse-BundleShape: dir

--- a/bundles/org.eclipse.equinox.launcher.win32.win32.x86_64/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.launcher.win32.win32.x86_64/META-INF/MANIFEST.MF
@@ -3,8 +3,8 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.equinox.launcher.win32.win32.x86_64;singleton:=true
-Bundle-Version: 1.2.1000.qualifier
-Fragment-Host: org.eclipse.equinox.launcher;bundle-version="[1.5.0,1.7.0)"
+Bundle-Version: 1.2.1100.qualifier
+Fragment-Host: org.eclipse.equinox.launcher;bundle-version="[1.6.0,1.7.0)"
 Eclipse-PlatformFilter: (& (osgi.ws=win32) (osgi.os=win32) (osgi.arch=x86_64))
 Bundle-Localization: launcher.win32.win32.x86_64
 Eclipse-BundleShape: dir

--- a/bundles/org.eclipse.equinox.launcher/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.launcher/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.launcher;singleton:=true
-Bundle-Version: 1.6.800.qualifier
+Bundle-Version: 1.6.900.qualifier
 Main-Class: org.eclipse.equinox.launcher.Main
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/features/org.eclipse.equinox.core.sdk/feature.xml
+++ b/features/org.eclipse.equinox.core.sdk/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.equinox.core.sdk"
       label="%featureName"
-      version="3.25.100.qualifier"
+      version="3.25.200.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">


### PR DESCRIPTION
This allows cross-compilation on Windows between x86_64 and aarch64 by specifying the `-arch` argument as usual when calling the win32/build.bat script.

@chirontt do you see any problem with this?