### PR TITLE
[Build] Assume new equinox.binaries repo name by default in scripts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,9 +28,9 @@ jobs:
     - name: checkout equinox.binaries
       uses: actions/checkout@v4
       with:
-       fetch-depth: 1 # only shallow here, we don't have jgit timestamps
-       repository: eclipse-equinox/equinox.binaries
-       path: rt.equinox.binaries
+        fetch-depth: 1 # only shallow here, we don't have jgit timestamps
+        repository: eclipse-equinox/equinox.binaries
+        path: equinox.binaries
     - name: Set up JDK 17
       uses: actions/setup-java@v4
       with:
@@ -54,7 +54,7 @@ jobs:
     - name: Build with Maven
       uses: coactions/setup-xvfb@v1
       env:
-        EQUINOX_BINARIES_LOC: ${{ github.workspace }}/rt.equinox.binaries
+        EQUINOX_BINARIES_LOC: ${{ github.workspace }}/equinox.binaries
       with:
        working-directory: equinox
        run: >- 
@@ -65,7 +65,7 @@ jobs:
         -Dcompare-version-with-baselines.skip=false
         -Dmaven.test.failure.ignore=true
         -Dnative=${{ matrix.config.ws }}.${{ matrix.config.os }}.x86_64
-        -Drt.equinox.binaries.loc=${{ github.workspace }}/rt.equinox.binaries
+        -Dequinox.binaries.loc=${{ github.workspace }}/equinox.binaries
         clean verify
     - name: Upload native artifacts
       uses: actions/upload-artifact@v4
@@ -73,8 +73,8 @@ jobs:
       with:
         name: ${{ matrix.config.name }} launcher artifacts
         path: |
-          rt.equinox.binaries/org.eclipse.equinox.executable/bin/${{ matrix.config.ws }}/${{ matrix.config.os }}/x86_64/**/eclipse*
-          rt.equinox.binaries/org.eclipse.equinox.launcher.${{ matrix.config.ws }}.${{ matrix.config.os }}.x86_64/eclipse_*.${{ matrix.config.native-extension }}
+          equinox.binaries/org.eclipse.equinox.executable/bin/${{ matrix.config.ws }}/${{ matrix.config.os }}/x86_64/**/eclipse*
+          equinox.binaries/org.eclipse.equinox.launcher.${{ matrix.config.ws }}.${{ matrix.config.os }}.x86_64/eclipse_*.${{ matrix.config.native-extension }}
         if-no-files-found: error
     - name: Upload ${{ matrix.config.name }} Test Results
       uses: actions/upload-artifact@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,7 +38,7 @@ jobs:
       with:
        fetch-depth: 1 # only shallow here, we don't have jgit timestamps
        repository: eclipse-equinox/equinox.binaries
-       path: rt.equinox.binaries
+       path: equinox.binaries
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3
@@ -69,7 +69,7 @@ jobs:
         -Papi-check
         -Dcompare-version-with-baselines.skip=false
         -Dmaven.test.failure.ignore=true
-        -Drt.equinox.binaries.loc=${{ github.workspace }}/rt.equinox.binaries
+        -Dequinox.binaries.loc=${{ github.workspace }}/equinox.binaries
         -DskipTests=true
         clean verify
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -323,7 +323,7 @@ pipeline {
 					sh '''
 						mvn clean verify --batch-mode --fail-at-end -Dmaven.repo.local=$WORKSPACE/.m2/repository \
 							-Pbree-libs -Papi-check -Pjavadoc\
-							-Drt.equinox.binaries.loc=$WORKSPACE/equinox.binaries
+							-Dequinox.binaries.loc=$WORKSPACE/equinox.binaries
 					'''
 				}
 			}

--- a/bundles/org.eclipse.equinox.launcher.cocoa.macosx.aarch64/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.launcher.cocoa.macosx.aarch64/META-INF/MANIFEST.MF
@@ -3,8 +3,8 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.equinox.launcher.cocoa.macosx.aarch64;singleton:=true
-Bundle-Version: 1.2.1000.qualifier
-Fragment-Host: org.eclipse.equinox.launcher;bundle-version="[1.5.0,1.7.0)"
+Bundle-Version: 1.2.1100.qualifier
+Fragment-Host: org.eclipse.equinox.launcher;bundle-version="[1.6.0,1.7.0)"
 Eclipse-PlatformFilter: (& (osgi.ws=cocoa) (osgi.os=macosx) (osgi.arch=aarch64) )
 Bundle-Localization: launcher.cocoa.macosx.aarch64
 Eclipse-BundleShape: dir

--- a/bundles/org.eclipse.equinox.launcher.cocoa.macosx.x86_64/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.launcher.cocoa.macosx.x86_64/META-INF/MANIFEST.MF
@@ -3,8 +3,8 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.equinox.launcher.cocoa.macosx.x86_64;singleton:=true
-Bundle-Version: 1.2.1000.qualifier
-Fragment-Host: org.eclipse.equinox.launcher;bundle-version="[1.5.0,1.7.0)"
+Bundle-Version: 1.2.1100.qualifier
+Fragment-Host: org.eclipse.equinox.launcher;bundle-version="[1.6.0,1.7.0)"
 Eclipse-PlatformFilter: (& (osgi.ws=cocoa) (osgi.os=macosx) (osgi.arch=x86_64) )
 Bundle-Localization: launcher.cocoa.macosx.x86_64
 Eclipse-BundleShape: dir

--- a/bundles/org.eclipse.equinox.launcher.cocoa.macosx/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.launcher.cocoa.macosx/META-INF/MANIFEST.MF
@@ -3,8 +3,8 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.equinox.launcher.cocoa.macosx;singleton:=true
-Bundle-Version: 1.2.1000.qualifier
-Fragment-Host: org.eclipse.equinox.launcher;bundle-version="[1.5.0,1.7.0)"
+Bundle-Version: 1.2.1100.qualifier
+Fragment-Host: org.eclipse.equinox.launcher;bundle-version="[1.6.0,1.7.0)"
 Eclipse-PlatformFilter: (& (osgi.ws=cocoa) (osgi.os=macosx) (osgi.arch=aarch64) )
 Bundle-Localization: launcher.cocoa.macosx.aarch64
 Eclipse-BundleShape: dir

--- a/bundles/org.eclipse.equinox.launcher.gtk.linux.aarch64/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.launcher.gtk.linux.aarch64/META-INF/MANIFEST.MF
@@ -3,8 +3,8 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.equinox.launcher.gtk.linux.aarch64;singleton:=true
-Bundle-Version: 1.2.1000.qualifier
-Fragment-Host: org.eclipse.equinox.launcher;bundle-version="[1.5.0,1.7.0)"
+Bundle-Version: 1.2.1100.qualifier
+Fragment-Host: org.eclipse.equinox.launcher;bundle-version="[1.6.0,1.7.0)"
 Eclipse-PlatformFilter: (& (osgi.ws=gtk) (osgi.os=linux) (osgi.arch=aarch64))
 Bundle-Localization: launcher.gtk.linux.aarch64
 Eclipse-BundleShape: dir

--- a/bundles/org.eclipse.equinox.launcher.gtk.linux.loongarch64/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.launcher.gtk.linux.loongarch64/META-INF/MANIFEST.MF
@@ -3,8 +3,8 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.equinox.launcher.gtk.linux.loongarch64;singleton:=true
-Bundle-Version: 1.2.1000.qualifier
-Fragment-Host: org.eclipse.equinox.launcher;bundle-version="[1.5.0,1.7.0)"
+Bundle-Version: 1.2.1100.qualifier
+Fragment-Host: org.eclipse.equinox.launcher;bundle-version="[1.6.0,1.7.0)"
 Eclipse-PlatformFilter: (& (osgi.ws=gtk) (osgi.os=linux) (osgi.arch=loongarch64))
 Bundle-Localization: launcher.gtk.linux.loongarch64
 Eclipse-BundleShape: dir

--- a/bundles/org.eclipse.equinox.launcher.gtk.linux.ppc64le/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.launcher.gtk.linux.ppc64le/META-INF/MANIFEST.MF
@@ -3,8 +3,8 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.equinox.launcher.gtk.linux.ppc64le;singleton:=true
-Bundle-Version: 1.2.1000.qualifier
-Fragment-Host: org.eclipse.equinox.launcher;bundle-version="[1.5.0,1.7.0)"
+Bundle-Version: 1.2.1100.qualifier
+Fragment-Host: org.eclipse.equinox.launcher;bundle-version="[1.6.0,1.7.0)"
 Eclipse-PlatformFilter: (& (osgi.ws=gtk) (osgi.os=linux) (osgi.arch=ppc64le))
 Bundle-Localization: launcher.gtk.linux.ppc64le
 Eclipse-BundleShape: dir

--- a/bundles/org.eclipse.equinox.launcher.gtk.linux.x86_64/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.launcher.gtk.linux.x86_64/META-INF/MANIFEST.MF
@@ -3,8 +3,8 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.equinox.launcher.gtk.linux.x86_64;singleton:=true
-Bundle-Version: 1.2.1000.qualifier
-Fragment-Host: org.eclipse.equinox.launcher;bundle-version="[1.5.0,1.7.0)"
+Bundle-Version: 1.2.1100.qualifier
+Fragment-Host: org.eclipse.equinox.launcher;bundle-version="[1.6.0,1.7.0)"
 Eclipse-PlatformFilter: (& (osgi.ws=gtk) (osgi.os=linux) (osgi.arch=x86_64))
 Bundle-Localization: launcher.gtk.linux.x86_64
 Eclipse-BundleShape: dir

--- a/bundles/org.eclipse.equinox.launcher.win32.win32.aarch64/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.launcher.win32.win32.aarch64/META-INF/MANIFEST.MF
@@ -3,8 +3,8 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.equinox.launcher.win32.win32.aarch64;singleton:=true
-Bundle-Version: 1.2.1000.qualifier
-Fragment-Host: org.eclipse.equinox.launcher;bundle-version="[1.5.0,1.7.0)"
+Bundle-Version: 1.2.1100.qualifier
+Fragment-Host: org.eclipse.equinox.launcher;bundle-version="[1.6.0,1.7.0)"
 Eclipse-PlatformFilter: (& (osgi.ws=win32) (osgi.os=win32) (osgi.arch=aarch64))
 Bundle-Localization: launcher.win32.win32.aarch64
 Eclipse-BundleShape: dir

--- a/bundles/org.eclipse.equinox.launcher.win32.win32.x86_64/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.launcher.win32.win32.x86_64/META-INF/MANIFEST.MF
@@ -3,8 +3,8 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.equinox.launcher.win32.win32.x86_64;singleton:=true
-Bundle-Version: 1.2.1000.qualifier
-Fragment-Host: org.eclipse.equinox.launcher;bundle-version="[1.5.0,1.7.0)"
+Bundle-Version: 1.2.1100.qualifier
+Fragment-Host: org.eclipse.equinox.launcher;bundle-version="[1.6.0,1.7.0)"
 Eclipse-PlatformFilter: (& (osgi.ws=win32) (osgi.os=win32) (osgi.arch=x86_64))
 Bundle-Localization: launcher.win32.win32.x86_64
 Eclipse-BundleShape: dir

--- a/bundles/org.eclipse.equinox.launcher/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.launcher/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.launcher;singleton:=true
-Bundle-Version: 1.6.800.qualifier
+Bundle-Version: 1.6.900.qualifier
 Main-Class: org.eclipse.equinox.launcher.Main
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/features/org.eclipse.equinox.core.sdk/feature.xml
+++ b/features/org.eclipse.equinox.core.sdk/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.equinox.core.sdk"
       label="%featureName"
-      version="3.25.100.qualifier"
+      version="3.25.200.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/features/org.eclipse.equinox.executable.feature/library/cocoa/build.sh
+++ b/features/org.eclipse.equinox.executable.feature/library/cocoa/build.sh
@@ -62,7 +62,7 @@ PROGRAM_OUTPUT="$programOutput"
 DEFAULT_OS="$defaultOS"
 DEFAULT_WS="$defaultWS"
 DEPLOYMENT_TARGET=11.0
-if [ "$BINARIES_DIR" = "" ]; then BINARIES_DIR="../../../../../rt.equinox.binaries"; fi
+if [ "$BINARIES_DIR" = "" ]; then BINARIES_DIR="../../../../../equinox.binaries"; fi
 
 if [ "$defaultOSArch" == "arm64" ] || [ "$defaultOSArch" == "aarch64" ]
 then

--- a/features/org.eclipse.equinox.executable.feature/library/gtk/build.sh
+++ b/features/org.eclipse.equinox.executable.feature/library/gtk/build.sh
@@ -39,7 +39,7 @@ programOutput="eclipse"
 defaultOS=""
 defaultOSArch=""
 defaultWS="gtk"
-if [ "$BINARIES_DIR" = "" ]; then BINARIES_DIR="../../../../../rt.equinox.binaries"; fi
+if [ "$BINARIES_DIR" = "" ]; then BINARIES_DIR="../../../../../equinox.binaries"; fi
 defaultJava=DEFAULT_JAVA_JNI
 defaultJavaHome=""
 javaHome=""

--- a/features/org.eclipse.equinox.executable.feature/library/win32/build.bat
+++ b/features/org.eclipse.equinox.executable.feature/library/win32/build.bat
@@ -151,7 +151,7 @@ set DEFAULT_OS=%defaultOS%
 set DEFAULT_OS_ARCH=%defaultOSArch%
 set DEFAULT_WS=%defaultWS%
 set JAVA_HOME=%javaHome%
-IF "%BINARIES_DIR%"=="" set "BINARIES_DIR=..\..\..\..\..\rt.equinox.binaries"
+IF "%BINARIES_DIR%"=="" set "BINARIES_DIR=..\..\..\..\..\equinox.binaries"
 IF "%EXE_OUTPUT_DIR%"=="" set "EXE_OUTPUT_DIR=%BINARIES_DIR%\org.eclipse.equinox.executable\bin\%defaultWS%\%defaultOS%\%defaultOSArch%"
 IF "%LIB_OUTPUT_DIR%"=="" set "LIB_OUTPUT_DIR=%BINARIES_DIR%\org.eclipse.equinox.launcher.%defaultWS%.%defaultOS%.%defaultOSArch%"
 

--- a/features/org.eclipse.equinox.executable.feature/pom.xml
+++ b/features/org.eclipse.equinox.executable.feature/pom.xml
@@ -119,7 +119,7 @@
                       them -->
                     <echo message="Copy eclipse binaries to launcher binaries" level="info"/>
                     <copy todir="bin" verbose="true" includeEmptyDirs="false" failonerror="true">
-                      <fileset dir="${rt.equinox.binaries.loc}/org.eclipse.equinox.executable/bin/">
+                      <fileset dir="${equinox.binaries.loc}/org.eclipse.equinox.executable/bin/">
                         <include name="cocoa/macosx/x86_64/**/*"/>
                         <include name="cocoa/macosx/aarch64/**/*"/>
                         <include name="gtk/linux/ppc64le/**/*"/>

--- a/launcher-binary-parent/pom.xml
+++ b/launcher-binary-parent/pom.xml
@@ -42,7 +42,7 @@
         <configuration>
           <additionalFileSets>
             <fileSet>
-              <directory>${rt.equinox.binaries.loc}/${project.artifactId}</directory>
+              <directory>${equinox.binaries.loc}/${project.artifactId}</directory>
               <includes>
                 <include>*.so</include>
                 <include>*.dll</include>

--- a/pom.xml
+++ b/pom.xml
@@ -25,10 +25,10 @@
 
   <properties>
     <tycho.scmUrl>scm:git:https://github.com/eclipse-equinox/equinox.git</tycho.scmUrl>
-    <!-- location of rt.equinox.binaries project -->
+    <!-- location of equinox.binaries project -->
     <!-- required by: org.eclipse.equinox.feature:org.eclipse.equinox.executable -->
     <!-- required by: org.eclipse.equinox.framework:launcher-binary-parent -->
-    <rt.equinox.binaries.loc>../../../rt.equinox.binaries</rt.equinox.binaries.loc>
+    <equinox.binaries.loc>../../../equinox.binaries</equinox.binaries.loc>
     <target-platform.optionalDependencies>require</target-platform.optionalDependencies>
   </properties>
 


### PR DESCRIPTION
Because the repository containing the Equinox binaries is now named 'eclipse-equinox/equinox.binaries' its folder is, by default, named 'equinox.binaries' after cloning it.
In order to simplify contributions that name should be assumed by default.

Accordingly rename the property 'rt.equinox.binaries.loc' used in the build to 'equinox.binaries.loc'.

@tjwatson do you have any objections?