### PR TITLE
Extend StateBuilder to handle EE from Require-Capability header

### DIFF
--- a/bundles/org.eclipse.osgi.compatibility.state/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.osgi.compatibility.state/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.osgi.compatibility.state
-Bundle-Version: 1.2.1000.qualifier
+Bundle-Version: 1.2.1100.qualifier
 ExtensionBundle-Activator: org.eclipse.osgi.compatibility.state.Activator
 Fragment-Host: org.eclipse.osgi;bundle-version="3.12.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8


### PR DESCRIPTION
With this change, the BundleDescription instance that is returned by the StateBuilder now also contains the execution environments that are required by the Require-Capability header, rather than only the Bundle-RequireExecutionEnvironment header.

Previously, a call to getExecutionEnvironments() would always return an empty array, if a bundle lacks the Bundle-RequireExecutionEnvironment header, even though a minimum version is required as a capability.

Resolves https://github.com/eclipse-equinox/equinox/issues/643