### PR TITLE
Fix BasicLocation set method when read-only and lock requested

### DIFF
--- a/bundles/org.eclipse.osgi.tests/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.osgi.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Core OSGi Tests
 Bundle-SymbolicName: org.eclipse.osgi.tests;singleton:=true
-Bundle-Version: 3.19.100.qualifier
+Bundle-Version: 3.20.100.qualifier
 Bundle-Vendor: Eclipse.org
 Require-Bundle: 
  org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",

--- a/bundles/org.eclipse.osgi.tests/pom.xml
+++ b/bundles/org.eclipse.osgi.tests/pom.xml
@@ -19,7 +19,7 @@
 </parent>
   <groupId>org.eclipse.osgi</groupId>
   <artifactId>org.eclipse.osgi.tests</artifactId>
-  <version>3.19.100-SNAPSHOT</version>
+  <version>3.20.100-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <properties>

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/services/datalocation/BasicLocationTests.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/services/datalocation/BasicLocationTests.java
@@ -24,6 +24,7 @@ import static org.junit.Assume.assumeTrue;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -42,7 +43,6 @@ import org.eclipse.osgi.launch.Equinox;
 import org.eclipse.osgi.service.datalocation.Location;
 import org.eclipse.osgi.tests.OSGiTestsActivator;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -164,17 +164,19 @@ public class BasicLocationTests {
 	}
 
 	@Test
-	public void testCreateLocation04() {
+	public void testCreateLocation04() throws IllegalStateException, MalformedURLException, IOException {
 		Location configLocation = configLocationTracker.getService();
 		File testLocationFile = OSGiTestsActivator.getContext().getDataFile("testLocations/testCreateLocation04");
 		Location testLocation = configLocation.createLocation(null, null, true);
-		try {
-			testLocation.set(testLocationFile.toURL(), true);
+		// note that if read-only and lock was requested then false is returned; but the
+		// location is set
+		assertFalse("Could not set location", testLocation.set(testLocationFile.toURL(), true));
+		assertTrue("Location should be set", testLocation.isSet());
+
+		assertThrows("Should not be able to lock read-only location", IOException.class, () -> {
+			assertTrue("Could not lock location", testLocation.lock());
 			testLocation.release();
-			Assert.fail("Should not be able to lock read-only location");
-		} catch (Throwable t) {
-			// expected
-		}
+		});
 	}
 
 	@Test

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/services/datalocation/BasicLocationTests.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/services/datalocation/BasicLocationTests.java
@@ -180,15 +180,14 @@ public class BasicLocationTests {
 	}
 
 	@Test
-	public void testCreateLocation05() {
+	public void testCreateLocation05() throws IllegalStateException, MalformedURLException, IOException {
 		Location configLocation = configLocationTracker.getService();
 		File testLocationFile = OSGiTestsActivator.getContext().getDataFile("testLocations/testCreateLocation01");
 		Location testLocation = configLocation.createLocation(null, null, false);
-		try {
-			testLocation.set(testLocationFile.toURL(), false);
-		} catch (Throwable t) {
-			fail("Failed to set location", t);
-		}
+
+		assertTrue("Could not set location", testLocation.set(testLocationFile.toURL(), false));
+		assertTrue("Location should be set", testLocation.isSet());
+
 		try {
 			assertTrue("Could not lock location", testLocation.lock());
 			assertFalse("Could lock a secend time", testLocation.lock());

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/location/BasicLocation.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/location/BasicLocation.java
@@ -136,6 +136,7 @@ public class BasicLocation implements Location {
 	@Override
 	public synchronized boolean set(URL value, boolean lock, String lockFilePath)
 			throws IllegalStateException, IOException {
+		boolean gotLock = false;
 		synchronized (this) {
 			if (location != null)
 				throw new IllegalStateException(Msg.ECLIPSE_CANNOT_CHANGE_LOCATION);
@@ -159,10 +160,11 @@ public class BasicLocation implements Location {
 					file = new File(value.getPath(), DEFAULT_LOCK_FILENAME);
 				}
 			}
-			lock = lock && !isReadOnly;
-			if (lock) {
-				if (!lock(file, value))
+			if (lock && !isReadOnly) {
+				if (!lock(file, value)) {
 					return false;
+				}
+				gotLock = true;
 			}
 			lockFile = file;
 			location = value;
@@ -171,7 +173,7 @@ public class BasicLocation implements Location {
 			}
 		}
 		updateUrl(serviceRegistration);
-		return lock;
+		return lock ? gotLock : true;
 	}
 
 	private void updateUrl(ServiceRegistration<?> registration) {

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/location/BasicLocation.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/location/BasicLocation.java
@@ -171,7 +171,7 @@ public class BasicLocation implements Location {
 			}
 		}
 		updateUrl(serviceRegistration);
-		return true;
+		return lock;
 	}
 
 	private void updateUrl(ServiceRegistration<?> registration) {


### PR DESCRIPTION
https://github.com/eclipse-equinox/equinox.framework/pull/39 PR introduced a breaking change that always returned true with a read-only location and lock was requested to the set method.

The testCreateLocation04 method also needed fixing to properly test this case.

Fixes #460