### PR TITLE
Remove unnecessary casts

### DIFF
--- a/bundles/org.eclipse.equinox.app/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.app/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.app; singleton:=true
-Bundle-Version: 1.7.100.qualifier
+Bundle-Version: 1.7.200.qualifier
 Bundle-Vendor: %providerName
 Bundle-Activator: org.eclipse.equinox.internal.app.Activator
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.equinox.app/src/org/eclipse/equinox/internal/app/EclipseAppContainer.java
+++ b/bundles/org.eclipse.equinox.app/src/org/eclipse/equinox/internal/app/EclipseAppContainer.java
@@ -568,7 +568,7 @@ public class EclipseAppContainer
 					.getCardinalityType() == EclipseAppDescriptor.FLAG_CARD_LIMITED) {
 				if (activeLimited != null) {
 					ArrayList<EclipseAppHandle> limited = activeLimited
-							.get(((EclipseAppDescriptor) appHandle.getApplicationDescriptor()).getApplicationId());
+							.get(appHandle.getApplicationDescriptor().getApplicationId());
 					if (limited != null)
 						limited.remove(appHandle);
 				}

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/serviceregistry/ServiceExceptionTests.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/serviceregistry/ServiceExceptionTests.java
@@ -212,7 +212,7 @@ public class ServiceExceptionTests extends AbstractBundleTests {
 				return;
 			if (!(event.getThrowable() instanceof ServiceException))
 				return;
-			if (((ServiceException) event.getThrowable()).getCause() != exception)
+			if (event.getThrowable().getCause() != exception)
 				return;
 			if (((ServiceException) event.getThrowable()).getType() != exceptionType)
 				return;

--- a/features/org.eclipse.equinox.compendium.sdk/feature.xml
+++ b/features/org.eclipse.equinox.compendium.sdk/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.equinox.compendium.sdk"
       label="%featureName"
-      version="3.23.100.qualifier"
+      version="3.23.200.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">


### PR DESCRIPTION
When https://github.com/eclipse-jdt/eclipse.jdt.core/pull/2471 is merged, ecj will signal more casts as unnecessary.

With this PR I suggest to remove affected casts before new warnings will show up in the build.