### PR TITLE
Build Equinox launcher binaries with MSVC 2022

### DIFF
--- a/features/org.eclipse.equinox.executable.feature/library/win32/build.bat
+++ b/features/org.eclipse.equinox.executable.feature/library/win32/build.bat
@@ -127,8 +127,6 @@ if "%MSVC_VERSION%"=="" set "MSVC_VERSION=auto"
 rem Search for a usable Visual Studio
 rem ---------------------------------
 if "%MSVC_HOME%"=="" echo "'MSVC_HOME' was not provided, auto-searching for Visual Studio..."
-rem Bug 574007: Path used on Azure build machines
-if "%MSVC_HOME%"=="" call :FindVisualStudio "%ProgramFiles(x86)%\Microsoft Visual Studio\$MSVC_VERSION$\BuildTools"
 rem Bug 578519: Common installation paths; VisualStudio is installed in x64 ProgramFiles since VS2022
 if "%MSVC_HOME%"=="" call :FindVisualStudio "%ProgramFiles%\Microsoft Visual Studio\$MSVC_VERSION$\$MSVC_EDITION$"
 if "%MSVC_HOME%"=="" call :FindVisualStudio "%ProgramFiles(x86)%\Microsoft Visual Studio\$MSVC_VERSION$\$MSVC_EDITION$"


### PR DESCRIPTION
Remove the MSVC search path specific for the Eclipse Releng Jenkins instance and MSVC 2019.

This should be submitted with https://github.com/eclipse-equinox/equinox/pull/595 in order to avoid extra rebuilds of the Windows binaries.