### PR TITLE
Allow interfacing with other adapter frameworks by using a proxy

### DIFF
--- a/bundles/org.eclipse.equinox.common/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.common/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.common; singleton:=true
-Bundle-Version: 3.19.100.qualifier
+Bundle-Version: 3.20.0.qualifier
 Bundle-Localization: plugin
 Export-Package: org.eclipse.core.internal.boot;x-friends:="org.eclipse.core.resources,org.eclipse.pde.build",
  org.eclipse.core.internal.runtime;common=split;mandatory:=common;

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/AdapterProxy.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/AdapterProxy.java
@@ -1,0 +1,42 @@
+package org.eclipse.core.runtime;
+
+/**
+ * <p>
+ * An {@link AdapterProxy} can be used to interface the Eclipse Adapter
+ * Framework with other techniques. To do so one has to provide a generic
+ * {@link IAdapterFactory} that adapts this other frameworks objects to the
+ * {@link AdapterProxy} interface, then as a last resort, the Eclipse Adapter
+ * Framework will ask this proxy as if the original object would have
+ * implemented {@link IAdaptable}.
+ * </p>
+ * <p>
+ * One example is the OSGi <a href=
+ * "https://docs.osgi.org/specification/osgi.cmpn/7.0.0/util.converter.html">Converter
+ * Specification</a> that allows to adapt/convert objects in an extensible way,
+ * therefore it is not possible to register a "classic" {@link IAdapterFactory}
+ * because the types that are probably convertible are unknown in advance. Also
+ * the objects itself can't be made to implement the {@link IAdaptable}
+ * interface. An implementation then might look like this:
+ * </p>
+ * 
+ * <pre>
+ * &#64;Component
+ * &#64;AdapterTypes(adaptableClass = Object.class, adapterNames = AdapterProxy.class)
+ * public class OSGiConverterProxyFactory implements IAdapterFactory {
+ * 
+ * 	&#64;Reference
+ * 	private Converter converter;
+ * 
+ * 	public <T> T getAdapter(Object adaptableObject, Class<T> adapterType) {
+ * 		Converting converting = converter.convert(adaptableObject);
+ * 		return converting.to(adapterType);
+ * 	}
+ * 
+ * }
+ * </pre>
+ * 
+ * @since 3.20
+ */
+public interface AdapterProxy extends IAdaptable {
+	// This is a specialized type that do not define any methods
+}

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/Adapters.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/Adapters.java
@@ -84,6 +84,13 @@ public class Adapters {
 
 		String adapterId = adapter.getName();
 		Object result = queryAdapterManager(sourceObject, adapterId, allowActivation);
+		if (result == null) {
+			// Last resort, this object is maybe using a different adaption technique
+			if (queryAdapterManager(sourceObject, AdapterProxy.class.getName(),
+					allowActivation) instanceof AdapterProxy proxy) {
+				result = proxy.getAdapter(adapter);
+			}
+		}
 		if (result != null) {
 			// Sanity-check
 			if (!adapter.isInstance(result)) {


### PR DESCRIPTION
While the Eclipse Adapter Framework is very powerful it currently  does not allow to interface with other adaption techniques (e.g. OSGi Converter Specification).

This adds a new way to adapt a class of objects to a proxy that then is asked for further adaption.