### PR TITLE
Synchronize jdt.compiler.targetPlatform in J2SE profiles

### DIFF
--- a/bundles/org.eclipse.osgi/J2SE-1.2.profile
+++ b/bundles/org.eclipse.osgi/J2SE-1.2.profile
@@ -48,6 +48,6 @@ org.osgi.framework.system.capabilities = \
 osgi.java.profile.name = J2SE-1.2
 org.eclipse.jdt.core.compiler.compliance=1.3
 org.eclipse.jdt.core.compiler.source=1.3
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.2
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=ignore
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=ignore

--- a/bundles/org.eclipse.osgi/J2SE-1.3.profile
+++ b/bundles/org.eclipse.osgi/J2SE-1.3.profile
@@ -106,6 +106,6 @@ org.osgi.framework.system.capabilities = \
 osgi.java.profile.name = J2SE-1.3
 org.eclipse.jdt.core.compiler.compliance=1.3
 org.eclipse.jdt.core.compiler.source=1.3
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.3
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=ignore
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=ignore

--- a/bundles/org.eclipse.osgi/J2SE-1.4.profile
+++ b/bundles/org.eclipse.osgi/J2SE-1.4.profile
@@ -175,6 +175,6 @@ org.osgi.framework.system.capabilities = \
 osgi.java.profile.name = J2SE-1.4
 org.eclipse.jdt.core.compiler.compliance=1.4
 org.eclipse.jdt.core.compiler.source=1.3
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.2
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.4
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=warning
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=warning


### PR DESCRIPTION
The org.eclipse.jdt.core.compiler.codegen.targetPlatform values in the J2SE profiles seem to not match what I would expect based on the Id of the profile and based on their description:
- https://docs.osgi.org/reference/eenames.html

These values where introduced in https://github.com/eclipse-equinox/equinox/commit/3165d6cdb5e10aa9d5163ee4cf7436bb65fb3ae6. The corresponding compliance settings where changed for example in
[Bug 268152](https://bugs.eclipse.org/bugs/show_bug.cgi?id=268152).

I don't know if there is a specific reason to have different values or if it was a mistake.
Given that ECJ is about to drop support for all Java version below 1.8 these values are probably irrelevant most of the time any ways. I just noticed it during my work for https://github.com/eclipse-pde/eclipse.pde/pull/1324, where this value influences the order of these old java versions (which is in practice also not very relevant anymore).

