### PR TITLE
[Build] Define k8-agent for linux.x86_64 natives completely in pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,12 +17,18 @@ def runOnNativeBuildAgent(String platform, Closure body) {
 	def final nativeBuildStageName = 'Perform native launcher build'
 	if (platform == 'gtk.linux.x86_64') {
 		podTemplate(inheritFrom: 'centos-latest' /* inhert general configuration */, containers: [
-			containerTemplate(name: 'launcherbuild', image: 'eclipse/platformreleng-centos-swt-build:8',
+			containerTemplate(name: 'jnlp', image: 'eclipsecbi/jiro-agent-centos-8',
 				resourceRequestCpu:'1000m', resourceRequestMemory:'512Mi',
 				resourceLimitCpu:'2000m', resourceLimitMemory:'4096Mi',
 				alwaysPullImage: true, command: 'cat', ttyEnabled: true)
 		]) {
-			node(POD_LABEL) { stage(nativeBuildStageName) { container('launcherbuild') { body() } } }
+			node(POD_LABEL) { stage(nativeBuildStageName) { container('jnlp') {
+				sh '''
+					#TODO try dnf
+					#sudo yum -y install gtk3-devel
+				'''
+				body()
+			} } }
 		}
 	} else {
 		if (platform == 'cocoa.macosx.x86_64') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,19 +16,18 @@
 def runOnNativeBuildAgent(String platform, Closure body) {
 	def final nativeBuildStageName = 'Perform native launcher build'
 	if (platform == 'gtk.linux.x86_64') {
-		podTemplate(inheritFrom: 'centos-latest' /* inhert general configuration */, containers: [
+		podTemplate(containers: [
 			containerTemplate(name: 'jnlp', image: 'eclipsecbi/jiro-agent-centos-8',
 				resourceRequestCpu:'1000m', resourceRequestMemory:'512Mi',
-				resourceLimitCpu:'2000m', resourceLimitMemory:'4096Mi',
-				alwaysPullImage: true, command: 'cat', ttyEnabled: true)
+				resourceLimitCpu:'2000m', resourceLimitMemory:'4096Mi'
+			)
 		]) {
-			node(POD_LABEL) { stage(nativeBuildStageName) { container('jnlp') {
+			node(POD_LABEL) { stage(nativeBuildStageName) {
 				sh '''
-					#TODO try dnf
-					#sudo yum -y install gtk3-devel
+					yum -y install gtk3-devel
 				'''
 				body()
-			} } }
+			} }
 		}
 	} else {
 		if (platform == 'cocoa.macosx.x86_64') {


### PR DESCRIPTION
This avoids the need to use customized docker images maintained in `eclipse.platform.releng.aggregator`.

This is similar to https://github.com/eclipse-platform/eclipse.platform.swt/pull/1332.