### PR TITLE
[Win32] Opt-in for long path capability in Eclipse application manifest

### DIFF
--- a/features/org.eclipse.equinox.executable.feature/library/win32/eclipse.exe.manifest
+++ b/features/org.eclipse.equinox.executable.feature/library/win32/eclipse.exe.manifest
@@ -8,8 +8,9 @@
 		</dependentAssembly>
 	</dependency>
 	<asmv3:application>
-		<asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">
-			<ms_windowsSettings:dpiAware xmlns:ms_windowsSettings="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</ms_windowsSettings:dpiAware>
+		<asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings" xmlns:ws2="http://schemas.microsoft.com/SMI/2016/WindowsSettings">
+			<dpiAware>true</dpiAware>
+			<ws2:longPathAware>true</ws2:longPathAware>
 		</asmv3:windowsSettings>
 	</asmv3:application>
 	<compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">


### PR DESCRIPTION
This allows an Eclipse application to avoid the path length limitation on Windows if additionally the limit disabled in the registry.

See
- https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=registry#application-manifest-updates-to-declare-long-path-capability
- https://learn.microsoft.com/en-us/windows/win32/sbscs/application-manifests#longPathAware