### PR TITLE
EclipsePreferences: use simple HashMap

### DIFF
--- a/bundles/org.eclipse.equinox.preferences/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.preferences/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.preferences; singleton:=true
-Bundle-Version: 3.11.100.qualifier
+Bundle-Version: 3.11.200.qualifier
 Bundle-Activator: org.eclipse.core.internal.preferences.Activator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.equinox.preferences/src/org/eclipse/core/internal/preferences/PreferencesService.java
+++ b/bundles/org.eclipse.equinox.preferences/src/org/eclipse/core/internal/preferences/PreferencesService.java
@@ -128,7 +128,7 @@ public class PreferencesService implements IPreferencesService {
 
 				// iterate over the preferences in this node and set them
 				// in the global space.
-				String[] keys = epNode.properties.keys();
+				String[] keys = epNode.keys();
 
 				// if this node was removed then we need to create a new one
 				if (removed) {

--- a/bundles/org.eclipse.equinox.preferences/src/org/eclipse/core/internal/preferences/RootPreferences.java
+++ b/bundles/org.eclipse.equinox.preferences/src/org/eclipse/core/internal/preferences/RootPreferences.java
@@ -48,23 +48,6 @@ public class RootPreferences extends EclipsePreferences {
 		}
 	}
 
-	private synchronized IEclipsePreferences getChild(String key) {
-		if (children == null) {
-			return null;
-		}
-		Object value = children.get(key);
-		if (value == null) {
-			return null;
-		}
-		if (value instanceof IEclipsePreferences eclipsePreferences) {
-			return eclipsePreferences;
-		}
-		// lazy initialization
-		IEclipsePreferences child = PreferencesService.getDefault().createNode(key);
-		addChild(key, child);
-		return child;
-	}
-
 	@Override
 	public Preferences node(String path) {
 		return getNode(path, true); // create if not found
@@ -79,11 +62,7 @@ public class RootPreferences extends EclipsePreferences {
 		String scope = path.substring(startIndex, endIndex == -1 ? path.length() : endIndex);
 		IEclipsePreferences child;
 		if (create) {
-			child = getChild(scope);
-			if (child == null) {
-				child = new EclipsePreferences(this, scope);
-				addChild(scope, child);
-			}
+			child = getOrCreate(scope);
 		} else {
 			child = getChild(scope, null, false);
 			if (child == null) {

--- a/features/org.eclipse.equinox.compendium.sdk/feature.xml
+++ b/features/org.eclipse.equinox.compendium.sdk/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.equinox.compendium.sdk"
       label="%featureName"
-      version="3.23.300.qualifier"
+      version="3.23.400.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">


### PR DESCRIPTION
Using a concurrent Map is a waste as every access is guarded by childAndPropertyLock anyway.

+ add missing guards (was used unguarded in RootPreferences)
+ make getChild(String key, Object context, boolean create) atomic