### PR TITLE
[Build] Replace use of coactions/setup-xvfb

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,8 +11,6 @@ on:
 
 jobs:
   build:
-    name: Build ${{ matrix.config.name }}
-    runs-on: ${{ matrix.config.runner-os }}
     strategy:
       fail-fast: false
       matrix:
@@ -20,6 +18,8 @@ jobs:
           - { name: Linux, runner-os: ubuntu-latest, ws: gtk, os: linux, native-extension: so }
           - { name: Windows, runner-os: windows-2019, ws: win32, os: win32, native-extension: dll }
           - { name: MacOS, runner-os: macos-13, ws: cocoa, os: macosx, native-extension: so }
+    name: Build ${{ matrix.config.name }}
+    runs-on: ${{ matrix.config.runner-os }}
     steps:
     - uses: actions/checkout@v4
       with:
@@ -45,13 +45,13 @@ jobs:
     - name: Set up Maven
       uses: stCarolas/setup-maven@v5
       with:
-        maven-version: 3.9.6
+        maven-version: 3.9.9
     - name: Install GTK requirements
       if: ${{ matrix.config.ws == 'gtk'}}
       run: |
         sudo apt-get update -q -y 
         sudo apt-get install -q -y libgtk-3-dev 
-    - name: Build with Maven
+    - name: Build
       uses: coactions/setup-xvfb@v1
       env:
         EQUINOX_BINARIES_LOC: ${{ github.workspace }}/equinox.binaries
@@ -101,7 +101,7 @@ jobs:
     - name: Set up Maven
       uses: stCarolas/setup-maven@v5
       with:
-        maven-version: 3.9.6
+        maven-version: 3.9.9
     - name: Run OSGi TCKs
       run: >- 
         mvn

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,9 @@ jobs:
           - { name: MacOS, runner-os: macos-13, ws: cocoa, os: macosx, native-extension: so }
     name: Build ${{ matrix.config.name }}
     runs-on: ${{ matrix.config.runner-os }}
+    defaults:
+      run: # Run on cmd on Windows because powershell interprets dots in arguments differently
+        shell: ${{ matrix.config.os == 'win32' && 'cmd' || 'bash' }}
     steps:
     - uses: actions/checkout@v4
       with:
@@ -52,12 +55,10 @@ jobs:
         sudo apt-get update -q -y 
         sudo apt-get install -q -y libgtk-3-dev 
     - name: Build
-      uses: coactions/setup-xvfb@v1
       env:
         EQUINOX_BINARIES_LOC: ${{ github.workspace }}/equinox.binaries
-      with:
-       working-directory: equinox
-       run: >- 
+      working-directory: equinox
+      run: >- 
         mvn
         --batch-mode
         -Pbree-libs

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,6 +33,7 @@ jobs:
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       with:
         fetch-depth: 0 # required for jgit timestamp provider to work
+        path: equinox
     - name: checkout equinox.binaries
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       with:
@@ -58,17 +59,16 @@ jobs:
     - name: Set up Maven
       uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1 # v5
       with:
-        maven-version: 3.9.6
-    - name: Build with Maven
+        maven-version: 3.9.9
+    - name: Build
       uses: coactions/setup-xvfb@6b00cf1889f4e1d5a48635647013c0508128ee1a
       with:
+       working-directory: equinox
        run: >- 
         mvn
         --batch-mode
         -Pbree-libs
         -Papi-check
-        -Dcompare-version-with-baselines.skip=false
-        -Dmaven.test.failure.ignore=true
         -Dequinox.binaries.loc=${{ github.workspace }}/equinox.binaries
         -DskipTests=true
         clean verify

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -61,10 +61,8 @@ jobs:
       with:
         maven-version: 3.9.9
     - name: Build
-      uses: coactions/setup-xvfb@6b00cf1889f4e1d5a48635647013c0508128ee1a
-      with:
-       working-directory: equinox
-       run: >- 
+      working-directory: equinox
+      run: >- 
         mvn
         --batch-mode
         -Pbree-libs


### PR DESCRIPTION
It will stop working on Oct 15 and is claimed to not be needed anymore in https://github.com/coactions/setup-xvfb/issues/29#issuecomment-2374414522