### PR TITLE
Enforce pick-up of linux.riscv64 root-files in equinox.executable.feature

### DIFF
--- a/features/org.eclipse.equinox.executable.feature/forceQualifierUpdate.txt
+++ b/features/org.eclipse.equinox.executable.feature/forceQualifierUpdate.txt
@@ -12,3 +12,4 @@ Bug 550714 - Comparator errors in I20190903-1110
 Bug 550674 - Specify hardened runtime for Mac app signing
 Bug 551174 - Comparator errors in 4.14 I build - I20190917-1800
 Bug 578952 - Add LoongArch64 Support
+Pick up linux.riscv64 support - https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2310


### PR DESCRIPTION
This allows to pick-up the new root-files for linux.riscv64 contributed via https://github.com/eclipse-equinox/equinox/pull/669.

This should unblock https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/2394 and should be reverted once that is submitted and has passed an I-build, together with
https://github.com/eclipse-equinox/equinox/blob/abde0eb3e1bc4800582e4d9ee18e88c0f3890a4f/features/org.eclipse.equinox.executable.feature/pom.xml#L94-L107

Without this the root files for linux.riscv64 are removed during baseline-replacement because [`tycho-p2-plugin:p2-metadata#baselineReplace`](https://tycho.eclipseprojects.io/doc/4.0.9/tycho-p2-plugin/p2-metadata-mojo.html#baselineReplace) has the value `all` by default, which means: `Replace build artifacts with baseline version. Attached artifacts only present in the build are removed.`

The reason this wasn't necessary for win32.aarch64 in https://github.com/eclipse-equinox/equinox/pull/559 is probably because https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/577 was submitted before the next I-build happened and therefore the different qualifier of the `o.e.equinox.executable.feature` prevented a baseline replacement.