### PR TITLE
Revert temporary local addition of linux.riscv64 in executable.feature

### DIFF
--- a/features/org.eclipse.equinox.executable.feature/pom.xml
+++ b/features/org.eclipse.equinox.executable.feature/pom.xml
@@ -91,20 +91,6 @@
           </execution>
         </executions>
       </plugin>
-      <!-- Temporary work-around until gtk.linux.riscv64 environment is enabled in general. -->
-       <plugin>
-        <groupId>org.eclipse.tycho</groupId>
-        <artifactId>target-platform-configuration</artifactId>
-        <configuration>
-          <environments combine.children="append">
-            <environment>
-              <os>linux</os>
-              <ws>gtk</ws>
-              <arch>riscv64</arch>
-            </environment>
-          </environments>
-        </configuration>
-       </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
Now that the linux.riscv64 environment is enabled globally in https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/2394, the one temporarily added in https://github.com/eclipse-equinox/equinox/pull/669 can be removed again.
Part of https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2310