### PR TITLE
Do not expose the ServicePermission to users of URL

### DIFF
--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/url/URLStreamHandlerProxy.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/url/URLStreamHandlerProxy.java
@@ -235,7 +235,7 @@ public class URLStreamHandlerProxy extends URLStreamHandler {
 		@Override
 		public synchronized URLStreamHandlerService get() {
 			if (service == null && !disposed) {
-				service = bundleContext.getService(reference);
+				service = URLStreamHandlerFactoryImpl.secureAction.getService(reference, bundleContext);
 			}
 			return service;
 		}


### PR DESCRIPTION
An important doPriv was removed which protected callers of URL from the SerivcePermissin check to get the handler service.