### PR TITLE
[Oomph-Setup] Change Equinox configuration setup to contain only equinox

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ Equinox implements the follwoing specification with the given level of complianc
 - Asking questions and share ideas: https://github.com/eclipse-equinox/equinox/discussions
 
 # Contributing
-[![Create Eclipse Development Environment for Equinox](https://download.eclipse.org/oomph/www/setups/svg/Equinox.svg)](https://www.eclipse.org/setups/installer/?url=https://raw.githubusercontent.com/eclipse-equinox/equinox/master/releng/org.eclipse.equinox.releng/EquinoxConfiguration.setup&show=true "Click to open Eclipse-Installer Auto Launch or drag into your running installer")
 
 For detailed information about development, testing and builds, see [CONTRIBUTING.md](CONTRIBUTING.md).
+
+[![Create Eclipse Development Environment for Equinox](https://download.eclipse.org/oomph/www/setups/svg/Equinox.svg)](
+https://www.eclipse.org/setups/installer/?url=https://raw.githubusercontent.com/eclipse-equinox/equinox/master/releng/org.eclipse.equinox.releng/EquinoxConfiguration.setup&show=true
+"Click to open Eclipse-Installer Auto Launch or drag into your running installer")

--- a/releng/org.eclipse.equinox.releng/Equinox.setup
+++ b/releng/org.eclipse.equinox.releng/Equinox.setup
@@ -24,11 +24,6 @@
       <value>https://projects.eclipse.org/projects/eclipse.equinox</value>
     </detail>
   </annotation>
-  <annotation
-      source="http://www.eclipse.org/oomph/setup/ConfigurationReference">
-    <reference
-        href="EquinoxConfiguration.setup#/"/>
-  </annotation>
   <setupTask
       xsi:type="setup:CompoundTask"
       name="User Preferences">
@@ -132,6 +127,11 @@
   </setupTask>
   <project name="core"
       label="Core">
+    <annotation
+        source="http://www.eclipse.org/oomph/setup/ConfigurationReference">
+      <reference
+          href="EquinoxConfiguration.setup#/"/>
+    </annotation>
     <setupTask
         xsi:type="git:GitCloneTask"
         id="github.clone.equinox.core"
@@ -212,6 +212,11 @@
   </project>
   <project name="p2"
       label="P2">
+    <annotation
+        source="http://www.eclipse.org/oomph/setup/ConfigurationReference">
+      <reference
+          href="https://raw.githubusercontent.com/eclipse-equinox/p2/master/releng/org.eclipse.equinox.p2.setup/EquinoxP2Configuration.setup#/"/>
+    </annotation>
     <setupTask
         xsi:type="git:GitCloneTask"
         id="github.clone.equinox.p2"

--- a/releng/org.eclipse.equinox.releng/EquinoxConfiguration.setup
+++ b/releng/org.eclipse.equinox.releng/EquinoxConfiguration.setup
@@ -25,7 +25,7 @@
         value="equinox"/>
     <productVersion
         href="index:/org.eclipse.setup#//@productCatalogs[name='org.eclipse.applications']/@products[name='eclipse.platform.sdk']/@versions[name='latest']"/>
-    <description>The Equinox installation provides the latest tools needed to work with the Eclipse Equinox's source code.</description>
+    <description>The Equinox installation provides the latest tools needed to work with the project's source code.</description>
   </installation>
   <workspace
       name="equinox.workspace"
@@ -61,29 +61,24 @@
             value="Equinox"/>
       </setupTask>
     </setupTask>
-    <setupTask
-        xsi:type="setup:VariableTask"
-        name="eclipse.git.authentication.style"
-        defaultValue="anonymous"/>
     <stream
         href="index:/org.eclipse.setup#//@projectCatalogs[name='org.eclipse']/@projects[name='equinox']/@projects[name='binaries']/@streams[name='master']"/>
     <stream
         href="index:/org.eclipse.setup#//@projectCatalogs[name='org.eclipse']/@projects[name='equinox']/@projects[name='core']/@streams[name='master']"/>
-    <stream
-        href="index:/org.eclipse.setup#//@projectCatalogs[name='org.eclipse']/@projects[name='equinox']/@projects[name='p2']/@streams[name='master']"/>
-    <description>The Equinox workspace provides the source code of the Equinox project.</description>
+    <description>The Equinox workspace provides all the source code of the project.</description>
   </workspace>
   <description>
     &lt;p>
-    The &lt;a href=&quot;https://www.eclipse.org/equinox/&quot;/>Equinox&lt;/a> configuration provisions a dedicated development environment 
-    for the complete set of source projects of the &lt;a href=&quot;https://projects.eclipse.org/projects/eclipse.equinox&quot;>Equinox project&lt;/a>.
+    The &lt;a href=&quot;https://www.eclipse.org/equinox/&quot;/>Equinox&lt;/a> configuration provisions a dedicated development environment for the complete set of projects that comprise the Equinox framework,
+    i.e. the projects that are contained in the &lt;a href=&quot;https://github.com/eclipse-equinox/equinox&quot;>equinox&lt;/a> repository.
     &lt;/p>
     &lt;p>
-    All the source projects from &lt;a href=&quot;https://github.com/eclipse-equinox&quot;>Equinox's Github Repositories&lt;/a>
-    are available, organized into working sets, and ready for contribution.
+    The installation is based on the latest successful integration build of the &lt;code>Eclipse Platform SDK&lt;/code>,
+    the PDE target platform, like the installation, is also based on the latest integration build,
+    and the API baseline is based on the most recent release.
+    &lt;p>
     &lt;/p>
-    &lt;/p>
-    Please &lt;a href=&quot;https://wiki.eclipse.org/Eclipse_Platform_SDK_Provisioning&quot;>read the analogous tutorial instructions&lt;/a> for the Eclipse Platform SDK's configuration for more details.
+    Please &lt;a href=&quot;https://wiki.eclipse.org/Eclipse_Platform_SDK_Provisioning&quot;>read the tutorial instructions&lt;/a> for more details.
     &lt;/p>
   </description>
 </setup:Configuration>


### PR DESCRIPTION
Add a `equinox.core` configuration setup that only contains the `Equinox` and `Equinox Binaries` repository, opposed to the 'full' equinox configuration that also contains P2.

I used Equinox Core to refer to this repository to resolve the name clash that exists between this repository and the overall organization name. Alternatively we could find another name for the configuration handling the 'full' Equinox organization and rename it. Actually I would be in favor of that but didn't found a good name for it, `Equinox Full`, `Equinox Organization`, `Equinox SDK`, `Equinox Complete`, `Equinox All`, all didn't sound like a perfect solution for me.

@laeubi, @merks do you have any suggestions or opinions on that?

This also adds a reference the new `equinox.p2` configuration added in the eclipse-equinox/p2 repository.
Additionally change the styled and drag&drop-able Oomph Configuration button in the main README to just display the Equinox Core configuration, not the 'full' Equinox organization config.

The 'full' equinox configuration is also added to the organizations overview page via (currently it's only shown in the CONTRIBUTING file for Equinox
- https://github.com/eclipse-equinox/.github/pull/2

Part of https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2430