### PR TITLE
Introduce robust URL to java.nio.file.Path conversion

### DIFF
--- a/bundles/org.eclipse.equinox.common/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.common/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.common; singleton:=true
-Bundle-Version: 3.19.200.qualifier
+Bundle-Version: 3.20.0.qualifier
 Bundle-Localization: plugin
 Export-Package: org.eclipse.core.internal.boot;x-friends:="org.eclipse.core.resources,org.eclipse.pde.build",
  org.eclipse.core.internal.runtime;common=split;mandatory:=common;

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/internal/runtime/DataArea.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/internal/runtime/DataArea.java
@@ -65,12 +65,11 @@ public class DataArea {
 			// This will try to init url either from the specified location value or from
 			// service default
 			URL url = service.getURL();
-			if (url == null)
+			if (url == null) {
 				throw new IllegalStateException(CommonMessages.meta_instanceDataUnspecified);
-			// TODO assume the URL is a file:
-			// Use the new File technique to ensure that the resultant string is
-			// in the right format (e.g., leading / removed from /c:/foo etc)
-			location = IPath.fromOSString(new File(url.getFile()).toString());
+			}
+			// Assume the URL is a file:
+			location = IPath.fromPath(URIUtil.toFilePath(url));
 			initializeLocation();
 		} catch (CoreException e) {
 			throw new IllegalStateException(e.getMessage());

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/internal/runtime/PlatformURLConfigConnection.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/internal/runtime/PlatformURLConfigConnection.java
@@ -16,8 +16,10 @@ package org.eclipse.core.internal.runtime;
 import java.io.*;
 import java.net.URL;
 import java.net.UnknownServiceException;
+import java.nio.file.Files;
 import org.eclipse.core.internal.boot.PlatformURLConnection;
 import org.eclipse.core.internal.boot.PlatformURLHandler;
+import org.eclipse.core.runtime.URIUtil;
 import org.eclipse.osgi.service.datalocation.Location;
 import org.eclipse.osgi.util.NLS;
 
@@ -51,23 +53,21 @@ public class PlatformURLConfigConnection extends PlatformURLConnection {
 		Location parentConfig = localConfig.getParentLocation();
 		// assume we will find the file locally
 		URL localURL = new URL(localConfig.getURL(), path);
-		if (!FILE_PROTOCOL.equals(localURL.getProtocol()) || parentConfig == null)
+		if (!FILE_PROTOCOL.equals(localURL.getProtocol()) || parentConfig == null) {
 			// we only support cascaded file: URLs
 			return localURL;
-		File localFile = new File(localURL.getPath());
-		if (localFile.exists())
+		}
+		if (Files.exists(URIUtil.toFilePath(localURL))) {
 			// file exists in local configuration
 			return localURL;
+		}
 		// try to find in the parent configuration
 		URL parentURL = new URL(parentConfig.getURL(), path);
-		if (FILE_PROTOCOL.equals(parentURL.getProtocol())) {
-			// we only support cascaded file: URLs
-			File parentFile = new File(parentURL.getPath());
-			if (parentFile.exists()) {
-				// parent has the location
-				parentConfiguration = true;
-				return parentURL;
-			}
+		// we only support cascaded file: URLs
+		if (FILE_PROTOCOL.equals(parentURL.getProtocol()) && Files.exists(URIUtil.toFilePath(parentURL))) {
+			// parent has the location
+			parentConfiguration = true;
+			return parentURL;
 		}
 		return localURL;
 	}

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/URIUtil.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/URIUtil.java
@@ -15,6 +15,7 @@ package org.eclipse.core.runtime;
 
 import java.io.File;
 import java.net.*;
+import java.nio.file.Path;
 
 /**
  * A utility class for manipulating URIs. This class works around some of the
@@ -312,11 +313,12 @@ public final class URIUtil {
 		// URL behaves differently across platforms so for file: URLs we parse from
 		// string form
 		if (SCHEME_FILE.equals(url.getProtocol())) {
-			String pathString = url.toExternalForm().substring(5);
+			String pathString = url.toExternalForm().substring(SCHEME_FILE.length() + 1);
 			// ensure there is a leading slash to handle common malformed URLs such as
 			// file:c:/tmp
-			if (pathString.indexOf('/') != 0)
+			if (!pathString.startsWith("/")) { //$NON-NLS-1$
 				pathString = '/' + pathString;
+			}
 			return toURI(SCHEME_FILE, null, pathString, null);
 		}
 		try {
@@ -325,6 +327,33 @@ public final class URIUtil {
 			// try multi-argument URI constructor to perform encoding
 			return toURI(url.getProtocol(), url.getUserInfo(), url.getHost(), url.getPort(), url.getPath(),
 					url.getQuery(), url.getRef());
+		}
+	}
+
+	/**
+	 * Returns the {@code Path} specified by the given {@code file} {@link URL}.
+	 * 
+	 * @throws IllegalArgumentException if the specified URL does not use the
+	 *                                  {@code file} protocol
+	 * 
+	 * @since 3.20
+	 */
+	public static Path toFilePath(URL url) {
+		if (!SCHEME_FILE.equals(url.getProtocol())) {
+			throw new IllegalArgumentException("Not a 'file' url: " + url); //$NON-NLS-1$
+		}
+		try {
+			return Path.of(url.toURI());
+		} catch (URISyntaxException | IllegalArgumentException e) {
+			try {
+				return Path.of(toURI(url));
+			} catch (URISyntaxException e1) {
+				String pathString = url.toExternalForm().substring(SCHEME_FILE.length() + 1);
+				if (pathString.length() > 1 && pathString.charAt(0) == '/' && pathString.charAt(1) != '/') {
+					pathString = pathString.substring(1);
+				}
+				return Path.of(pathString);
+			}
 		}
 	}
 


### PR DESCRIPTION
Converting a URL into a `Path` or `File` is not a trivial task, especially since URLs are often malformed and therefore the straight forward way `Path.of(url.toURI())` or `new File(url.toURI())` lead to a `URISyntaxException` being thrown. Therefore multiple different workarounds are used throughout the SDK, e.g. `Path.of(url.getPath())` or `Path.of(url.getFile())`, but they are again have their problems.

This PR suggest a new utility method in the `URIUtil` that is capable of all the different conversion methods and workarounds and has the goal to reliably convert `file`-URLs into `java.nio.file.Path`s regardless of if the URL is malformed or perfectly complying to the standard.

This could also help for https://github.com/eclipse-platform/eclipse.platform/issues/35 because one does not have to rely on malformed URLs anymore if they are just passed around internally (URLs displayed to the user are another topic).