### PR TITLE
fix Unnecessary @SuppressWarnings("deprecation")

### DIFF
--- a/bundles/org.eclipse.equinox.common.tests/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.common.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Common Eclipse Runtime Tests
 Bundle-Vendor: Eclipse.org - Equinox
 Bundle-SymbolicName: org.eclipse.equinox.common.tests;singleton:=true
-Bundle-Version: 3.17.400.qualifier
+Bundle-Version: 3.17.500.qualifier
 Automatic-Module-Name: org.eclipse.equinox.common.tests
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy

--- a/bundles/org.eclipse.equinox.common.tests/src/org/eclipse/equinox/common/tests/ProgressMonitorWrapperTest.java
+++ b/bundles/org.eclipse.equinox.common.tests/src/org/eclipse/equinox/common/tests/ProgressMonitorWrapperTest.java
@@ -24,7 +24,6 @@ import org.junit.Test;
 /**
  * Test cases for the Path class.
  */
-@SuppressWarnings("deprecation") // SubProgressMonitor
 public class ProgressMonitorWrapperTest {
 
 	/**


### PR DESCRIPTION
jdt does not require @SuppressWarnings("deprecation")
 for imports anymore.