### PR TITLE
Updated bundles with comparator errors

### DIFF
--- a/bundles/org.eclipse.osgi/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.osgi/META-INF/MANIFEST.MF
@@ -107,7 +107,7 @@ Bundle-Activator: org.eclipse.osgi.internal.framework.SystemBundleActivator
 Bundle-Description: %systemBundle
 Bundle-Copyright: %copyright
 Bundle-Vendor: %eclipse.org
-Bundle-Version: 3.22.0.qualifier
+Bundle-Version: 3.22.100.qualifier
 Bundle-Localization: systembundle
 Bundle-DocUrl: http://www.eclipse.org
 Eclipse-ExtensibleAPI: true

--- a/bundles/org.eclipse.osgi/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.osgi/forceQualifierUpdate.txt
@@ -9,3 +9,4 @@ https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/20
 Touch for module-info updates
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation #1139
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2595

--- a/bundles/org.eclipse.osgi/pom.xml
+++ b/bundles/org.eclipse.osgi/pom.xml
@@ -19,7 +19,7 @@
 </parent>
   <groupId>org.eclipse.osgi</groupId>
   <artifactId>org.eclipse.osgi</artifactId>
-  <version>3.22.0-SNAPSHOT</version>
+  <version>3.22.100-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   <properties>
 	  <!-- The actual TCKs are executed in the org.eclipse.osgi.tck module because of reference to other service implementations -->

--- a/features/org.eclipse.equinox.core.feature/feature.xml
+++ b/features/org.eclipse.equinox.core.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.equinox.core.feature"
       label="%featureName"
-      version="1.15.300.qualifier"
+      version="1.15.400.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/features/org.eclipse.equinox.core.sdk/feature.xml
+++ b/features/org.eclipse.equinox.core.sdk/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.equinox.core.sdk"
       label="%featureName"
-      version="3.25.300.qualifier"
+      version="3.25.400.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/features/org.eclipse.equinox.server.core/feature.xml
+++ b/features/org.eclipse.equinox.server.core/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.equinox.server.core"
       label="%featureName"
-      version="1.16.300.qualifier"
+      version="1.16.400.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">


### PR DESCRIPTION
Changes to ecj are for handling of switch on String.

See: https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2595