### PR TITLE
Read message bundles in UTF-8 and fall back to 8859-1 in `org.eclipse.osgi.util.NLS`

### DIFF
--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/util/NLSTestCase.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/util/NLSTestCase.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.osgi.tests.util;
 
+import static org.junit.Assert.assertEquals;
+
 import org.eclipse.osgi.util.NLS;
 import org.junit.Test;
 
@@ -24,4 +26,37 @@ public class NLSTestCase {
 		NLS.bind("", Integer.valueOf(0));
 	}
 
+	@Test
+	public void testPropertiesLatin1() {
+		assertEquals("Lorem ipsum dolor sit amet", MessagesLatin1.key_ascii);
+		assertEquals("ÀÅÆÇÈÊËÌÍÏÐÑÒÓÖ×ØÙÚÜÝÞßàâäåæçèéëìíïðñòõö÷øùúüýþ", MessagesLatin1.key_latin1);
+	}
+
+	@Test
+	public void testPropertiesUtf8() {
+		assertEquals("Ḽơᶉëᶆ ȋṕšᶙṁ", MessagesUtf8.key_en);
+		assertEquals("顾客很高兴", MessagesUtf8.key_ch);
+		assertEquals("고객은 매우 행복합니다", MessagesUtf8.key_ko);
+		assertEquals("Клиент очень доволен", MessagesUtf8.key_ru);
+	}
+
+	public static class MessagesLatin1 extends NLS {
+		public static String key_ascii;
+		public static String key_latin1;
+
+		static {
+			NLS.initializeMessages("org.eclipse.osgi.tests.util.nls.messages_latin1", MessagesLatin1.class);
+		}
+	}
+
+	public static class MessagesUtf8 extends NLS {
+		public static String key_en;
+		public static String key_ch;
+		public static String key_ko;
+		public static String key_ru;
+
+		static {
+			NLS.initializeMessages("org.eclipse.osgi.tests.util.nls.messages_utf8", MessagesUtf8.class);
+		}
+	}
 }

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/util/nls/messages_latin1.properties
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/util/nls/messages_latin1.properties
@@ -1,0 +1,3 @@
+key_ascii=Lorem ipsum dolor sit amet
+# This is a comment
+key_latin1=ÀÅÆÇÈÊËÌÍÏÐÑÒÓÖ×ØÙÚÜÝÞ‗אגהוזחטיכלםןנסעץצקרשתü‎‏

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/util/nls/messages_utf8.properties
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/util/nls/messages_utf8.properties
@@ -1,0 +1,5 @@
+key_en=Ḽơᶉëᶆ ȋṕšᶙṁ
+# This is a comment これはコメントです
+key_ch=顾客很高兴
+key_ko=고객은 매우 행복합니다
+key_ru=Клиент очень доволен

--- a/bundles/org.eclipse.osgi/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.osgi/META-INF/MANIFEST.MF
@@ -51,7 +51,7 @@ Export-Package: org.eclipse.core.runtime.adaptor;x-friends:="org.eclipse.core.ru
  org.eclipse.osgi.storage.bundlefile;x-internal:=true,
  org.eclipse.osgi.storage.url.reference;x-internal:=true,
  org.eclipse.osgi.storagemanager;version="1.0",
- org.eclipse.osgi.util;version="1.2.0",
+ org.eclipse.osgi.util;version="1.3",
  org.osgi.dto;version="1.1.1",
  org.osgi.framework;version="1.10",
  org.osgi.framework.connect;version="1.0";uses:="org.osgi.framework.launch",
@@ -107,7 +107,7 @@ Bundle-Activator: org.eclipse.osgi.internal.framework.SystemBundleActivator
 Bundle-Description: %systemBundle
 Bundle-Copyright: %copyright
 Bundle-Vendor: %eclipse.org
-Bundle-Version: 3.22.100.qualifier
+Bundle-Version: 3.23.0.qualifier
 Bundle-Localization: systembundle
 Bundle-DocUrl: http://www.eclipse.org
 Eclipse-ExtensibleAPI: true

--- a/bundles/org.eclipse.osgi/pom.xml
+++ b/bundles/org.eclipse.osgi/pom.xml
@@ -19,7 +19,7 @@
 </parent>
   <groupId>org.eclipse.osgi</groupId>
   <artifactId>org.eclipse.osgi</artifactId>
-  <version>3.22.100-SNAPSHOT</version>
+  <version>3.23.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   <properties>
 	  <!-- The actual TCKs are executed in the org.eclipse.osgi.tck module because of reference to other service implementations -->

--- a/bundles/org.eclipse.osgi/supplement/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.osgi/supplement/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.supplement
-Bundle-Version: 1.11.100.qualifier
+Bundle-Version: 1.12.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.equinox.log;version="1.1",
@@ -17,7 +17,7 @@ Export-Package: org.eclipse.equinox.log;version="1.1",
  org.eclipse.osgi.service.runnable;version="1.1",
  org.eclipse.osgi.service.urlconversion;version="1.0",
  org.eclipse.osgi.storagemanager;version="1.0",
- org.eclipse.osgi.util;version="1.1"
+ org.eclipse.osgi.util;version="1.3"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Import-Package: org.osgi.framework,
  org.osgi.framework.hooks.resolver,

--- a/bundles/org.eclipse.osgi/supplement/src/org/eclipse/osgi/util/NLS.java
+++ b/bundles/org.eclipse.osgi/supplement/src/org/eclipse/osgi/util/NLS.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
+import java.util.PropertyResourceBundle;
 import org.eclipse.osgi.framework.log.FrameworkLog;
 import org.eclipse.osgi.framework.log.FrameworkLogEntry;
 import org.eclipse.osgi.internal.util.SupplementDebug;
@@ -138,6 +139,16 @@ public abstract class NLS {
 	 *   org/eclipse/example/nls/messages_en.properties
 	 *   org/eclipse/example/nls/messages.properties
 	 * </pre>
+	 * <p>
+	 * The properties files are read using the default encoding for resource bundles:
+	 * <ul>
+	 *   <li>In Java 8, resource files are read using ISO-8859-1 character encoding. Characters outside
+	 *   its range must be represented using Unicode escape sequences (e.g., <code>&#92;uXXXX</code>).</li>
+	 *   <li>In Java 11 and later, resource files are initially read using UTF-8 character encoding. If a
+	 *   resource cannot be successfully read in UTF-8, it will be read from the start in ISO-8859-1
+	 *   character encoding.</li>
+	 * </ul>
+	 * </p>
 	 *
 	 * @param baseName the base name of a fully qualified message properties file.
 	 * @param clazz the class where the constants will exist
@@ -347,7 +358,10 @@ public abstract class NLS {
 				continue;
 			try {
 				final MessagesProperties properties = new MessagesProperties(fields, bundleName, isAccessible);
-				properties.load(input);
+				final PropertyResourceBundle bundle = new PropertyResourceBundle(input);
+				for (String key : bundle.keySet()) {
+					properties.put(key, bundle.getString(key));
+				}
 			} catch (IOException e) {
 				log(SEVERITY_ERROR, "Error loading " + variant, e); //$NON-NLS-1$
 			} finally {


### PR DESCRIPTION
All message bundles are currently loaded in the ISO 8859-1 character encoding. This enforces any message bundle that uses non-ASCII characters to escape such characters using escape sequences. This makes it notoriously hard to analyze or process such files without using specialized tools such as IDEs or relying on the `native2ascii` command-line tool.

This PR makes UTF-8 the default encoding when using `org.eclipse.osgi.util.NLS#initializeMessages` by leveraging the usage of [PropertyResourceBundle](https://docs.oracle.com/javase/8/docs/api/java/util/PropertyResourceBundle.html). Despite interpreting the stream in UTF-8 by default, it still correctly handles 8859-1 that is not compatible with UTF-8 by re-reading the stream from the start if it cannot be properly decoded in UTF-8 otherwise.