### PR TITLE
Remove old junit 4.13.1 from o.e.osgi pom

### DIFF
--- a/bundles/org.eclipse.osgi/pom.xml
+++ b/bundles/org.eclipse.osgi/pom.xml
@@ -72,12 +72,6 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.13.1</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
 			<version>5.11.0</version>


### PR DESCRIPTION
It's covered by the JUNIT_CONTAINER/4 on the classpath so no need to have junit explicitly listed in the pom as that requires extra maintenance to update it.