### PR TITLE
Build Equinox launcher for linux.x86_64 on debian-12

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,7 @@ def runOnNativeBuildAgent(String platform, Closure body) {
 	def final nativeBuildStageName = 'Perform native launcher build'
 	if (platform == 'gtk.linux.x86_64') {
 		podTemplate(inheritFrom: 'basic' /* inherit general configuration */, containers: [
-			containerTemplate(name: 'launcherbuild', image: 'eclipse/platformreleng-centos-swt-build:8',
+			containerTemplate(name: 'launcherbuild', image: 'eclipse/platformreleng-debian-swtnativebuild:12',
 				resourceRequestCpu:'1000m', resourceRequestMemory:'512Mi',
 				resourceLimitCpu:'2000m', resourceLimitMemory:'4096Mi',
 				alwaysPullImage: true, command: 'cat', ttyEnabled: true)

--- a/bundles/org.eclipse.equinox.launcher.gtk.linux.aarch64/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.launcher.gtk.linux.aarch64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.equinox.launcher.gtk.linux.aarch64;singleton:=true
-Bundle-Version: 1.2.1200.qualifier
+Bundle-Version: 1.2.1300.qualifier
 Fragment-Host: org.eclipse.equinox.launcher;bundle-version="[1.6.0,1.7.0)"
 Eclipse-PlatformFilter: (& (osgi.ws=gtk) (osgi.os=linux) (osgi.arch=aarch64))
 Bundle-Localization: launcher.gtk.linux.aarch64

--- a/bundles/org.eclipse.equinox.launcher.gtk.linux.loongarch64/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.launcher.gtk.linux.loongarch64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.equinox.launcher.gtk.linux.loongarch64;singleton:=true
-Bundle-Version: 1.2.1100.qualifier
+Bundle-Version: 1.2.1300.qualifier
 Fragment-Host: org.eclipse.equinox.launcher;bundle-version="[1.6.0,1.7.0)"
 Eclipse-PlatformFilter: (& (osgi.ws=gtk) (osgi.os=linux) (osgi.arch=loongarch64))
 Bundle-Localization: launcher.gtk.linux.loongarch64

--- a/bundles/org.eclipse.equinox.launcher.gtk.linux.ppc64le/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.launcher.gtk.linux.ppc64le/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.equinox.launcher.gtk.linux.ppc64le;singleton:=true
-Bundle-Version: 1.2.1200.qualifier
+Bundle-Version: 1.2.1300.qualifier
 Fragment-Host: org.eclipse.equinox.launcher;bundle-version="[1.6.0,1.7.0)"
 Eclipse-PlatformFilter: (& (osgi.ws=gtk) (osgi.os=linux) (osgi.arch=ppc64le))
 Bundle-Localization: launcher.gtk.linux.ppc64le

--- a/bundles/org.eclipse.equinox.launcher.gtk.linux.riscv64/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.launcher.gtk.linux.riscv64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.equinox.launcher.gtk.linux.riscv64;singleton:=true
-Bundle-Version: 1.2.1200.qualifier
+Bundle-Version: 1.2.1300.qualifier
 Fragment-Host: org.eclipse.equinox.launcher;bundle-version="[1.6.0,1.7.0)"
 Eclipse-PlatformFilter: (& (osgi.ws=gtk) (osgi.os=linux) (osgi.arch=riscv64))
 Bundle-Localization: launcher.gtk.linux.riscv64

--- a/bundles/org.eclipse.equinox.launcher.gtk.linux.x86_64/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.launcher.gtk.linux.x86_64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.equinox.launcher.gtk.linux.x86_64;singleton:=true
-Bundle-Version: 1.2.1200.qualifier
+Bundle-Version: 1.2.1300.qualifier
 Fragment-Host: org.eclipse.equinox.launcher;bundle-version="[1.6.0,1.7.0)"
 Eclipse-PlatformFilter: (& (osgi.ws=gtk) (osgi.os=linux) (osgi.arch=x86_64))
 Bundle-Localization: launcher.gtk.linux.x86_64


### PR DESCRIPTION
The image 'platformreleng-centos-swt-build:8' cannot be built anymore and is therefore not updated.
Align with SWT and use the debian-12 image instead.

This will increase the GLIBC version requirement to version 2.34, see https://github.com/eclipse-platform/eclipse.platform.swt/pull/1422#issuecomment-2470145844

See also https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/2441