### PR TITLE
upgrade tycho-build

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,6 +3,6 @@
 	<extension>
 		<groupId>org.eclipse.tycho</groupId>
 		<artifactId>tycho-build</artifactId>
-		<version>4.0.9</version>
+		<version>4.0.10</version>
 	</extension>
 </extensions>


### PR DESCRIPTION
It seems this can easily go unnoticed because the other tycho versions are managed in the centralized parent pom.