### PR TITLE
Use Java 21 in Github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,15 +34,17 @@ jobs:
         fetch-depth: 1 # only shallow here, we don't have jgit timestamps
         repository: eclipse-equinox/equinox.binaries
         path: equinox.binaries
-    - name: Set up JDK 17
+    - name: Set up JDKs
       uses: actions/setup-java@v4
       with:
         java-version: |
           8
           17
+          21
         mvn-toolchain-id: |
           JavaSE-1.8
           JavaSE-17
+          JavaSE-21
         distribution: 'temurin'
         cache: maven
     - name: Set up Maven
@@ -88,15 +90,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Set up JDK 17
+    - name: Set up JDKs
       uses: actions/setup-java@v4
       with:
         java-version: |
           8
           17
+          21
         mvn-toolchain-id: |
           JavaSE-1.8
           JavaSE-17
+          JavaSE-21
         distribution: 'temurin'
         cache: maven
     - name: Set up Maven

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,15 +45,17 @@ jobs:
       uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
-    - name: Set up JDK 17
+    - name: Set up JDKs
       uses: actions/setup-java@6a0805fcefea3d4657a47ac4c165951e33482018 # v4.2.2
       with:
         java-version: |
           8
           17
+          21
         mvn-toolchain-id: |
           JavaSE-1.8
           JavaSE-17
+          JavaSE-21
         distribution: 'temurin'
         cache: maven
     - name: Set up Maven


### PR DESCRIPTION
Platorm requires Java 21 now on some places so we should be prepared.