### PR TITLE
Add a provided capability for the equinox transformer hook

### DIFF
--- a/bundles/org.eclipse.equinox.transforms.hook/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.transforms.hook/META-INF/MANIFEST.MF
@@ -3,10 +3,10 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.equinox.transforms.hook
-Bundle-Version: 1.4.100.qualifier
+Bundle-Version: 1.4.200.qualifier
 Fragment-Host: org.eclipse.osgi;bundle-version="[3.10.0,4.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Localization: transformsHook
 Export-Package: org.eclipse.equinox.internal.transforms;x-internal:=true
 Automatic-Module-Name: org.eclipse.equinox.transforms.hook
-
+Provide-Capability: osgi.extender;osgi.extender="equinox.transforms.hook"

--- a/bundles/org.eclipse.equinox.transforms.xslt/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.transforms.xslt/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.equinox.transforms.xslt
-Bundle-Version: 1.3.100.qualifier
+Bundle-Version: 1.3.200.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Import-Package: org.eclipse.osgi.framework.log;version="1.0.0",
  org.osgi.framework;version="1.3.0",
@@ -14,3 +14,4 @@ Export-Package: org.eclipse.equinox.internal.transforms;x-internal:=true,
  org.eclipse.equinox.internal.transforms.xslt;x-internal:=true
 Bundle-Activator: org.eclipse.equinox.internal.transforms.xslt.Activator
 Automatic-Module-Name: org.eclipse.equinox.transforms.xslt
+Require-Capability: osgi.extender;filter:="(osgi.extender=equinox.transforms.hook)"


### PR DESCRIPTION
Currently there is no way for a transformer hook extension to really declare any requirement on the transformer feature (beside require bundle it).

This now adds a provided capability and a corresponding requirement for the xslt.

@tjwatson can you review this? Will it work even though `org.eclipse.equinox.transforms.hook` is a framework-extension?