### PR TITLE
Add "replace" as a default available transformer

### DIFF
--- a/bundles/org.eclipse.equinox.transforms.hook/src/org/eclipse/equinox/internal/transforms/ReplaceTransformer.java
+++ b/bundles/org.eclipse.equinox.transforms.hook/src/org/eclipse/equinox/internal/transforms/ReplaceTransformer.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Christoph Läubrich and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.equinox.internal.transforms;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Map;
+import org.eclipse.osgi.framework.log.FrameworkLogEntry;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+
+/**
+ * Basic default transformer that simply replaces a matching resource with
+ * another.
+ */
+class ReplaceTransformer {
+
+	static final String TYPE = "replace"; //$NON-NLS-1$
+	private TransformerHook hook;
+
+	ReplaceTransformer(TransformerHook hook) {
+		this.hook = hook;
+	}
+
+	public InputStream getInputStream(InputStream inputStream, final URL transformerUrl) {
+		try {
+			return transformerUrl.openStream();
+		} catch (IOException e) {
+			hook.log(FrameworkLogEntry.WARNING, String.format("Can't replace resource with %s", transformerUrl), e); //$NON-NLS-1$
+			return null;
+		}
+	}
+
+	public static void register(BundleContext context, TransformerHook transformerHook) {
+		context.registerService(Object.class, new ReplaceTransformer(transformerHook),
+				FrameworkUtil.asDictionary(Map.of(TransformTuple.TRANSFORMER_TYPE, TYPE)));
+	}
+}

--- a/bundles/org.eclipse.equinox.transforms.hook/src/org/eclipse/equinox/internal/transforms/TransformerHook.java
+++ b/bundles/org.eclipse.equinox.transforms.hook/src/org/eclipse/equinox/internal/transforms/TransformerHook.java
@@ -46,6 +46,7 @@ public class TransformerHook
 
 	public void start(BundleContext context) throws BundleException {
 		try {
+			ReplaceTransformer.register(context, this);
 			this.transformers = new TransformerList(context, logServices);
 		} catch (InvalidSyntaxException e) {
 			throw new BundleException("Problem registering service tracker: transformers", e); //$NON-NLS-1$


### PR DESCRIPTION
A while back in the incubation phase [there was a dedicated bundle](https://eclipse.googlesource.com/equinox/rt.equinox.incubator/+/refs/tags/I20120516-1900/components/bundles/org.eclipse.equinox.transforms.replace) that provided a "replace" transformer.

As this is the very basic transformation and do not require any special dependency it is now added back (in a slightly enhanced implementation) as being available by default.

This contributes to
- https://github.com/eclipse-platform/eclipse.platform.ui/pull/14#issuecomment-2558026326