### PR TITLE
Use java 17 source for javadoc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,7 @@
 					<configuration>
 						<!-- Special code only for J9 -->
 						<excludePackageNames>org.eclipse.osgi.internal.cds</excludePackageNames>
+						<source>17</source>
 					</configuration>
 				</plugin>
 			</plugins>


### PR DESCRIPTION
Equinox currently needs to run with java 17 as main jvm therefore it can't use higher javadoc source flag.

See
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/2708