### PR TITLE
Fix maven group id to match the actual deployment

### DIFF
--- a/bundles/build.properties
+++ b/bundles/build.properties
@@ -1,0 +1,1 @@
+pom.model.groupId=org.eclipse.platform

--- a/bundles/org.eclipse.osgi/pom.xml
+++ b/bundles/org.eclipse.osgi/pom.xml
@@ -17,7 +17,7 @@
     <version>4.35.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
 </parent>
-  <groupId>org.eclipse.osgi</groupId>
+  <groupId>org.eclipse.platform</groupId>
   <artifactId>org.eclipse.osgi</artifactId>
   <version>3.23.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>


### PR DESCRIPTION
Since a long while equinox is deployed to the org.eclipse.platform group id, but in the P2 maven metadata this is currently recorded as `org.eclipse.equinox` (and `org.eclipse.osgi`), this confuses tools like Tycho that try to match P2 to maven metadata (and is not very helpful at all)

This now fixes the issue for the bundles (as features are not deployed at the moment anyways).