### PR TITLE
Fix maven group id to match the actual deployment

### DIFF
--- a/bundles/org.eclipse.equinox.security.linux/pom.xml
+++ b/bundles/org.eclipse.equinox.security.linux/pom.xml
@@ -17,7 +17,8 @@
     <artifactId>parent</artifactId>
     <version>4.35.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
-</parent>
+  </parent>
+  <groupId>org.eclipse.platform</groupId>
   <artifactId>org.eclipse.equinox.security.linux</artifactId>
   <version>1.1.300-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>

--- a/bundles/org.eclipse.equinox.security.macosx/pom.xml
+++ b/bundles/org.eclipse.equinox.security.macosx/pom.xml
@@ -16,7 +16,8 @@
     <artifactId>parent</artifactId>
     <version>4.35.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
-</parent>
+  </parent>
+  <groupId>org.eclipse.platform</groupId>
   <artifactId>org.eclipse.equinox.security.macosx</artifactId>
   <version>1.102.300-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>

--- a/bundles/org.eclipse.equinox.security.win32/pom.xml
+++ b/bundles/org.eclipse.equinox.security.win32/pom.xml
@@ -17,6 +17,7 @@
     <version>4.35.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
+  <groupId>org.eclipse.platform</groupId>
   <artifactId>org.eclipse.equinox.security.win32</artifactId>
   <version>1.3.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>

--- a/bundles/org.eclipse.equinox.security/pom.xml
+++ b/bundles/org.eclipse.equinox.security/pom.xml
@@ -16,8 +16,8 @@
     <artifactId>parent</artifactId>
     <version>4.35.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
-</parent>
-  <groupId>org.eclipse.equinox</groupId>
+  </parent>
+  <groupId>org.eclipse.platform</groupId>
   <artifactId>org.eclipse.equinox.security</artifactId>
   <version>1.4.500-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>

--- a/bundles/org.eclipse.osgi.tests/pom.xml
+++ b/bundles/org.eclipse.osgi.tests/pom.xml
@@ -16,8 +16,8 @@
     <artifactId>parent</artifactId>
     <version>4.35.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
-</parent>
-  <groupId>org.eclipse.osgi</groupId>
+  </parent>
+  <groupId>org.eclipse.platform</groupId>
   <artifactId>org.eclipse.osgi.tests</artifactId>
   <version>3.22.100-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>


### PR DESCRIPTION
Fix the remaining bundles not addressed by the previous commit.

https://github.com/eclipse-equinox/equinox/pull/737