### PR TITLE
Create an SLF4j provider implementation for the Equinox Log

### DIFF
--- a/bundles/org.eclipse.equinox.slf4j/.classpath
+++ b/bundles/org.eclipse.equinox.slf4j/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/bundles/org.eclipse.equinox.slf4j/.project
+++ b/bundles/org.eclipse.equinox.slf4j/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.eclipse.equinox.slf4j</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/bundles/org.eclipse.equinox.slf4j/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.eclipse.equinox.slf4j/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/bundles/org.eclipse.equinox.slf4j/.settings/org.eclipse.jdt.core.prefs
+++ b/bundles/org.eclipse.equinox.slf4j/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,9 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
+org.eclipse.jdt.core.compiler.compliance=17
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=17

--- a/bundles/org.eclipse.equinox.slf4j/.settings/org.eclipse.pde.core.prefs
+++ b/bundles/org.eclipse.equinox.slf4j/.settings/org.eclipse.pde.core.prefs
@@ -1,0 +1,4 @@
+eclipse.preferences.version=1
+pluginProject.equinox=false
+pluginProject.extensions=false
+resolve.requirebundle=false

--- a/bundles/org.eclipse.equinox.slf4j/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.slf4j/META-INF/MANIFEST.MF
@@ -1,0 +1,17 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: %bundleName
+Bundle-Vendor: %providerName
+Bundle-SymbolicName: org.eclipse.equinox.slf4j
+Bundle-Version: 1.0.0.qualifier
+Import-Package: org.slf4j;version="[1.7.30,3.0.0)",
+ org.slf4j.helpers;version="[1.7.0,3.0.0)",
+ org.slf4j.spi;version="[1.7.0,3.0.0)"
+Require-Bundle: org.eclipse.equinox.common;bundle-version="[3.20.0,4.0.0)",
+ org.eclipse.osgi;bundle-version="[3.23.0,4.0.0)"
+Automatic-Module-Name: org.eclipse.equinox.slf4j
+Bundle-ActivationPolicy: lazy
+Bundle-Activator: org.eclipse.equinox.slf4j.EquinoxLoggerFactoryActivator
+Bundle-RequiredExecutionEnvironment: JavaSE-17
+Provide-Capability: osgi.serviceloader;osgi.serviceloader="org.slf4j.spi.SLF4JServiceProvider";register:="org.eclipse.equinox.slf4j.EquinoxLoggerFactory";uses:="org.slf4j.spi,org.slf4j"
+Require-Capability: osgi.extender;filter:="(osgi.extender=osgi.serviceloader.registrar)"

--- a/bundles/org.eclipse.equinox.slf4j/META-INF/services/org.slf4j.spi.SLF4JServiceProvider
+++ b/bundles/org.eclipse.equinox.slf4j/META-INF/services/org.slf4j.spi.SLF4JServiceProvider
@@ -1,0 +1,1 @@
+org.eclipse.equinox.slf4j.EquinoxSLF4JProvider

--- a/bundles/org.eclipse.equinox.slf4j/about.html
+++ b/bundles/org.eclipse.equinox.slf4j/about.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1" />
+<title>About</title>
+</head>
+<body lang="EN-US">
+	<h2>About This Content</h2>
+
+	<p>November 30, 2017</p>
+	<h3>License</h3>
+
+	<p>
+		The Eclipse Foundation makes available all content in this plug-in
+		(&quot;Content&quot;). Unless otherwise indicated below, the Content
+		is provided to you under the terms and conditions of the Eclipse
+		Public License Version 2.0 (&quot;EPL&quot;). A copy of the EPL is
+		available at <a href="http://www.eclipse.org/legal/epl-2.0">http://www.eclipse.org/legal/epl-2.0</a>.
+		For purposes of the EPL, &quot;Program&quot; will mean the Content.
+	</p>
+
+	<p>
+		If you did not receive this Content directly from the Eclipse
+		Foundation, the Content is being redistributed by another party
+		(&quot;Redistributor&quot;) and different terms and conditions may
+		apply to your use of any object code in the Content. Check the
+		Redistributor's license that was provided with the Content. If no such
+		license exists, contact the Redistributor. Unless otherwise indicated
+		below, the terms and conditions of the EPL still apply to any source
+		code in the Content and such source code may be obtained at <a
+			href="http://www.eclipse.org/">http://www.eclipse.org</a>.
+	</p>
+
+</body>
+</html>

--- a/bundles/org.eclipse.equinox.slf4j/build.properties
+++ b/bundles/org.eclipse.equinox.slf4j/build.properties
@@ -1,0 +1,8 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .,\
+               about.html,\
+               plugin.properties
+src.includes = about.html,\
+               plugin.properties

--- a/bundles/org.eclipse.equinox.slf4j/plugin.properties
+++ b/bundles/org.eclipse.equinox.slf4j/plugin.properties
@@ -1,0 +1,15 @@
+###############################################################################
+# Copyright (c) 2007, 2009 IBM Corporation and others.
+#
+# This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+# 
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bundleName = Equinox SLF4J Provider
+providerName = Eclipse.org - Equinox

--- a/bundles/org.eclipse.equinox.slf4j/src/org/eclipse/equinox/slf4j/EquinoxLogger.java
+++ b/bundles/org.eclipse.equinox.slf4j/src/org/eclipse/equinox/slf4j/EquinoxLogger.java
@@ -1,0 +1,245 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Christoph Läubrich and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.equinox.slf4j;
+
+import org.osgi.service.log.Logger;
+import org.slf4j.helpers.FormattingTuple;
+import org.slf4j.helpers.MessageFormatter;
+
+class EquinoxLogger extends org.slf4j.helpers.MarkerIgnoringBase {
+
+	private static final long serialVersionUID = 1L;
+	private Logger logger;
+
+	EquinoxLogger(String name, Logger logger) {
+		this.name = name;
+		this.logger = logger;
+	}
+
+	@Override
+	public boolean isTraceEnabled() {
+		return logger != null && logger.isTraceEnabled();
+	}
+
+	@Override
+	public void trace(String msg) {
+		if (isTraceEnabled()) {
+			logger.trace(msg);
+		}
+	}
+
+	@Override
+	public void trace(String msg, Throwable t) {
+		if (isTraceEnabled()) {
+			logger.trace(msg, t);
+		}
+	}
+
+	@Override
+	public void trace(String format, Object arg1) {
+		if (isTraceEnabled()) {
+			FormattingTuple tp = MessageFormatter.format(format, arg1);
+			logger.trace(tp.getMessage(), tp.getThrowable());
+		}
+	}
+
+	@Override
+	public void trace(String format, Object arg1, Object arg2) {
+		if (isTraceEnabled()) {
+			FormattingTuple tp = MessageFormatter.format(format, arg1, arg2);
+			logger.trace(tp.getMessage(), tp.getThrowable());
+		}
+	}
+
+	@Override
+	public void trace(String format, Object... argArray) {
+		if (isTraceEnabled()) {
+			FormattingTuple tp = MessageFormatter.arrayFormat(format, argArray);
+			logger.trace(tp.getMessage(), tp.getThrowable());
+		}
+	}
+
+	@Override
+	public boolean isDebugEnabled() {
+		return logger != null && logger.isDebugEnabled();
+	}
+
+	@Override
+	public void debug(String msg) {
+		if (isDebugEnabled()) {
+			logger.debug(msg);
+		}
+	}
+
+	@Override
+	public void debug(String msg, Throwable t) {
+		if (isDebugEnabled()) {
+			logger.debug(msg, t);
+		}
+	}
+
+	@Override
+	public void debug(String format, Object arg1) {
+		if (isDebugEnabled()) {
+			FormattingTuple tp = MessageFormatter.format(format, arg1);
+			logger.debug(tp.getMessage(), tp.getThrowable());
+		}
+	}
+
+	@Override
+	public void debug(String format, Object arg1, Object arg2) {
+		if (isDebugEnabled()) {
+			FormattingTuple tp = MessageFormatter.format(format, arg1, arg2);
+			logger.debug(tp.getMessage(), tp.getThrowable());
+		}
+	}
+
+	@Override
+	public void debug(String format, Object... argArray) {
+		if (isDebugEnabled()) {
+			FormattingTuple tp = MessageFormatter.arrayFormat(format, argArray);
+			logger.debug(tp.getMessage(), tp.getThrowable());
+		}
+	}
+
+	@Override
+	public boolean isInfoEnabled() {
+		return logger != null && logger.isInfoEnabled();
+	}
+
+	@Override
+	public void info(String msg) {
+		if (isInfoEnabled()) {
+			logger.info(msg);
+		}
+	}
+
+	@Override
+	public void info(String msg, Throwable t) {
+		if (isInfoEnabled()) {
+			logger.info(msg, t);
+		}
+	}
+
+	@Override
+	public void info(String format, Object arg1) {
+		if (isInfoEnabled()) {
+			FormattingTuple tp = MessageFormatter.format(format, arg1);
+			logger.info(tp.getMessage(), tp.getThrowable());
+		}
+	}
+
+	@Override
+	public void info(String format, Object arg1, Object arg2) {
+		if (isInfoEnabled()) {
+			FormattingTuple tp = MessageFormatter.format(format, arg1, arg2);
+			logger.info(tp.getMessage(), tp.getThrowable());
+		}
+	}
+
+	@Override
+	public void info(String format, Object... argArray) {
+		if (isInfoEnabled()) {
+			FormattingTuple tp = MessageFormatter.arrayFormat(format, argArray);
+			logger.info(tp.getMessage(), tp.getThrowable());
+		}
+	}
+
+	@Override
+	public boolean isWarnEnabled() {
+		return logger != null && logger.isWarnEnabled();
+	}
+
+	@Override
+	public void warn(String msg) {
+		if (isWarnEnabled()) {
+			logger.warn(msg);
+		}
+	}
+
+	@Override
+	public void warn(String msg, Throwable t) {
+		if (isWarnEnabled()) {
+			logger.warn(msg, t);
+		}
+	}
+
+	@Override
+	public void warn(String format, Object arg1) {
+		if (isWarnEnabled()) {
+			FormattingTuple tp = MessageFormatter.format(format, arg1);
+			logger.warn(tp.getMessage(), tp.getThrowable());
+		}
+	}
+
+	@Override
+	public void warn(String format, Object arg1, Object arg2) {
+		if (isWarnEnabled()) {
+			FormattingTuple tp = MessageFormatter.format(format, arg1, arg2);
+			logger.warn(tp.getMessage(), tp.getThrowable());
+		}
+	}
+
+	@Override
+	public void warn(String format, Object... argArray) {
+		if (isWarnEnabled()) {
+			FormattingTuple tp = MessageFormatter.arrayFormat(format, argArray);
+			logger.warn(tp.getMessage(), tp.getThrowable());
+		}
+	}
+
+	@Override
+	public boolean isErrorEnabled() {
+		return logger != null && logger.isErrorEnabled();
+	}
+
+	@Override
+	public void error(String msg) {
+		if (isErrorEnabled()) {
+			logger.error(msg);
+		}
+	}
+
+	@Override
+	public void error(String msg, Throwable t) {
+		if (isErrorEnabled()) {
+			logger.error(msg, t);
+		}
+	}
+
+	@Override
+	public void error(String format, Object arg1) {
+		if (isErrorEnabled()) {
+			FormattingTuple tp = MessageFormatter.format(format, arg1);
+			logger.error(tp.getMessage(), tp.getThrowable());
+		}
+	}
+
+	@Override
+	public void error(String format, Object arg1, Object arg2) {
+		if (isErrorEnabled()) {
+			FormattingTuple tp = MessageFormatter.format(format, arg1, arg2);
+			logger.error(tp.getMessage(), tp.getThrowable());
+		}
+	}
+
+	@Override
+	public void error(String format, Object... argArray) {
+		if (isErrorEnabled()) {
+			FormattingTuple tp = MessageFormatter.arrayFormat(format, argArray);
+			logger.error(tp.getMessage(), tp.getThrowable());
+		}
+	}
+
+}

--- a/bundles/org.eclipse.equinox.slf4j/src/org/eclipse/equinox/slf4j/EquinoxLoggerFactory.java
+++ b/bundles/org.eclipse.equinox.slf4j/src/org/eclipse/equinox/slf4j/EquinoxLoggerFactory.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Christoph Läubrich and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.equinox.slf4j;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.eclipse.core.internal.runtime.PlatformLogWriter;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.service.log.LogService;
+import org.osgi.service.log.Logger;
+import org.slf4j.ILoggerFactory;
+
+/**
+ * An implementation of the SLF4J {@link ILoggerFactory} that is using the
+ * equinox platform log like done with the ILog interface
+ */
+public class EquinoxLoggerFactory implements org.slf4j.ILoggerFactory {
+
+	private static final StackWalker STACK_WALKER = StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE);
+	private static final Bundle FACTORY_BUNDLE = FrameworkUtil.getBundle(EquinoxLoggerFactory.class);
+	private static final Bundle SLF4J_BUNDLE = FrameworkUtil.getBundle(org.slf4j.ILoggerFactory.class);
+	static final ConcurrentMap<Bundle, EquinoxLogger> LOGGER_MAP = new ConcurrentHashMap<>();
+	static final AtomicReference<LogService> logService = new AtomicReference<>();
+
+	@Override
+	public org.slf4j.Logger getLogger(String name) {
+		Bundle bundle = getBundle();
+		if (bundle == null) {
+			return new EquinoxLogger(name, null);
+		}
+		return LOGGER_MAP.computeIfAbsent(bundle, b -> {
+			LogService service = logService.get();
+			@SuppressWarnings("restriction")
+			Logger bundleLogger = service == null ? null
+					: service.getLogger(b, PlatformLogWriter.EQUINOX_LOGGER_NAME, Logger.class);
+			return new EquinoxLogger(name, bundleLogger);
+		});
+	}
+
+	private Bundle getBundle() {
+		return STACK_WALKER.walk(s -> s.map(frame -> FrameworkUtil.getBundle(frame.getDeclaringClass()))
+				.dropWhile(stackFrameBundle -> stackFrameBundle == FACTORY_BUNDLE || stackFrameBundle == SLF4J_BUNDLE)
+				.findFirst().orElse(null));
+	}
+
+}

--- a/bundles/org.eclipse.equinox.slf4j/src/org/eclipse/equinox/slf4j/EquinoxLoggerFactoryActivator.java
+++ b/bundles/org.eclipse.equinox.slf4j/src/org/eclipse/equinox/slf4j/EquinoxLoggerFactoryActivator.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Christoph Läubrich and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.equinox.slf4j;
+
+import org.eclipse.equinox.log.ExtendedLogService;
+import org.osgi.framework.BundleActivator;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.BundleEvent;
+import org.osgi.framework.BundleListener;
+import org.osgi.framework.ServiceReference;
+import org.osgi.util.tracker.ServiceTracker;
+import org.osgi.util.tracker.ServiceTrackerCustomizer;
+
+/**
+ * Manages the interaction with OSGi objects
+ */
+public class EquinoxLoggerFactoryActivator implements BundleActivator, BundleListener {
+
+	@Override
+	public void start(BundleContext context) throws Exception {
+		context.addBundleListener(this);
+		ServiceTracker<ExtendedLogService, ExtendedLogService> tracker = new ServiceTracker<>(context,
+				ExtendedLogService.class, new ServiceTrackerCustomizer<ExtendedLogService, ExtendedLogService>() {
+
+					@Override
+					public ExtendedLogService addingService(ServiceReference<ExtendedLogService> reference) {
+						ExtendedLogService service = context.getService(reference);
+						if (service != null) {
+							if (EquinoxLoggerFactory.logService.compareAndSet(null, service)) {
+								EquinoxLoggerFactory.LOGGER_MAP.clear();
+							}
+						}
+						return service;
+					}
+
+					@Override
+					public void modifiedService(ServiceReference<ExtendedLogService> reference,
+							ExtendedLogService service) {
+						// don't care...
+
+					}
+
+					@Override
+					public void removedService(ServiceReference<ExtendedLogService> reference,
+							ExtendedLogService service) {
+						if (EquinoxLoggerFactory.logService.compareAndSet(service, null)) {
+							EquinoxLoggerFactory.LOGGER_MAP.clear();
+						}
+					}
+				});
+		tracker.open();
+	}
+
+	@Override
+	public void stop(BundleContext context) throws Exception {
+		context.removeBundleListener(this);
+		EquinoxLoggerFactory.logService.set(null);
+		EquinoxLoggerFactory.LOGGER_MAP.clear();
+	}
+
+	@Override
+	public void bundleChanged(BundleEvent event) {
+		if (event.getType() == BundleEvent.UNINSTALLED || event.getType() == BundleEvent.UNRESOLVED) {
+			EquinoxLoggerFactory.LOGGER_MAP.remove(event.getBundle());
+		}
+	}
+
+}

--- a/bundles/org.eclipse.equinox.slf4j/src/org/eclipse/equinox/slf4j/EquinoxSLF4JProvider.java
+++ b/bundles/org.eclipse.equinox.slf4j/src/org/eclipse/equinox/slf4j/EquinoxSLF4JProvider.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Christoph Läubrich and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.equinox.slf4j;
+
+import org.slf4j.ILoggerFactory;
+import org.slf4j.IMarkerFactory;
+import org.slf4j.helpers.BasicMDCAdapter;
+import org.slf4j.helpers.BasicMarkerFactory;
+import org.slf4j.spi.MDCAdapter;
+import org.slf4j.spi.SLF4JServiceProvider;
+
+public class EquinoxSLF4JProvider implements SLF4JServiceProvider {
+
+	private IMarkerFactory markerFactory;
+	private MDCAdapter mdcAdapter;
+	private EquinoxLoggerFactory loggerFactory;
+
+	@Override
+	public void initialize() {
+		loggerFactory = new EquinoxLoggerFactory();
+		markerFactory = new BasicMarkerFactory();
+		mdcAdapter = new BasicMDCAdapter();
+	}
+
+	@Override
+	public ILoggerFactory getLoggerFactory() {
+		return loggerFactory;
+	}
+
+	@Override
+	public IMarkerFactory getMarkerFactory() {
+		return markerFactory;
+	}
+
+	@Override
+	public MDCAdapter getMDCAdapter() {
+		return mdcAdapter;
+	}
+
+	@Override
+	public String getRequestedApiVersion() {
+		// It would be better to replace this by a compile time constant on the other
+		// hand SLF4j currently only supports 2.0 anyways
+		return "2.0.0";
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -189,6 +189,7 @@
 		    <module>bundles/org.eclipse.equinox.coordinator</module>
 		    <module>bundles/org.eclipse.equinox.device</module>
 		    <module>bundles/org.eclipse.equinox.event</module>
+		    <module>bundles/org.eclipse.equinox.slf4j</module>
 		
 		    <module>bundles/org.eclipse.equinox.http.service.api</module>
 		    <module>bundles/org.eclipse.equinox.http.jetty</module>


### PR DESCRIPTION
Currently when running an application with Equinox that uses other logging techniques one has some kind if mixture when it comes to logging as some parts are logging to Equinox Log (especially eclipse platform) and some are logging to something else (e.g. jul, log4j, ...).

A common approach for this is to use bridges that redirect different loggings to one api (e.g. slf4j) and then installing one desired provider to use that for unified logging.

To support such deployments, this now adds a slf4-provider that acts as such provider for slf4j so one can use it with slf4j api and also with such bridges to get a unified logging.

### To test this do the following:

1. Make sure no other provider is included into your product, e.g. start it with -console and type in `ss slf4j`, if needed remove all and if you start your product you should see:
```
SLF4J(W): No SLF4J providers were found.
SLF4J(W): Defaulting to no-operation (NOP) logger implementation
SLF4J(W): See https://www.slf4j.org/codes.html#noProviders for further details.
```

2. Now add the bundle `org.eclipse.equinox.slf4j` to your product and make sure it includes `org.apache.aries.spifly.dynamic.bundle` as well and is started at level 1

An example product can be found here:

```
<?xml version="1.0" encoding="UTF-8"?>
<?pde version="3.5"?>

<product uid="testslf4j" version="1.0.0.qualifier" type="bundles" includeLaunchers="true" autoIncludeRequirements="false">

   <configIni use="default">
   </configIni>

   <launcherArgs>
      <programArgs>-console
      </programArgs>
      <vmArgs>-Declipse.ignoreApp=true
-Dosgi.noShutdown=true
      </vmArgs>
      <vmArgsMac>-XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts
      </vmArgsMac>
   </launcherArgs>

   <launcher>
      <win useIco="false">
         <bmp/>
      </win>
   </launcher>

   <vm>
   </vm>

   <plugins>
      <plugin id="my.logging.bundle"/>
      <plugin id="org.apache.aries.spifly.dynamic.bundle"/>
      <plugin id="org.apache.felix.gogo.command"/>
      <plugin id="org.apache.felix.gogo.runtime"/>
      <plugin id="org.apache.felix.gogo.shell"/>
      <plugin id="org.apache.felix.scr"/>
      <plugin id="org.eclipse.equinox.common"/>
      <plugin id="org.eclipse.equinox.console"/>
      <plugin id="org.eclipse.equinox.slf4j"/>
      <plugin id="org.eclipse.osgi"/>
      <plugin id="org.objectweb.asm"/>
      <plugin id="org.objectweb.asm.commons"/>
      <plugin id="org.objectweb.asm.tree"/>
      <plugin id="org.objectweb.asm.tree.analysis"/>
      <plugin id="org.objectweb.asm.util"/>
      <plugin id="org.osgi.service.component"/>
      <plugin id="org.osgi.util.function"/>
      <plugin id="org.osgi.util.promise"/>
      <plugin id="slf4j.api"/>
   </plugins>

   <configurations>
      <plugin id="my.logging.bundle" autoStart="true" startLevel="0" />
      <plugin id="org.apache.aries.spifly.dynamic.bundle" autoStart="true" startLevel="1" />
      <plugin id="org.apache.felix.scr" autoStart="true" startLevel="2" />
      <plugin id="org.eclipse.core.runtime" autoStart="true" startLevel="0" />
      <plugin id="org.eclipse.equinox.common" autoStart="true" startLevel="2" />
      <plugin id="org.eclipse.equinox.event" autoStart="true" startLevel="2" />
      <plugin id="org.eclipse.equinox.simpleconfigurator" autoStart="true" startLevel="1" />
   </configurations>

</product>
```


that has a `my.logging.bundle` bundle using SLF4J and then you will see log messages like this:

```
!SESSION 2025-02-09 08:49:41.906 -----------------------------------------------
eclipse.buildId=unknown
java.version=21
java.vendor=Oracle Corporation
BootLoader constants: OS=linux, ARCH=x86_64, WS=gtk, NL=de_DE
Framework arguments:  -application 
Command-line arguments:  -application  -data /opt/eclipse/platform-sdk/ws/../runtime-testslf4j.product -dev file:///opt/eclipse/platform-sdk/ws/.metadata/.plugins/org.eclipse.pde.core/testslf4j.product/dev.properties -os linux -ws gtk -arch x86_64 -consoleLog -console

!ENTRY my.logging.bundle 2 0 2025-02-09 08:49:42.376
!MESSAGE I warn you!

!ENTRY my.logging.bundle 1 0 2025-02-09 08:49:42.377
!MESSAGE This is an info

!ENTRY my.logging.bundle 0 0 2025-02-09 08:49:42.377
!MESSAGE Debug
```