### PR TITLE
Add simple test for the external classpath

### DIFF
--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/bundles/classes/ExternalClassPathActivator.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/bundles/classes/ExternalClassPathActivator.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.osgi.tests.bundles.classes;
+
+import java.net.URL;
+import org.osgi.framework.BundleActivator;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.wiring.BundleWiring;
+
+public class ExternalClassPathActivator implements BundleActivator {
+
+	@Override
+	public void start(BundleContext context) throws Exception {
+		URL resource = context.getBundle().adapt(BundleWiring.class).getClassLoader().getResource("lib/resource.txt");
+		System.out.println(resource.toExternalForm());
+	}
+
+	@Override
+	public void stop(BundleContext context) throws Exception {
+		// TODO Auto-generated method stub
+
+	}
+
+}


### PR DESCRIPTION
Not a recommended feature to use, but there are zero tests for the external class-path for bundles.  Adding a testcase that was written while debugging an issue with external class-paths