### PR TITLE
Update reexported version of org.eclipse.core.text package

### DIFF
--- a/bundles/org.eclipse.equinox.common/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.common/META-INF/MANIFEST.MF
@@ -15,7 +15,7 @@ Export-Package: org.eclipse.core.internal.boot;x-friends:="org.eclipse.core.reso
    org.eclipse.core.filesystem,
    org.eclipse.equinox.security",
  org.eclipse.core.runtime;common=split;version="3.7.0";mandatory:=common,
- org.eclipse.core.text;version="3.13.0",
+ org.eclipse.core.text;version="3.14.0",
  org.eclipse.equinox.events;version="1.0.0"
 Bundle-Vendor: %providerName
 Bundle-Activator: org.eclipse.core.internal.runtime.Activator


### PR DESCRIPTION
The minor version for the package 'org.eclipse.core.text' should be incremented to version 3.14.0,
since new APIs have been added since version 3.13.0

Fixes https://github.com/eclipse-equinox/equinox/issues/742