### PR TITLE
Improve how Equinox trace is disabled with LoggerAdmin

### DIFF
--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/equinox/log/test/LogEquinoxTraceTest.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/equinox/log/test/LogEquinoxTraceTest.java
@@ -169,9 +169,8 @@ public class LogEquinoxTraceTest extends AbstractBundleTests {
 					logEntry.getLoggerName());
 		}
 
-		// remove all debug options which should disable debug trace
-		rootLogLevels.clear();
-		rootLogLevels.put(Debug.EQUINOX_TRACE, LogLevel.TRACE);
+		// Setting the EQUINOX.TRACE to anything but trace should disable
+		rootLogLevels.put(Debug.EQUINOX_TRACE, LogLevel.AUDIT);
 		rootContext.setLogLevels(rootLogLevels);
 		assertFalse("Expected debug to be disabled.", debugOptions.isDebugEnabled());
 		assertEquals("Expected no debug Options.", 0, debugOptions.getOptions().size());

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/log/ExtendedLogServiceFactory.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/log/ExtendedLogServiceFactory.java
@@ -251,18 +251,21 @@ public class ExtendedLogServiceFactory implements ServiceFactory<ExtendedLogServ
 			}
 			Map<String, LogLevel> logLevels = systemBundleLoggerContext.getEffectiveLogLevels();
 			LogLevel equinoxTrace = logLevels.remove(Debug.EQUINOX_TRACE);
-			if (equinoxTrace != LogLevel.TRACE) {
+			if (equinoxTrace == null) {
 				return;
 			}
 			DebugOptions debugOptions = getConfiguration().getDebugOptions();
 			Map<String, String> options = debugOptions.getOptions();
 			options.clear();
 			boolean enable = false;
-			for (Entry<String, LogLevel> level : logLevels.entrySet()) {
-				if (level.getValue() == LogLevel.TRACE
-						&& !(EQUINOX_LOGGER_NAME.equals(level.getKey()) || PERF_LOGGER_NAME.equals(level.getKey()))) {
-					options.put(level.getKey(), Boolean.TRUE.toString());
-					enable = true;
+			if (equinoxTrace == LogLevel.TRACE) {
+				// enable trace options if the EQUINOX.TRACE is set to trace
+				for (Entry<String, LogLevel> level : logLevels.entrySet()) {
+					if (level.getValue() == LogLevel.TRACE && !(EQUINOX_LOGGER_NAME.equals(level.getKey())
+							|| PERF_LOGGER_NAME.equals(level.getKey()))) {
+						options.put(level.getKey(), Boolean.TRUE.toString());
+						enable = true;
+					}
 				}
 			}
 			debugOptions.setOptions(options);


### PR DESCRIPTION
Use EQUINOX.TRACE key to disable trace also with any value that is not LogLevel.TRACE.