### PR TITLE
Build launcher with older version of debian to limit glibc version required

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,7 @@ def runOnNativeBuildAgent(String platform, Closure body) {
 	def final nativeBuildStageName = 'Perform native launcher build'
 	if (platform == 'gtk.linux.x86_64') {
 		podTemplate(inheritFrom: 'basic' /* inherit general configuration */, containers: [
-			containerTemplate(name: 'launcherbuild', image: 'eclipse/platformreleng-debian-swtnativebuild:12',
+			containerTemplate(name: 'launcherbuild', image: 'eclipse/platformreleng-debian-swtgtk3nativebuild:10',
 				resourceRequestCpu:'1000m', resourceRequestMemory:'512Mi',
 				resourceLimitCpu:'2000m', resourceLimitMemory:'4096Mi',
 				alwaysPullImage: true, command: 'cat', ttyEnabled: true)
@@ -219,7 +219,7 @@ pipeline {
 									withEnv(["JAVA_HOME=${WORKSPACE}/jdk.resources", "EXE_OUTPUT_DIR=${WORKSPACE}/libs", "LIB_OUTPUT_DIR=${WORKSPACE}/libs"]) {
 										dir(ws) {
 											if (isUnix()) {
-												sh "sh build.sh -ws ${ws} -os ${os} -arch ${arch} install"
+												sh "sh build.sh -ws ${ws} -os ${os} -arch ${arch} checklibs install"
 											} else {
 												bat "cmd /c build.bat -ws ${ws} -os ${os} -arch ${arch} install"
 											}

--- a/bundles/org.eclipse.equinox.launcher.cocoa.macosx.aarch64/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.launcher.cocoa.macosx.aarch64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.equinox.launcher.cocoa.macosx.aarch64;singleton:=true
-Bundle-Version: 1.2.1100.qualifier
+Bundle-Version: 1.2.1200.qualifier
 Fragment-Host: org.eclipse.equinox.launcher;bundle-version="[1.6.0,1.7.0)"
 Eclipse-PlatformFilter: (& (osgi.ws=cocoa) (osgi.os=macosx) (osgi.arch=aarch64) )
 Bundle-Localization: launcher.cocoa.macosx.aarch64

--- a/bundles/org.eclipse.equinox.launcher.cocoa.macosx.x86_64/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.launcher.cocoa.macosx.x86_64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.equinox.launcher.cocoa.macosx.x86_64;singleton:=true
-Bundle-Version: 1.2.1100.qualifier
+Bundle-Version: 1.2.1200.qualifier
 Fragment-Host: org.eclipse.equinox.launcher;bundle-version="[1.6.0,1.7.0)"
 Eclipse-PlatformFilter: (& (osgi.ws=cocoa) (osgi.os=macosx) (osgi.arch=x86_64) )
 Bundle-Localization: launcher.cocoa.macosx.x86_64

--- a/bundles/org.eclipse.equinox.launcher.win32.win32.aarch64/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.launcher.win32.win32.aarch64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.equinox.launcher.win32.win32.aarch64;singleton:=true
-Bundle-Version: 1.2.1100.qualifier
+Bundle-Version: 1.2.1200.qualifier
 Fragment-Host: org.eclipse.equinox.launcher;bundle-version="[1.6.0,1.7.0)"
 Eclipse-PlatformFilter: (& (osgi.ws=win32) (osgi.os=win32) (osgi.arch=aarch64))
 Bundle-Localization: launcher.win32.win32.aarch64

--- a/bundles/org.eclipse.equinox.launcher.win32.win32.x86_64/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.launcher.win32.win32.x86_64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.equinox.launcher.win32.win32.x86_64;singleton:=true
-Bundle-Version: 1.2.1100.qualifier
+Bundle-Version: 1.2.1200.qualifier
 Fragment-Host: org.eclipse.equinox.launcher;bundle-version="[1.6.0,1.7.0)"
 Eclipse-PlatformFilter: (& (osgi.ws=win32) (osgi.os=win32) (osgi.arch=x86_64))
 Bundle-Localization: launcher.win32.win32.x86_64

--- a/features/org.eclipse.equinox.executable.feature/library/cocoa/make_cocoa.mak
+++ b/features/org.eclipse.equinox.executable.feature/library/cocoa/make_cocoa.mak
@@ -85,6 +85,9 @@ $(EXEC): $(MAIN_OBJS) $(COMMON_OBJS)
 $(DLL): $(DLL_OBJS) $(COMMON_OBJS)
 	$(CC) -bundle -o $(DLL) $(ARCHS) $(DLL_OBJS) $(COMMON_OBJS) $(LIBS)
 
+# There are no known checks today for macOS to be done here. See make_linux.mak's checklibs for more info.
+checklibs: all
+
 install: all
 	$(info Install into: EXE_OUTPUT_DIR:$(EXE_OUTPUT_DIR) LIB_OUTPUT_DIR:$(LIB_OUTPUT_DIR))
 	mkdir -p $(EXE_OUTPUT_DIR)

--- a/features/org.eclipse.equinox.executable.feature/library/gtk/check_dependencies.sh
+++ b/features/org.eclipse.equinox.executable.feature/library/gtk/check_dependencies.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+###############################################################################
+# Copyright (c) 2020, 2025 Kichwa Coders Canada Inc and others.
+#
+# This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+
+set -eu
+set -o pipefail
+
+SCRIPT=$( basename "${BASH_SOURCE[0]}" )
+
+###
+# Check that executable/so ${FILE}
+# use glibc symbols no greater than ${ALLOWED_GLIBC_VERSION} and depend on
+# no libs other than ${ALLOWED_LIBS}
+FILE=$1; shift
+ALLOWED_GLIBC_VERSION=$1; shift
+ALLOWED_LIBS="$@"; shift
+
+# Check for permitted libraries using `readelf -d` looking for shared
+# libraries that are listed as needed. e.g. lines like:
+#  0x0000000000000001 (NEEDED)             Shared library: [libpthread.so.0]
+readelf -d ${FILE} | grep -E '\(NEEDED\)' | while read needed; do
+    needed=${needed//*Shared library: [/}
+    needed=${needed//]*/}
+    if [[ ! " ${ALLOWED_LIBS} " =~ " ${needed} " ]]; then
+        echo "ERROR: $FILE has illegal dependency of ${needed}"
+        exit 1
+    fi
+done
+
+# The way the version check is done is that all symbol version info is extracted
+# from relocations match @GLIBC_*, the versions are sorted with the max
+# allowed version added to the list too. And then we check the last entry in
+# the list to make sure it is == to max allowed version.
+objdump -R ${FILE} | grep @GLIBC_ | while read version; do
+    echo ${version//*@GLIBC_}
+done > /tmp/version_check
+echo ${ALLOWED_GLIBC_VERSION} >> /tmp/version_check
+max_version_in_use=$(cat /tmp/version_check | sort --unique --version-sort | tail -n1)
+if [ "$max_version_in_use" != "$ALLOWED_GLIBC_VERSION" ]; then
+    echo "ERROR: $FILE has dependency on glibc greater than allowed version of ${ALLOWED_GLIBC_VERSION} for at least the following symbols"
+    # This only lists greatest version number symbols
+    objdump -R ${FILE} | grep @GLIBC_${max_version_in_use}
+    exit 1
+fi

--- a/features/org.eclipse.equinox.executable.feature/library/gtk/make_linux.mak
+++ b/features/org.eclipse.equinox.executable.feature/library/gtk/make_linux.mak
@@ -133,6 +133,34 @@ $(DLL): $(DLL_OBJS) $(COMMON_OBJS)
 	$(info Linking and generating: $(DLL))
 	$(CC) $(LFLAGS) -o $(DLL) $(DLL_OBJS) $(COMMON_OBJS) $(LIBS)
 
+
+# Permitted dependencies and glibc versions
+# This does not include libraries that are dynamically loaded with dlopen,
+# like all the gtk libraries. The purpose of this list, and the version
+# limit on glibc is to ensure eclipse launcher will be able to start
+# on the widest range on Linuxes.
+# All other error handling regarding missing/problematic libraries
+# can be done at runtime.
+ifeq ($(DEFAULT_OS_ARCH),x86_64)
+PERMITTED_LIBRARIES=libc.so.6 libpthread.so.0 libdl.so.2
+PERMITTED_GLIBC_VERSION=2.7
+checklibs: all
+	$(info Verifying $(EXEC) $(DLL) have permitted dependencies)
+	./check_dependencies.sh $(EXEC) $(PERMITTED_GLIBC_VERSION) $(PERMITTED_LIBRARIES)
+	./check_dependencies.sh $(DLL) $(PERMITTED_GLIBC_VERSION) $(PERMITTED_LIBRARIES)
+else
+# We don't enforce max version and library sets on non-x86-64 because
+# 1. We build on native hardware for those platforms so we don't have
+#    ability to use docker to adjust dependency versions as easily
+# 2. The other platforms that are newer are generally faster moving
+#    and it is less likely to break users to have harder version
+#    requirements.
+# As we get bigger user base on non-x86-64 we should start enforcing
+# upper bounds for them too.
+checklibs: all
+endif
+
+
 install: all
 	$(info Install into: EXE_OUTPUT_DIR:$(EXE_OUTPUT_DIR) LIB_OUTPUT_DIR:$(LIB_OUTPUT_DIR))
 	mkdir -p $(EXE_OUTPUT_DIR)


### PR DESCRIPTION
Doing this allows eclipse launcher to run on older Linux installs than the just the most recent versions. In particular this is important to ensure users who do check for updates end up with a still working eclipse launcher.

In addition, this commit introduces a check in the build process that the built eclipse/eclipse.so only contains the expected sets of dependencies.

The x86_64 PERMITTED_GLIBC_VERSION value is based on what Eclipse 4.34 used and what is now achieved again with this commit. For other linux platforms we don't enforce versions yet.

The check_dependencies.sh script was derived from work I did on CDT [here](https://github.com/eclipse-cdt/cdt/blob/dfdc174b6d972037db2f299457fac9f0dd44c081/releng/scripts/check_glibc_dependencies.sh)

Requires https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/2802

Fixes https://github.com/eclipse-equinox/equinox/issues/830