### PR TITLE
Adjust the metadata of equinox-slf4j provider

### DIFF
--- a/bundles/org.eclipse.equinox.slf4j/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.slf4j/META-INF/MANIFEST.MF
@@ -4,14 +4,14 @@ Bundle-Name: %bundleName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.equinox.slf4j
 Bundle-Version: 1.0.0.qualifier
-Import-Package: org.slf4j;version="[1.7.30,3.0.0)",
- org.slf4j.helpers;version="[1.7.0,3.0.0)",
- org.slf4j.spi;version="[1.7.0,3.0.0)"
+Import-Package: org.slf4j;version="[2.0.0,3.0.0)",
+ org.slf4j.helpers;version="[2.0.0,3.0.0)",
+ org.slf4j.spi;version="[2.0.0,3.0.0)"
 Require-Bundle: org.eclipse.equinox.common;bundle-version="[3.20.0,4.0.0)",
  org.eclipse.osgi;bundle-version="[3.23.0,4.0.0)"
 Automatic-Module-Name: org.eclipse.equinox.slf4j
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: org.eclipse.equinox.slf4j.EquinoxLoggerFactoryActivator
 Bundle-RequiredExecutionEnvironment: JavaSE-17
-Provide-Capability: osgi.serviceloader;osgi.serviceloader="org.slf4j.spi.SLF4JServiceProvider";register:="org.eclipse.equinox.slf4j.EquinoxLoggerFactory";uses:="org.slf4j.spi,org.slf4j"
+Provide-Capability: osgi.serviceloader;osgi.serviceloader="org.slf4j.spi.SLF4JServiceProvider";register:="org.eclipse.equinox.slf4j.EquinoxLoggerFactory";type=equinox
 Require-Capability: osgi.extender;filter:="(osgi.extender=osgi.serviceloader.registrar)"


### PR DESCRIPTION
- do not add uses
- use a type
- use 2.0 for lower bounds of slf4j