### PR TITLE
Fix org.eclipse.equinox.slf4j bundle localization and build properties

### DIFF
--- a/bundles/org.eclipse.equinox.slf4j/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.slf4j/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-Vendor: %providerName
+Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.equinox.slf4j
 Bundle-Version: 1.0.0.qualifier
 Import-Package: org.slf4j;version="[2.0.0,3.0.0)",

--- a/bundles/org.eclipse.equinox.slf4j/build.properties
+++ b/bundles/org.eclipse.equinox.slf4j/build.properties
@@ -4,5 +4,4 @@ bin.includes = META-INF/,\
                .,\
                about.html,\
                plugin.properties
-src.includes = about.html,\
-               plugin.properties
+src.includes = about.html


### PR DESCRIPTION
Small cosmetic change to show proper bundle name in installer dialog & to fix warning in build properties