### PR TITLE
Use import-package instead of require-bundle

### DIFF
--- a/bundles/org.eclipse.equinox.slf4j/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.slf4j/META-INF/MANIFEST.MF
@@ -5,11 +5,14 @@ Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.equinox.slf4j
 Bundle-Version: 1.0.0.qualifier
-Import-Package: org.slf4j;version="[2.0.0,3.0.0)",
+Import-Package: org.eclipse.equinox.log;version="[1.1.0,2.0.0)",
+ org.osgi.framework;version="[1.10.0,2.0.0)",
+ org.osgi.service.log;version="[1.5.0,2.0.0)",
+ org.osgi.util.tracker;version="[1.5.0,2.0.0)",
+ org.slf4j;version="[2.0.0,3.0.0)",
  org.slf4j.helpers;version="[2.0.0,3.0.0)",
  org.slf4j.spi;version="[2.0.0,3.0.0)"
-Require-Bundle: org.eclipse.equinox.common;bundle-version="[3.20.0,4.0.0)",
- org.eclipse.osgi;bundle-version="[3.23.0,4.0.0)"
+Require-Bundle: org.eclipse.equinox.common;bundle-version="[3.20.0,4.0.0)"
 Automatic-Module-Name: org.eclipse.equinox.slf4j
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: org.eclipse.equinox.slf4j.EquinoxLoggerFactoryActivator


### PR DESCRIPTION
So it can work with "older" eclipse release used in Tycho-Api tools