### PR TITLE
Fix org.eclipse.equinox.launcher.Main.buildURI to decode URIs

### DIFF
--- a/bundles/org.eclipse.equinox.launcher/src/org/eclipse/equinox/launcher/Main.java
+++ b/bundles/org.eclipse.equinox.launcher/src/org/eclipse/equinox/launcher/Main.java
@@ -32,6 +32,8 @@ import java.io.UnsupportedEncodingException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.net.URLConnection;
@@ -1177,7 +1179,7 @@ public class Main {
 		boolean isFile = spec.startsWith(FILE_SCHEME);
 		try {
 			if (isFile) {
-				File toAdjust = new File(spec.substring(5));
+				File toAdjust = toFileURL(spec);
 				toAdjust = resolveFile(toAdjust);
 				if (toAdjust.isDirectory())
 					return adjustTrailingSlash(toAdjust.toURL(), trailingSlash);
@@ -1197,6 +1199,15 @@ public class Main {
 			} catch (MalformedURLException e1) {
 				return null;
 			}
+		}
+	}
+
+	private static File toFileURL(String spec) {
+		try {
+			// Try to build it from a URI that will be properly decoded.
+			return new File(new URI(spec));
+		} catch (URISyntaxException | IllegalArgumentException e) {
+			return new File(spec.substring(5));
 		}
 	}
 

--- a/bundles/org.eclipse.osgi/supplement/src/org/eclipse/osgi/internal/location/LocationHelper.java
+++ b/bundles/org.eclipse.osgi/supplement/src/org/eclipse/osgi/internal/location/LocationHelper.java
@@ -41,7 +41,7 @@ public class LocationHelper {
 		boolean isFile = spec.startsWith("file:"); //$NON-NLS-1$
 		try {
 			if (isFile)
-				return adjustTrailingSlash(new File(spec.substring(5)).toURL(), trailingSlash);
+				return adjustTrailingSlash(toFileURL(spec).toURL(), trailingSlash);
 			return new URL(spec);
 		} catch (MalformedURLException e) {
 			// if we failed and it is a file spec, there is nothing more we can do
@@ -53,6 +53,15 @@ public class LocationHelper {
 			} catch (MalformedURLException e1) {
 				return null;
 			}
+		}
+	}
+
+	private static File toFileURL(String spec) {
+		try {
+			// Try to build it from a URI that will be properly decoded.
+			return new File(new URI(spec));
+		} catch (URISyntaxException | IllegalArgumentException e) {
+			return new File(spec.substring(5));
 		}
 	}
 


### PR DESCRIPTION
- First try to create a URI from the spec and then create a File from that URI to ensure that the spec is properly decoded.

https://github.com/eclipse-pde/eclipse.pde/issues/1630