### PR TITLE
Prevent NPE by Adding Null Check

### DIFF
--- a/bundles/org.eclipse.osgi/felix/src/org/apache/felix/resolver/ProblemReduction.java
+++ b/bundles/org.eclipse.osgi/felix/src/org/apache/felix/resolver/ProblemReduction.java
@@ -51,6 +51,9 @@ class ProblemReduction {
         Resource targetResource = requirement.getResource();
         // fetch the current candidate for this requirement
         Capability currentCandidate = candidates.getFirstCandidate(requirement);
+		if (currentCandidate == null) {
+			return Collections.emptyList();
+		}
         Resource candidateResource = currentCandidate.getResource();
         // now check if it has any uses constraints
         Set<String> uses = new TreeSet<>(Util.getUses(currentCandidate));


### PR DESCRIPTION
Added null check to prevent NPE when retrieving
org.osgi.resource.Capability via org.apache.felix.resolver.Candidates.getFirstCandidate(Requirement) method.

Fixes : https://github.com/eclipse-equinox/equinox/issues/723