### PR TITLE
README: Add link to new documentation website and fixed homepage link

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Equinox implements the follwoing specification with the given level of complianc
 
 # More information
 
-- Homepage: https://www.eclipse.org/equinox/
+- Homepage: https://equinox.eclipseprojects.io/
 - Bug tracker: https://github.com/eclipse-equinox/equinox/issues
 - Asking questions and share ideas: https://github.com/eclipse-equinox/equinox/discussions
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,12 +1,10 @@
 # Equinox Documentation
 
-This is the documentation of the Eclipse Equinox Framework.
-[https://github.com/eclipse-equinox/equinox](https://github.com/eclipse-equinox/equinox)
+This is the documentation of the [Eclipse Equinox Framework](https://projects.eclipse.org/projects/eclipse.equinox).
 
 Equinox is an implementation of the OSGi core framework specification, a set of bundles that implement various optional OSGi services and other infrastructure for running OSGi-based systems.
 
-PRs to improve the documentation are always welcome.
-
+Github: [https://github.com/eclipse-equinox/equinox](https://github.com/eclipse-equinox/equinox)
 
 
 ## Articles
@@ -43,3 +41,6 @@ PRs to improve the documentation are always welcome.
         {% endfor %}
     </tbody>
 </table>
+
+
+PRs on [Github](https://github.com/eclipse-equinox/equinox/tree/master/docs) to improve the documentation are always welcome.


### PR DESCRIPTION
- added Documentation: https://equinox.eclipseprojects.io/
- fixed Homepage link, which gave a 404 before.