### PR TITLE
Fix bugs in the file-search logic at Equinox launcher Main

### DIFF
--- a/bundles/org.eclipse.equinox.launcher/src/org/eclipse/equinox/launcher/Main.java
+++ b/bundles/org.eclipse.equinox.launcher/src/org/eclipse/equinox/launcher/Main.java
@@ -506,7 +506,6 @@ public class Main {
 
 	private String getLibraryPath(String fragmentName, URL[] defaultPath) {
 		String libPath = null;
-		String fragment = null;
 		if (inDevelopmentMode && devClassPathProps != null) {
 			String devPathList = devClassPathProps.getProperty(PLUGIN_ID);
 			String[] locations = getArrayFromList(devPathList);
@@ -514,7 +513,7 @@ public class Main {
 				File location = new File(locations[0]);
 				if (location.isAbsolute()) {
 					String dir = location.getParent();
-					fragment = searchFor(fragmentName, dir);
+					String fragment = searchFor(fragmentName, dir);
 					if (fragment != null) {
 						libPath = getLibraryFromFragment(fragment);
 					}
@@ -528,9 +527,7 @@ public class Main {
 				for (int i = urls.length - 1; i >= 0 && libPath == null; i--) {
 					File entryFile = new File(urls[i].getFile());
 					String dir = entryFile.getParent();
-					if (fragment == null) {
-						fragment = searchFor(fragmentName, dir);
-					}
+					String fragment = searchFor(fragmentName, dir);
 					if (fragment != null) {
 						libPath = getLibraryFromFragment(fragment);
 					}
@@ -541,7 +538,7 @@ public class Main {
 			URL install = getInstallLocation();
 			String location = install.getFile();
 			location += "/plugins/"; //$NON-NLS-1$
-			fragment = searchFor(fragmentName, location);
+			String fragment = searchFor(fragmentName, location);
 			if (fragment != null) {
 				libPath = getLibraryFromFragment(fragment);
 			}
@@ -1089,7 +1086,7 @@ public class Main {
 		if (result == -1) {
 			return null;
 		}
-		File candidate = new File(start, names[result]);
+		File candidate = new File(root, names[result]);
 		return candidate.getAbsolutePath().replace(File.separatorChar, '/') + (candidate.isDirectory() ? "/" : ""); //$NON-NLS-1$//$NON-NLS-2$
 	}
 


### PR DESCRIPTION
1. When searching the library-path with an explicit bootLocation available not always the fragment from the current directory was considered. Instead the first one found was reused for all other directories.
2. When searching for a target directory the final result was resolved against the given start directory instead of the resolved search root, where the target-directory was actually found.