### PR TITLE
Touch org.eclipse.equinox.launcher to reflect compiler changes

### DIFF
--- a/bundles/org.eclipse.equinox.launcher/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.launcher/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@
 Bug 403352 - Update all parent versions to match our build stream
 Bug 534597 - Unanticipated comparator errors in I20180511-2000
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2972


### PR DESCRIPTION
See https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2972