### PR TITLE
Add Enable-Native-Access: ALL-UNNAMED to launcher manifest

### DIFF
--- a/bundles/org.eclipse.equinox.launcher/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.launcher/META-INF/MANIFEST.MF
@@ -8,4 +8,5 @@ Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Localization: launcher
 Export-Package: org.eclipse.equinox.launcher;x-internal:=true
+Enable-Native-Access: ALL-UNNAMED
 Automatic-Module-Name: org.eclipse.equinox.launcher


### PR DESCRIPTION
Due to https://openjdk.org/jeps/472 there is:
```
WARNING: A restricted method in java.lang.Runtime has been called
WARNING: java.lang.Runtime::load has been called by
org.eclipse.equinox.launcher.JNIBridge in an unnamed module
(file:/home/jenkins/agent/workspace/AutomatedTests/ep436I-unit-linux-x86_64-java24/workarea/I20250411-0200/eclipse-testing/platformLocation/eclipse/plugins/org.eclipse.equinox.launcher_1.6.1000.v20250227-1734.jar)
WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for
callers in this module
WARNING: Restricted methods will be blocked in a future release unless
native access is enabled
```
whenever the launcher is used.
As per the description in the jep putting this manifest header should fix at least the cases where launcher is used as jar file. Unfortunately, this doesn't help with starting inner eclipse. As having custom manifest entries is allowed I'm pushing this one as it helps a tiny bit to see the warning less.