### PR TITLE
Change NLS.bind(String, Object[]) to varargs

### DIFF
--- a/bundles/org.eclipse.equinox.app/src/org/eclipse/equinox/internal/app/EclipseAppHandle.java
+++ b/bundles/org.eclipse.equinox.app/src/org/eclipse/equinox/internal/app/EclipseAppHandle.java
@@ -7,7 +7,7 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     Josh Arnold - Bug 180080 Equinox Application Admin spec violations
@@ -229,9 +229,8 @@ public class EclipseAppHandle extends ApplicationHandle implements ApplicationRu
 		}
 
 		if (Activator.DEBUG) {
-			System.out.println(NLS.bind(Messages.application_returned,
-					(new String[] { getApplicationDescriptor().getApplicationId(),
-							tempResult == null ? "null" : tempResult.toString() }))); //$NON-NLS-1$
+			System.out.println(NLS.bind(Messages.application_returned, getApplicationDescriptor().getApplicationId(),
+					tempResult == null ? "null" : tempResult.toString())); //$NON-NLS-1$
 		}
 		return tempResult;
 	}

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/Adapters.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/Adapters.java
@@ -135,8 +135,7 @@ public class Adapters {
 			return Optional.ofNullable(adapt(sourceObject, adapter));
 		} catch (AssertionFailedException e) {
 			RuntimeLog.log(Status.error(
-					NLS.bind(CommonMessages.adapters_internal_error_of, new Object[] {
-							sourceObject.getClass().getName(), adapter.getClass().getName(), e.getLocalizedMessage() }),
+					NLS.bind(CommonMessages.adapters_internal_error_of, sourceObject.getClass().getName(), adapter.getClass().getName(), e.getLocalizedMessage()),
 					e));
 			return Optional.empty();
 		}

--- a/bundles/org.eclipse.equinox.coordinator/src/org/eclipse/equinox/coordinator/CoordinationImpl.java
+++ b/bundles/org.eclipse.equinox.coordinator/src/org/eclipse/equinox/coordinator/CoordinationImpl.java
@@ -108,9 +108,8 @@ public class CoordinationImpl {
 					// any thread, and there's nothing to compare. If the coordination
 					// is using this thread, then we can't block due to risk of deadlock.
 					if (t == Thread.currentThread()) {
-						throw new CoordinationException(
-								NLS.bind(Messages.Deadlock, new Object[] { participant, getName(), getId() }), referent,
-								CoordinationException.DEADLOCK_DETECTED);
+						throw new CoordinationException(NLS.bind(Messages.Deadlock, participant, getName(), getId()),
+								referent, CoordinationException.DEADLOCK_DETECTED);
 					}
 				}
 			}
@@ -122,8 +121,8 @@ public class CoordinationImpl {
 			try {
 				coordination.join(1000);
 			} catch (InterruptedException e) {
-				String message = NLS.bind(Messages.LockInterrupted,
-						new Object[] { participant, name, id, coordination.getName(), coordination.getId() });
+				String message = NLS.bind(Messages.LockInterrupted, participant, name, id, coordination.getName(),
+						coordination.getId());
 				coordinator.getLogService().debug(message, e);
 				// This thread was interrupted while waiting for the coordination
 				// to terminate.
@@ -154,9 +153,8 @@ public class CoordinationImpl {
 				// pushed them onto the stack, if any.
 				if (thread != Thread.currentThread()) {
 					throw new CoordinationException(
-							NLS.bind(Messages.EndingThreadNotSame,
-									new Object[] { name, id, thread, Thread.currentThread() }),
-							referent, CoordinationException.WRONG_THREAD);
+							NLS.bind(Messages.EndingThreadNotSame, name, id, thread, Thread.currentThread()), referent,
+							CoordinationException.WRONG_THREAD);
 				}
 				// Unwind the stack in case there are other coordinations higher
 				// up than this one. See bug 421487 for why peek() may be null.
@@ -190,7 +188,7 @@ public class CoordinationImpl {
 			try {
 				participant.ended(referent);
 			} catch (Exception e) {
-				coordinator.getLogService().warn(NLS.bind(Messages.ParticipantEndedError, new Object[] { participant, name, id }), e);
+				coordinator.getLogService().warn(NLS.bind(Messages.ParticipantEndedError, participant, name, id), e);
 				// Only the first exception will be propagated.
 				if (exception == null) {
 					exception = e;
@@ -205,8 +203,8 @@ public class CoordinationImpl {
 		// If a partial ending has occurred, throw the required exception.
 		if (exception != null) {
 			throw new CoordinationException(
-					NLS.bind(Messages.CoordinationPartiallyEnded, new Object[] { name, id, exceptionParticipant }),
-					referent, CoordinationException.PARTIALLY_ENDED, exception);
+					NLS.bind(Messages.CoordinationPartiallyEnded, name, id, exceptionParticipant), referent,
+					CoordinationException.PARTIALLY_ENDED, exception);
 		}
 	}
 
@@ -243,7 +241,7 @@ public class CoordinationImpl {
 					timeInMillis = newTotalTimeout - maxTimeout;
 				}
 				// Otherwise, accept the full extension.
- else {
+				else {
 					totalTimeout = newTotalTimeout;
 				}
 			}
@@ -262,10 +260,8 @@ public class CoordinationImpl {
 					// Now determine how it terminated and throw the appropriate exception.
 					checkTerminated();
 				} catch (InterruptedException e) {
-					throw new CoordinationException(
-							NLS.bind(Messages.InterruptedTimeoutExtension,
-									new Object[] { totalTimeout, getName(), getId(), timeInMillis }),
-							referent, CoordinationException.UNKNOWN, e);
+					throw new CoordinationException(NLS.bind(Messages.InterruptedTimeoutExtension, totalTimeout,
+							getName(), getId(), timeInMillis), referent, CoordinationException.UNKNOWN, e);
 				}
 			}
 			// Create the new timeout.
@@ -306,7 +302,7 @@ public class CoordinationImpl {
 			try {
 				participant.failed(referent);
 			} catch (Exception e) {
-				coordinator.getLogService().warn(NLS.bind(Messages.ParticipantFailedError, new Object[] { participant, name, id }), e);
+				coordinator.getLogService().warn(NLS.bind(Messages.ParticipantFailedError, participant, name, id), e);
 			}
 		}
 		synchronized (this) {

--- a/bundles/org.eclipse.equinox.coordinator/src/org/eclipse/equinox/coordinator/CoordinationTimerTask.java
+++ b/bundles/org.eclipse.equinox.coordinator/src/org/eclipse/equinox/coordinator/CoordinationTimerTask.java
@@ -35,8 +35,8 @@ public class CoordinationTimerTask extends TimerTask {
 		try {
 			coordination.fail(Coordination.TIMEOUT);
 		} catch (Throwable t) {
-			coordination.getLogService().error(NLS.bind(Messages.CoordinationTimedOutError,
-					new Object[] { coordination.getName(), coordination.getId(), Thread.currentThread() }), t);
+			coordination.getLogService().error(NLS.bind(Messages.CoordinationTimedOutError, coordination.getName(),
+					coordination.getId(), Thread.currentThread()), t);
 		}
 	}
 }

--- a/bundles/org.eclipse.equinox.coordinator/src/org/eclipse/equinox/coordinator/CoordinatorImpl.java
+++ b/bundles/org.eclipse.equinox.coordinator/src/org/eclipse/equinox/coordinator/CoordinatorImpl.java
@@ -90,8 +90,7 @@ public class CoordinatorImpl implements Coordinator {
 		public void push(CoordinationImpl c) {
 			if (contains(c)) {
 				throw new CoordinationException(
-						NLS.bind(Messages.CoordinationAlreadyExists,
-								new Object[] { c.getName(), c.getId(), Thread.currentThread() }),
+						NLS.bind(Messages.CoordinationAlreadyExists, c.getName(), c.getId(), Thread.currentThread()),
 						c.getReferent(), CoordinationException.ALREADY_PUSHED);
 			}
 			c.setThreadAndEnclosingCoordination(Thread.currentThread(),
@@ -145,7 +144,7 @@ public class CoordinatorImpl implements Coordinator {
 		// Override the requested timeout with the max timeout, if necessary.
 		if (maxTimeout != 0) {
 			if (timeout == 0 || maxTimeout < timeout) {
-				logTracker.warn(NLS.bind(Messages.MaximumTimeout, new Object[] { timeout, maxTimeout, name }));
+				logTracker.warn(NLS.bind(Messages.MaximumTimeout, timeout, maxTimeout, name));
 				timeout = maxTimeout;
 			}
 		}
@@ -202,8 +201,8 @@ public class CoordinatorImpl implements Coordinator {
 			try {
 				checkPermission(CoordinationPermission.ADMIN, result.getName());
 			} catch (SecurityException e) {
-				logTracker.debug(NLS.bind(Messages.GetCoordinationNotPermitted,
-						new Object[] { Thread.currentThread(), result.getName(), result.getId() }), e);
+				logTracker.debug(NLS.bind(Messages.GetCoordinationNotPermitted, Thread.currentThread(),
+						result.getName(), result.getId()), e);
 				result = null;
 			}
 		}
@@ -226,8 +225,8 @@ public class CoordinatorImpl implements Coordinator {
 					checkPermission(CoordinationPermission.ADMIN, coordination.getName());
 					result.add(coordination.getReferent());
 				} catch (SecurityException e) {
-					logTracker.debug(NLS.bind(Messages.GetCoordinationNotPermitted,
-							new Object[] { Thread.currentThread(), coordination.getName(), coordination.getId() }), e);
+					logTracker.debug(NLS.bind(Messages.GetCoordinationNotPermitted, Thread.currentThread(),
+							coordination.getName(), coordination.getId()), e);
 				}
 			}
 		}

--- a/bundles/org.eclipse.equinox.metatype/src/org/eclipse/equinox/metatype/impl/AttributeDefinitionImpl.java
+++ b/bundles/org.eclipse.equinox.metatype/src/org/eclipse/equinox/metatype/impl/AttributeDefinitionImpl.java
@@ -205,7 +205,7 @@ public class AttributeDefinitionImpl extends LocalizationElement implements Equi
 				String reason = vt.validate(this);
 				if ((reason != null) && reason.length() > 0) {
 					logger.log(LogTracker.LOG_WARNING,
-							NLS.bind(MetaTypeMsg.INVALID_OPTIONS, new Object[] { values.get(index), getID(), reason }));
+							NLS.bind(MetaTypeMsg.INVALID_OPTIONS, values.get(index), getID(), reason));
 					labels.remove(index);
 					values.remove(index);
 					index--; // Because this one has been removed.
@@ -240,7 +240,7 @@ public class AttributeDefinitionImpl extends LocalizationElement implements Equi
 		String reason = vt.validate(this);
 		if ((reason != null) && reason.length() > 0) {
 			logger.log(LogTracker.LOG_WARNING,
-					NLS.bind(MetaTypeMsg.INVALID_DEFAULTS, new Object[] { vt.getValuesAsString(), getID(), reason }));
+					NLS.bind(MetaTypeMsg.INVALID_DEFAULTS, vt.getValuesAsString(), getID(), reason));
 			return;
 		}
 		String[] defaults = vt.getValuesAsArray();

--- a/bundles/org.eclipse.equinox.metatype/src/org/eclipse/equinox/metatype/impl/DataParser.java
+++ b/bundles/org.eclipse.equinox.metatype/src/org/eclipse/equinox/metatype/impl/DataParser.java
@@ -186,16 +186,16 @@ public class DataParser {
 		@Override
 		public void startElement(String uri, String localName, String qName, Attributes attributes)
 				throws SAXException {
-			throw new SAXException(NLS.bind(MetaTypeMsg.UNEXPECTED_ELEMENT, new Object[] { qName,
-					attributes.getValue(ID), _dp_url, _dp_bundle.getBundleId(), _dp_bundle.getSymbolicName() }));
+			throw new SAXException(NLS.bind(MetaTypeMsg.UNEXPECTED_ELEMENT, qName, attributes.getValue(ID), _dp_url,
+					_dp_bundle.getBundleId(), _dp_bundle.getSymbolicName()));
 		}
 
 		@Override
 		public void characters(char[] buf, int start, int end) throws SAXException {
 			String s = new String(buf, start, end).trim();
 			if (s.length() > 0) {
-				throw new SAXException(NLS.bind(MetaTypeMsg.UNEXPECTED_TEXT, new Object[] { s, elementName, elementId,
-						_dp_url, _dp_bundle.getBundleId(), _dp_bundle.getSymbolicName() }));
+				throw new SAXException(NLS.bind(MetaTypeMsg.UNEXPECTED_TEXT, s, elementName, elementId, _dp_url,
+						_dp_bundle.getBundleId(), _dp_bundle.getSymbolicName()));
 			}
 		}
 
@@ -240,8 +240,8 @@ public class DataParser {
 			if (name.equalsIgnoreCase(METADATA)) {
 				new MetaDataHandler(this).init(name, attributes);
 			} else {
-				logger.log(LogTracker.LOG_WARNING, NLS.bind(MetaTypeMsg.UNEXPECTED_ELEMENT, new Object[] { name,
-						attributes.getValue(ID), _dp_url, _dp_bundle.getBundleId(), _dp_bundle.getSymbolicName() }));
+				logger.log(LogTracker.LOG_WARNING, NLS.bind(MetaTypeMsg.UNEXPECTED_ELEMENT, name,
+						attributes.getValue(ID), _dp_url, _dp_bundle.getBundleId(), _dp_bundle.getSymbolicName()));
 			}
 		}
 
@@ -289,8 +289,8 @@ public class DataParser {
 				OcdHandler ocdHandler = new OcdHandler(this);
 				ocdHandler.init(name, atts, _dp_OCDs);
 			} else {
-				logger.log(LogTracker.LOG_WARNING, NLS.bind(MetaTypeMsg.UNEXPECTED_ELEMENT, new Object[] { name,
-						atts.getValue(ID), _dp_url, _dp_bundle.getBundleId(), _dp_bundle.getSymbolicName() }));
+				logger.log(LogTracker.LOG_WARNING, NLS.bind(MetaTypeMsg.UNEXPECTED_ELEMENT, name, atts.getValue(ID),
+						_dp_url, _dp_bundle.getBundleId(), _dp_bundle.getSymbolicName()));
 			}
 		}
 
@@ -301,8 +301,8 @@ public class DataParser {
 			if (_dp_designateHandlers.size() == 0) {
 				// Schema defines at least one DESIGNATE is required.
 				_isParsedDataValid = false;
-				logger.log(LogTracker.LOG_WARNING, NLS.bind(MetaTypeMsg.MISSING_ELEMENT, new Object[] { DESIGNATE,
-						METADATA, elementId, _dp_url, _dp_bundle.getBundleId(), _dp_bundle.getSymbolicName() }));
+				logger.log(LogTracker.LOG_WARNING, NLS.bind(MetaTypeMsg.MISSING_ELEMENT, DESIGNATE, METADATA, elementId,
+						_dp_url, _dp_bundle.getBundleId(), _dp_bundle.getSymbolicName()));
 				return;
 			}
 
@@ -313,8 +313,8 @@ public class DataParser {
 							.merge(dh._merge_val).pid(dh._pid_val).optional(dh._optional_val).build());
 				} else {
 					logger.log(LogTracker.LOG_ERROR,
-							NLS.bind(MetaTypeMsg.OCD_REF_NOT_FOUND, new Object[] { dh._pid_val, dh._factory_val,
-									dh._ocdref, _dp_url, _dp_bundle.getBundleId(), _dp_bundle.getSymbolicName() }));
+							NLS.bind(MetaTypeMsg.OCD_REF_NOT_FOUND, dh._pid_val, dh._factory_val, dh._ocdref, _dp_url,
+									_dp_bundle.getBundleId(), _dp_bundle.getSymbolicName()));
 				}
 			}
 		}
@@ -346,8 +346,8 @@ public class DataParser {
 			String ocd_name_val = atts.getValue(NAME);
 			if (ocd_name_val == null) {
 				_isParsedDataValid = false;
-				logger.log(LogTracker.LOG_ERROR, NLS.bind(MetaTypeMsg.MISSING_ATTRIBUTE, new Object[] { NAME, name,
-						atts.getValue(ID), _dp_url, _dp_bundle.getBundleId(), _dp_bundle.getSymbolicName() }));
+				logger.log(LogTracker.LOG_ERROR, NLS.bind(MetaTypeMsg.MISSING_ATTRIBUTE, NAME, name, atts.getValue(ID),
+						_dp_url, _dp_bundle.getBundleId(), _dp_bundle.getSymbolicName()));
 				return;
 			}
 
@@ -359,8 +359,8 @@ public class DataParser {
 			_refID = atts.getValue(ID);
 			if (_refID == null) {
 				_isParsedDataValid = false;
-				logger.log(LogTracker.LOG_ERROR, NLS.bind(MetaTypeMsg.MISSING_ATTRIBUTE, new Object[] { ID, name,
-						atts.getValue(ID), _dp_url, _dp_bundle.getBundleId(), _dp_bundle.getSymbolicName() }));
+				logger.log(LogTracker.LOG_ERROR, NLS.bind(MetaTypeMsg.MISSING_ATTRIBUTE, ID, name, atts.getValue(ID),
+						_dp_url, _dp_bundle.getBundleId(), _dp_bundle.getSymbolicName()));
 				return;
 			}
 
@@ -388,8 +388,8 @@ public class DataParser {
 					icons.add(iconHandler._icon);
 				}
 			} else {
-				logger.log(LogTracker.LOG_WARNING, NLS.bind(MetaTypeMsg.UNEXPECTED_ELEMENT, new Object[] { name,
-						atts.getValue(ID), _dp_url, _dp_bundle.getBundleId(), _dp_bundle.getSymbolicName() }));
+				logger.log(LogTracker.LOG_WARNING, NLS.bind(MetaTypeMsg.UNEXPECTED_ELEMENT, name, atts.getValue(ID),
+						_dp_url, _dp_bundle.getBundleId(), _dp_bundle.getSymbolicName()));
 			}
 		}
 
@@ -427,8 +427,8 @@ public class DataParser {
 			String icon_resource_val = atts.getValue(RESOURCE);
 			if (icon_resource_val == null) {
 				_isParsedDataValid = false;
-				logger.log(LogTracker.LOG_ERROR, NLS.bind(MetaTypeMsg.MISSING_ATTRIBUTE, new Object[] { RESOURCE, name,
-						atts.getValue(ID), _dp_url, _dp_bundle.getBundleId(), _dp_bundle.getSymbolicName() }));
+				logger.log(LogTracker.LOG_ERROR, NLS.bind(MetaTypeMsg.MISSING_ATTRIBUTE, RESOURCE, name,
+						atts.getValue(ID), _dp_url, _dp_bundle.getBundleId(), _dp_bundle.getSymbolicName()));
 				return;
 			}
 
@@ -482,16 +482,16 @@ public class DataParser {
 			String ad_id_val = atts.getValue(ID);
 			if (ad_id_val == null) {
 				_isParsedDataValid = false;
-				logger.log(LogTracker.LOG_ERROR, NLS.bind(MetaTypeMsg.MISSING_ATTRIBUTE, new Object[] { ID, name,
-						atts.getValue(ID), _dp_url, _dp_bundle.getBundleId(), _dp_bundle.getSymbolicName() }));
+				logger.log(LogTracker.LOG_ERROR, NLS.bind(MetaTypeMsg.MISSING_ATTRIBUTE, ID, name, atts.getValue(ID),
+						_dp_url, _dp_bundle.getBundleId(), _dp_bundle.getSymbolicName()));
 				return;
 			}
 
 			String ad_type_val = atts.getValue(TYPE);
 			if (ad_type_val == null) {
 				_isParsedDataValid = false;
-				logger.log(LogTracker.LOG_ERROR, NLS.bind(MetaTypeMsg.MISSING_ATTRIBUTE, new Object[] { TYPE, name,
-						atts.getValue(ID), _dp_url, _dp_bundle.getBundleId(), _dp_bundle.getSymbolicName() }));
+				logger.log(LogTracker.LOG_ERROR, NLS.bind(MetaTypeMsg.MISSING_ATTRIBUTE, TYPE, name, atts.getValue(ID),
+						_dp_url, _dp_bundle.getBundleId(), _dp_bundle.getSymbolicName()));
 				return;
 			}
 			if (ad_type_val.equalsIgnoreCase(STRING)) {
@@ -520,8 +520,8 @@ public class DataParser {
 				_dataType = AttributeDefinition.BIGINTEGER;
 			} else {
 				_isParsedDataValid = false;
-				logger.log(LogTracker.LOG_ERROR, NLS.bind(MetaTypeMsg.INVALID_TYPE, new Object[] { ad_type_val,
-						ad_id_val, _dp_url, _dp_bundle.getBundleId(), _dp_bundle.getSymbolicName() }));
+				logger.log(LogTracker.LOG_ERROR, NLS.bind(MetaTypeMsg.INVALID_TYPE, ad_type_val, ad_id_val, _dp_url,
+						_dp_bundle.getBundleId(), _dp_bundle.getSymbolicName()));
 				return;
 			}
 
@@ -580,8 +580,8 @@ public class DataParser {
 					_optionValues.add(optionHandler._value_val);
 				}
 			} else {
-				logger.log(LogTracker.LOG_WARNING, NLS.bind(MetaTypeMsg.UNEXPECTED_ELEMENT, new Object[] { name,
-						atts.getValue(ID), _dp_url, _dp_bundle.getBundleId(), _dp_bundle.getSymbolicName() }));
+				logger.log(LogTracker.LOG_WARNING, NLS.bind(MetaTypeMsg.UNEXPECTED_ELEMENT, name, atts.getValue(ID),
+						_dp_url, _dp_bundle.getBundleId(), _dp_bundle.getSymbolicName()));
 			}
 		}
 
@@ -599,16 +599,15 @@ public class DataParser {
 				values = new String[0];
 			}
 			if (numOfValues != values.length) {
-				logger.log(LogTracker.LOG_WARNING, NLS.bind(MetaTypeMsg.INVALID_OPTIONS_XML,
-						new Object[] { elementId, _dp_url, _dp_bundle.getBundleId(), _dp_bundle.getSymbolicName() }));
+				logger.log(LogTracker.LOG_WARNING, NLS.bind(MetaTypeMsg.INVALID_OPTIONS_XML, elementId, _dp_url,
+						_dp_bundle.getBundleId(), _dp_bundle.getSymbolicName()));
 			}
 
 			if (ad_defaults_str != null) {
 				_ad.setDefaultValue(ad_defaults_str, true);
 				if (_ad.getDefaultValue() == null) {
-					logger.log(LogTracker.LOG_WARNING,
-							NLS.bind(MetaTypeMsg.INVALID_DEFAULTS_XML, new Object[] { ad_defaults_str, elementId,
-									_dp_url, _dp_bundle.getBundleId(), _dp_bundle.getSymbolicName() }));
+					logger.log(LogTracker.LOG_WARNING, NLS.bind(MetaTypeMsg.INVALID_DEFAULTS_XML, ad_defaults_str,
+							elementId, _dp_url, _dp_bundle.getBundleId(), _dp_bundle.getSymbolicName()));
 				}
 			}
 
@@ -636,16 +635,16 @@ public class DataParser {
 			_label_val = atts.getValue(LABEL);
 			if (_label_val == null) {
 				_isParsedDataValid = false;
-				logger.log(LogTracker.LOG_ERROR, NLS.bind(MetaTypeMsg.MISSING_ATTRIBUTE, new Object[] { LABEL, name,
-						atts.getValue(ID), _dp_url, _dp_bundle.getBundleId(), _dp_bundle.getSymbolicName() }));
+				logger.log(LogTracker.LOG_ERROR, NLS.bind(MetaTypeMsg.MISSING_ATTRIBUTE, LABEL, name, atts.getValue(ID),
+						_dp_url, _dp_bundle.getBundleId(), _dp_bundle.getSymbolicName()));
 				return;
 			}
 
 			_value_val = atts.getValue(VALUE);
 			if (_value_val == null) {
 				_isParsedDataValid = false;
-				logger.log(LogTracker.LOG_ERROR, NLS.bind(MetaTypeMsg.MISSING_ATTRIBUTE, new Object[] { VALUE, name,
-						atts.getValue(ID), _dp_url, _dp_bundle.getBundleId(), _dp_bundle.getSymbolicName() }));
+				logger.log(LogTracker.LOG_ERROR, NLS.bind(MetaTypeMsg.MISSING_ATTRIBUTE, VALUE, name, atts.getValue(ID),
+						_dp_url, _dp_bundle.getBundleId(), _dp_bundle.getSymbolicName()));
 				return;
 			}
 		}
@@ -677,8 +676,8 @@ public class DataParser {
 			_factory_val = atts.getValue(FACTORY);
 			if (_pid_val == null && _factory_val == null) {
 				_isParsedDataValid = false;
-				logger.log(LogTracker.LOG_ERROR, NLS.bind(MetaTypeMsg.MISSING_DESIGNATE_PID_AND_FACTORYPID,
-						new Object[] { elementId, _dp_url, _dp_bundle.getBundleId(), _dp_bundle.getSymbolicName() }));
+				logger.log(LogTracker.LOG_ERROR, NLS.bind(MetaTypeMsg.MISSING_DESIGNATE_PID_AND_FACTORYPID, elementId,
+						_dp_url, _dp_bundle.getBundleId(), _dp_bundle.getSymbolicName()));
 				return;
 			}
 
@@ -723,8 +722,8 @@ public class DataParser {
 					_ocdref = objectHandler._ocdref;
 				}
 			} else {
-				logger.log(LogTracker.LOG_WARNING, NLS.bind(MetaTypeMsg.UNEXPECTED_ELEMENT, new Object[] { name,
-						atts.getValue(ID), _dp_url, _dp_bundle.getBundleId(), _dp_bundle.getSymbolicName() }));
+				logger.log(LogTracker.LOG_WARNING, NLS.bind(MetaTypeMsg.UNEXPECTED_ELEMENT, name, atts.getValue(ID),
+						_dp_url, _dp_bundle.getBundleId(), _dp_bundle.getSymbolicName()));
 			}
 		}
 
@@ -739,8 +738,8 @@ public class DataParser {
 			if (_ocdref == null) {
 				_isParsedDataValid = false;
 				// Schema defines at least one OBJECT is required.
-				logger.log(LogTracker.LOG_ERROR, NLS.bind(MetaTypeMsg.MISSING_ELEMENT, new Object[] { OBJECT, DESIGNATE,
-						elementId, _dp_url, _dp_bundle.getBundleId(), _dp_bundle.getSymbolicName() }));
+				logger.log(LogTracker.LOG_ERROR, NLS.bind(MetaTypeMsg.MISSING_ELEMENT, OBJECT, DESIGNATE, elementId,
+						_dp_url, _dp_bundle.getBundleId(), _dp_bundle.getSymbolicName()));
 				return;
 
 			}
@@ -766,8 +765,8 @@ public class DataParser {
 			_ocdref = atts.getValue(OCDREF);
 			if (_ocdref == null) {
 				_isParsedDataValid = false;
-				logger.log(LogTracker.LOG_ERROR, NLS.bind(MetaTypeMsg.MISSING_ATTRIBUTE, new Object[] { OCDREF, name,
-						atts.getValue(ID), _dp_url, _dp_bundle.getBundleId(), _dp_bundle.getSymbolicName() }));
+				logger.log(LogTracker.LOG_ERROR, NLS.bind(MetaTypeMsg.MISSING_ATTRIBUTE, OCDREF, name,
+						atts.getValue(ID), _dp_url, _dp_bundle.getBundleId(), _dp_bundle.getSymbolicName()));
 				return;
 			}
 		}
@@ -787,8 +786,8 @@ public class DataParser {
 				attributeHandler.init(name, atts);
 				// The ATTRIBUTE element is only used by RFC94, do nothing for it here.
 			} else {
-				logger.log(LogTracker.LOG_WARNING, NLS.bind(MetaTypeMsg.UNEXPECTED_ELEMENT, new Object[] { name,
-						atts.getValue(ID), _dp_url, _dp_bundle.getBundleId(), _dp_bundle.getSymbolicName() }));
+				logger.log(LogTracker.LOG_WARNING, NLS.bind(MetaTypeMsg.UNEXPECTED_ELEMENT, name, atts.getValue(ID),
+						_dp_url, _dp_bundle.getBundleId(), _dp_bundle.getSymbolicName()));
 			}
 		}
 	}
@@ -815,16 +814,16 @@ public class DataParser {
 			_adref_val = atts.getValue(ADREF);
 			if (_adref_val == null) {
 				_isParsedDataValid = false;
-				logger.log(LogTracker.LOG_ERROR, NLS.bind(MetaTypeMsg.MISSING_ATTRIBUTE, new Object[] { ADREF, name,
-						atts.getValue(ID), _dp_url, _dp_bundle.getBundleId(), _dp_bundle.getSymbolicName() }));
+				logger.log(LogTracker.LOG_ERROR, NLS.bind(MetaTypeMsg.MISSING_ATTRIBUTE, ADREF, name, atts.getValue(ID),
+						_dp_url, _dp_bundle.getBundleId(), _dp_bundle.getSymbolicName()));
 				return;
 			}
 
 			_content_val = atts.getValue(CONTENT);
 			if (_content_val == null) {
 				_isParsedDataValid = false;
-				logger.log(LogTracker.LOG_ERROR, NLS.bind(MetaTypeMsg.MISSING_ATTRIBUTE, new Object[] { CONTENT, name,
-						atts.getValue(ID), _dp_url, _dp_bundle.getBundleId(), _dp_bundle.getSymbolicName() }));
+				logger.log(LogTracker.LOG_ERROR, NLS.bind(MetaTypeMsg.MISSING_ATTRIBUTE, CONTENT, name,
+						atts.getValue(ID), _dp_url, _dp_bundle.getBundleId(), _dp_bundle.getSymbolicName()));
 				return;
 			}
 		}

--- a/bundles/org.eclipse.equinox.metatype/src/org/eclipse/equinox/metatype/impl/MetaTypeProviderImpl.java
+++ b/bundles/org.eclipse.equinox.metatype/src/org/eclipse/equinox/metatype/impl/MetaTypeProviderImpl.java
@@ -125,8 +125,8 @@ public class MetaTypeProviderImpl implements MetaTypeProvider {
 					}
 				}
 			} catch (Exception e) {
-				logger.log(LogTracker.LOG_WARNING, NLS.bind(MetaTypeMsg.METADATA_FILE_PARSE_ERROR,
-						new Object[] { entry, bundle.getBundleId(), bundle.getSymbolicName() }), e);
+				logger.log(LogTracker.LOG_WARNING, NLS.bind(MetaTypeMsg.METADATA_FILE_PARSE_ERROR, entry,
+						bundle.getBundleId(), bundle.getSymbolicName()), e);
 			}
 		}
 		return result;

--- a/bundles/org.eclipse.equinox.metatype/src/org/eclipse/equinox/metatype/impl/MetaTypeProviderTracker.java
+++ b/bundles/org.eclipse.equinox.metatype/src/org/eclipse/equinox/metatype/impl/MetaTypeProviderTracker.java
@@ -184,7 +184,7 @@ public class MetaTypeProviderTracker implements EquinoxMetaTypeInformation {
 			}
 		}
 		log.log(LogTracker.LOG_WARNING, NLS.bind(MetaTypeMsg.INVALID_PID_METATYPE_PROVIDER_IGNORED,
-				new Object[] { _bundle.getSymbolicName(), _bundle.getBundleId(), name, value }), e);
+				_bundle.getSymbolicName(), _bundle.getBundleId(), name, value), e);
 		return new String[0];
 	}
 

--- a/bundles/org.eclipse.equinox.metatype/src/org/eclipse/equinox/metatype/impl/ValueTokenizer.java
+++ b/bundles/org.eclipse.equinox.metatype/src/org/eclipse/equinox/metatype/impl/ValueTokenizer.java
@@ -181,14 +181,12 @@ public class ValueTokenizer {
 			// If the cardinality is zero, the value must contain one and only one token.
 			if (cardinality == 0) {
 				if (values.size() != 1) {
-					return NLS.bind(MetaTypeMsg.CARDINALITY_VIOLATION,
-							new Object[] { getValuesAsString(), values.size(), 1, 1 });
+					return NLS.bind(MetaTypeMsg.CARDINALITY_VIOLATION, getValuesAsString(), values.size(), 1, 1);
 				}
 			}
 			// Otherwise, the number of tokens must be between 0 and cardinality, inclusive.
 			else if (values.size() > cardinality) {
-				return NLS.bind(MetaTypeMsg.CARDINALITY_VIOLATION,
-						new Object[] { getValuesAsString(), values.size(), 0, cardinality });
+				return NLS.bind(MetaTypeMsg.CARDINALITY_VIOLATION, getValuesAsString(), values.size(), 0, cardinality);
 			}
 			// Now inspect each token.
 			for (Iterator<String> i = values.iterator(); i.hasNext();) {

--- a/bundles/org.eclipse.equinox.preferences/src/org/eclipse/core/internal/preferences/PreferencesService.java
+++ b/bundles/org.eclipse.equinox.preferences/src/org/eclipse/core/internal/preferences/PreferencesService.java
@@ -1020,7 +1020,7 @@ public class PreferencesService implements IPreferencesService {
 		if (installed.getMajor() == pref.getMajor() && installed.getMinor() == pref.getMinor()) {
 			return null;
 		}
-		String msg = NLS.bind(PrefsMessages.preferences_incompatible, new Object[] { pref, bundle, installed });
+		String msg = NLS.bind(PrefsMessages.preferences_incompatible, pref, bundle, installed);
 		boolean isError = installed.getMajor() < pref.getMajor();
 		return isError ? Status.error(msg) : Status.warning(msg);
 	}

--- a/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/internal/registry/ExtensionRegistry.java
+++ b/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/internal/registry/ExtensionRegistry.java
@@ -1415,8 +1415,8 @@ public class ExtensionRegistry implements IExtensionRegistry, IDynamicExtensionR
 			if (existingExtension != null) {
 				String currentSupplier = contribution.getDefaultNamespace();
 				String existingSupplier = existingExtension.getContributor().getName();
-				String msg = NLS.bind(RegistryMessages.parse_duplicateExtension,
-						new String[] { currentSupplier, existingSupplier, uniqueId });
+				String msg = NLS.bind(RegistryMessages.parse_duplicateExtension, currentSupplier, existingSupplier,
+						uniqueId);
 				log(new Status(IStatus.WARNING, RegistryMessages.OWNER_NAME, 0, msg, null));
 				return false;
 			}

--- a/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/internal/registry/ExtensionsParser.java
+++ b/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/internal/registry/ExtensionsParser.java
@@ -414,9 +414,9 @@ public class ExtensionsParser extends DefaultHandler {
 		String msg;
 		if (name.equals("")) { //$NON-NLS-1$
 			msg = NLS.bind(RegistryMessages.parse_error, ex.getMessage());
-		} else { //$NON-NLS-1$
-			msg = NLS.bind(RegistryMessages.parse_errorNameLineColumn, (new Object[] { name,
-			Integer.toString(ex.getLineNumber()), Integer.toString(ex.getColumnNumber()), ex.getMessage() }));
+		} else {
+			msg = NLS.bind(RegistryMessages.parse_errorNameLineColumn, name, ex.getLineNumber(), ex.getColumnNumber(),
+					ex.getMessage());
 		}
 		error(new Status(IStatus.WARNING, RegistryMessages.OWNER_NAME, PARSE_PROBLEM, msg, ex));
 	}
@@ -532,16 +532,16 @@ public class ExtensionsParser extends DefaultHandler {
 			if (existingExtension != null) {
 				String currentSupplier = contribution.getDefaultNamespace();
 				String existingSupplier = existingExtension.getContributor().getName();
-				String msg = NLS.bind(RegistryMessages.parse_duplicateExtension,
-						new String[] { currentSupplier, existingSupplier, uniqueId });
+				String msg = NLS.bind(RegistryMessages.parse_duplicateExtension, currentSupplier, existingSupplier,
+						uniqueId);
 				registry.log(new Status(IStatus.WARNING, RegistryMessages.OWNER_NAME, 0, msg, null));
 			} else if (processedExtensionIds != null) { // check elements in this contribution
 				for (String extensionId : processedExtensionIds) {
 					if (uniqueId.equals(extensionId)) {
 						String currentSupplier = contribution.getDefaultNamespace();
 						String existingSupplier = currentSupplier;
-						String msg = NLS.bind(RegistryMessages.parse_duplicateExtension,
-								new String[] { currentSupplier, existingSupplier, uniqueId });
+						String msg = NLS.bind(RegistryMessages.parse_duplicateExtension, currentSupplier,
+								existingSupplier, uniqueId);
 						registry.log(new Status(IStatus.WARNING, RegistryMessages.OWNER_NAME, 0, msg, null));
 						break;
 					}
@@ -562,8 +562,8 @@ public class ExtensionsParser extends DefaultHandler {
 		if (locator == null) {
 			internalError(NLS.bind(RegistryMessages.parse_missingAttribute, attribute, element));
 		} else {
-			internalError(NLS.bind(RegistryMessages.parse_missingAttributeLine,
-					(new String[] { attribute, element, Integer.toString(locator.getLineNumber()) })));
+			internalError(
+					NLS.bind(RegistryMessages.parse_missingAttributeLine, attribute, element, locator.getLineNumber()));
 		}
 	}
 
@@ -571,8 +571,8 @@ public class ExtensionsParser extends DefaultHandler {
 		if (locator == null) {
 			internalError(NLS.bind(RegistryMessages.parse_unknownAttribute, attribute, element));
 		} else {
-			internalError(NLS.bind(RegistryMessages.parse_unknownAttributeLine,
-					(new String[] { attribute, element, Integer.toString(locator.getLineNumber()) })));
+			internalError(
+					NLS.bind(RegistryMessages.parse_unknownAttributeLine, attribute, element, locator.getLineNumber()));
 		}
 	}
 
@@ -580,8 +580,8 @@ public class ExtensionsParser extends DefaultHandler {
 		if (locator == null) {
 			internalError(NLS.bind(RegistryMessages.parse_unknownElement, element, parent));
 		} else {
-			internalError(NLS.bind(RegistryMessages.parse_unknownElementLine,
-					(new String[] { element, parent, Integer.toString(locator.getLineNumber()) })));
+			internalError(
+					NLS.bind(RegistryMessages.parse_unknownElementLine, element, parent, locator.getLineNumber()));
 		}
 	}
 

--- a/bundles/org.eclipse.equinox.security.ui/src/org/eclipse/equinox/internal/security/ui/wizard/CertificateImportFileSelectPage.java
+++ b/bundles/org.eclipse.equinox.security.ui/src/org/eclipse/equinox/internal/security/ui/wizard/CertificateImportFileSelectPage.java
@@ -105,7 +105,7 @@ public class CertificateImportFileSelectPage extends WizardPage implements Liste
 	public IWizardPage getNextPage() {
 		File file = new File(filePathField.getText().trim());
 		if (file.isDirectory() || !file.exists()) {
-			setErrorMessage(NLS.bind(SecurityUIMsg.WIZARD_FILE_NOT_FOUND, new String[] { filePathField.getText() }));
+			setErrorMessage(NLS.bind(SecurityUIMsg.WIZARD_FILE_NOT_FOUND, filePathField.getText()));
 			return null;
 		}
 		saveFileSelection();

--- a/bundles/org.eclipse.equinox.useradmin/src/org/eclipse/equinox/internal/useradmin/UserAdminStore.java
+++ b/bundles/org.eclipse.equinox.useradmin/src/org/eclipse/equinox/internal/useradmin/UserAdminStore.java
@@ -184,7 +184,7 @@ public class UserAdminStore {
 			});
 		} catch (PrivilegedActionException ex) {
 			log.error(NLS.bind(UserAdminMsg.Backing_Store_Write_Exception,
-					new Object[] { NLS.bind(UserAdminMsg.adding_Credential_to__15, role.getName()) }), ex);
+					NLS.bind(UserAdminMsg.adding_Credential_to__15, role.getName())), ex);
 			throw ((BackingStoreException) ex.getException());
 		}
 
@@ -217,10 +217,8 @@ public class UserAdminStore {
 				return (null);
 			});
 		} catch (PrivilegedActionException ex) {
-			log.error(
-					NLS.bind(UserAdminMsg.Backing_Store_Write_Exception,
-							new Object[] { NLS.bind(UserAdminMsg.adding_member__18, role.getName(), group.getName()) }),
-					ex);
+			log.error(NLS.bind(UserAdminMsg.Backing_Store_Write_Exception,
+					NLS.bind(UserAdminMsg.adding_member__18, role.getName(), group.getName())), ex);
 			throw ((BackingStoreException) ex.getException());
 		}
 	}

--- a/bundles/org.eclipse.osgi/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.osgi/META-INF/MANIFEST.MF
@@ -107,7 +107,7 @@ Bundle-Activator: org.eclipse.osgi.internal.framework.SystemBundleActivator
 Bundle-Description: %systemBundle
 Bundle-Copyright: %copyright
 Bundle-Vendor: %eclipse.org
-Bundle-Version: 3.23.0.qualifier
+Bundle-Version: 3.23.100.qualifier
 Bundle-Localization: systembundle
 Bundle-DocUrl: http://www.eclipse.org
 Eclipse-ExtensibleAPI: true

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/container/ModuleContainer.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/container/ModuleContainer.java
@@ -461,9 +461,8 @@ public final class ModuleContainer implements DebugOptionsListener {
 					BundleContext context = bundle == null ? null : bundle.getBundleContext();
 					if (context != null && context.getBundle(existingLocation.getId()) == null) {
 						Bundle b = existingLocation.getBundle();
-						throw new BundleException(
-								NLS.bind(Msg.ModuleContainer_NameCollisionWithLocation,
-										new Object[] { b.getSymbolicName(), b.getVersion(), location }),
+						throw new BundleException(NLS.bind(Msg.ModuleContainer_NameCollisionWithLocation,
+								b.getSymbolicName(), b.getVersion(), location),
 								BundleException.REJECTED_BY_HOOK);
 					}
 				}

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/framework/BundleContextImpl.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/framework/BundleContextImpl.java
@@ -845,8 +845,8 @@ public class BundleContextImpl implements BundleContext, EventDispatcher<Object,
 			clazz = bundleActivator.getClass().getName();
 
 			throw new BundleException(
-					NLS.bind(Msg.BUNDLE_ACTIVATOR_EXCEPTION, new Object[] { clazz, "start", //$NON-NLS-1$
-							bundle.getSymbolicName() == null ? "" + bundle.getBundleId() : bundle.getSymbolicName() }), //$NON-NLS-1$
+					NLS.bind(Msg.BUNDLE_ACTIVATOR_EXCEPTION, clazz, "start", //$NON-NLS-1$
+							bundle.getSymbolicName() == null ? "" + bundle.getBundleId() : bundle.getSymbolicName()), //$NON-NLS-1$
 					BundleException.ACTIVATOR_ERROR, t);
 		}
 	}
@@ -914,8 +914,8 @@ public class BundleContextImpl implements BundleContext, EventDispatcher<Object,
 			String clazz = (activator == null) ? "" : activator.getClass().getName(); //$NON-NLS-1$
 
 			throw new BundleException(
-					NLS.bind(Msg.BUNDLE_ACTIVATOR_EXCEPTION, new Object[] { clazz, "stop", //$NON-NLS-1$
-							bundle.getSymbolicName() == null ? "" + bundle.getBundleId() : bundle.getSymbolicName() }), //$NON-NLS-1$
+					NLS.bind(Msg.BUNDLE_ACTIVATOR_EXCEPTION, clazz, "stop", //$NON-NLS-1$
+												bundle.getSymbolicName() == null ? "" + bundle.getBundleId() : bundle.getSymbolicName()), //$NON-NLS-1$
 					BundleException.ACTIVATOR_ERROR, t);
 		} finally {
 			activator = null;

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/framework/EquinoxContainer.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/framework/EquinoxContainer.java
@@ -48,7 +48,6 @@ import org.eclipse.osgi.storage.BundleInfo;
 import org.eclipse.osgi.storage.Storage;
 import org.eclipse.osgi.storage.bundlefile.MRUBundleFileList;
 import org.eclipse.osgi.util.ManifestElement;
-import org.eclipse.osgi.util.NLS;
 import org.osgi.framework.AdminPermission;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
@@ -267,7 +266,7 @@ public class EquinoxContainer implements ThreadFactory, Runnable {
 			current.setContextClassLoader(contextFinder);
 			return;
 		} catch (Exception e) {
-			logServices.log(NAME, FrameworkLogEntry.INFO, NLS.bind(Msg.CANNOT_SET_CONTEXTFINDER, null), e);
+			logServices.log(NAME, FrameworkLogEntry.INFO, Msg.CANNOT_SET_CONTEXTFINDER, e);
 		}
 
 	}

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/hooks/EclipseLazyStarter.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/hooks/EclipseLazyStarter.java
@@ -123,9 +123,8 @@ public class EclipseLazyStarter extends ClassLoaderHook {
 			} catch (BundleException e) {
 				Bundle bundle = managerElement.getGeneration().getRevision().getBundle();
 				if (e.getType() == BundleException.STATECHANGE_ERROR) {
-					String message = NLS.bind(Msg.ECLIPSE_CLASSLOADER_CONCURRENT_STARTUP,
-							new Object[] { Thread.currentThread(), name, m.getStateChangeOwner(), bundle,
-									Long.valueOf(System.currentTimeMillis() - startTime) });
+					String message = NLS.bind(Msg.ECLIPSE_CLASSLOADER_CONCURRENT_STARTUP, Thread.currentThread(), name,
+							m.getStateChangeOwner(), bundle, Long.valueOf(System.currentTimeMillis() - startTime));
 					container.getLogServices().log(EquinoxContainer.NAME, FrameworkLogEntry.WARNING, message, e);
 					continue;
 				}

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/serviceregistry/ServiceFactoryUse.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/serviceregistry/ServiceFactoryUse.java
@@ -263,7 +263,7 @@ public class ServiceFactoryUse<S> extends ServiceUse<S> {
 				debug.trace(OPTION_DEBUG_SERVICES, "Service object is not an instanceof " + invalidService); //$NON-NLS-1$
 			}
 			ServiceException se = new ServiceException(NLS.bind(Msg.SERVICE_FACTORY_NOT_INSTANCEOF_CLASS_EXCEPTION,
-					new Object[] { factory.getClass().getName(), service.getClass().getName(), invalidService }),
+					factory.getClass().getName(), service.getClass().getName(), invalidService),
 					ServiceException.FACTORY_ERROR);
 			context.getContainer().getEventPublisher().publishFrameworkEvent(FrameworkEvent.ERROR,
 					registration.getBundle(), se);

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/url/ContentHandlerFactoryImpl.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/url/ContentHandlerFactoryImpl.java
@@ -119,8 +119,8 @@ public class ContentHandlerFactoryImpl extends MultiplexingFactory implements ja
 				if (prop instanceof String)
 					prop = new String[] { (String) prop }; // TODO should this be a warning?
 				if (!(prop instanceof String[])) {
-					String message = NLS.bind(Msg.URL_HANDLER_INCORRECT_TYPE, new Object[] {
-							URLConstants.URL_CONTENT_MIMETYPE, contentHandlerClazz, serviceReference.getBundle() });
+					String message = NLS.bind(Msg.URL_HANDLER_INCORRECT_TYPE, URLConstants.URL_CONTENT_MIMETYPE,
+							contentHandlerClazz, serviceReference.getBundle());
 					container.getLogServices().log(EquinoxContainer.NAME, FrameworkLogEntry.WARNING, message, null);
 					continue;
 				}

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/storage/FrameworkExtensionInstaller.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/storage/FrameworkExtensionInstaller.java
@@ -258,8 +258,8 @@ public class FrameworkExtensionInstaller {
 			} catch (Exception e) {
 				Bundle b = current.get(activator);
 				BundleException eventException = new BundleException(
-						NLS.bind(Msg.BUNDLE_ACTIVATOR_EXCEPTION,
-								new Object[] { activator.getClass(), "stop", b == null ? "" : b.getSymbolicName() }), //$NON-NLS-1$ //$NON-NLS-2$
+						NLS.bind(Msg.BUNDLE_ACTIVATOR_EXCEPTION, activator.getClass(), "stop", //$NON-NLS-1$
+								b == null ? "" : b.getSymbolicName()), //$NON-NLS-1$
 						BundleException.ACTIVATOR_ERROR, e);
 				configuration.getHookRegistry().getContainer().getEventPublisher()
 						.publishFrameworkEvent(FrameworkEvent.ERROR, b, eventException);
@@ -290,10 +290,8 @@ public class FrameworkExtensionInstaller {
 				eventException = new BundleException(Msg.BundleContextImpl_LoadActivatorError + ' ' + extensionRevision,
 						BundleException.ACTIVATOR_ERROR, e);
 			} else {
-				eventException = new BundleException(
-						NLS.bind(Msg.BUNDLE_ACTIVATOR_EXCEPTION,
-								new Object[] { activator.getClass(), "start", extensionRevision.getSymbolicName() }), //$NON-NLS-1$
-						BundleException.ACTIVATOR_ERROR, e);
+				eventException = new BundleException(NLS.bind(Msg.BUNDLE_ACTIVATOR_EXCEPTION, activator.getClass(),
+						"start", extensionRevision.getSymbolicName()), BundleException.ACTIVATOR_ERROR, e); //$NON-NLS-1$
 			}
 			configuration.getHookRegistry().getContainer().getEventPublisher()
 					.publishFrameworkEvent(FrameworkEvent.ERROR, extensionRevision.getBundle(), eventException);

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/storage/Storage.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/storage/Storage.java
@@ -724,10 +724,8 @@ public class Storage {
 				BundleContext context = bundle == null ? null : bundle.getBundleContext();
 				if (context != null && context.getBundle(existingLocation.getId()) == null) {
 					Bundle b = existingLocation.getBundle();
-					throw new BundleException(
-							NLS.bind(Msg.ModuleContainer_NameCollisionWithLocation,
-									new Object[] { b.getSymbolicName(), b.getVersion(), bundleLocation }),
-							BundleException.REJECTED_BY_HOOK);
+					throw new BundleException(NLS.bind(Msg.ModuleContainer_NameCollisionWithLocation,
+							b.getSymbolicName(), b.getVersion(), bundleLocation), BundleException.REJECTED_BY_HOOK);
 				}
 			}
 			return (Generation) existingLocation.getCurrentRevision().getRevisionInfo();

--- a/bundles/org.eclipse.osgi/pom.xml
+++ b/bundles/org.eclipse.osgi/pom.xml
@@ -19,7 +19,7 @@
 </parent>
   <groupId>org.eclipse.platform</groupId>
   <artifactId>org.eclipse.osgi</artifactId>
-  <version>3.23.0-SNAPSHOT</version>
+  <version>3.23.100-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   <properties>
 	  <!-- The actual TCKs are executed in the org.eclipse.osgi.tck module because of reference to other service implementations -->

--- a/bundles/org.eclipse.osgi/supplement/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.osgi/supplement/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.supplement
-Bundle-Version: 1.12.0.qualifier
+Bundle-Version: 1.12.100.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.equinox.log;version="1.1",

--- a/bundles/org.eclipse.osgi/supplement/src/org/eclipse/osgi/internal/location/Locker_JavaNio.java
+++ b/bundles/org.eclipse.osgi/supplement/src/org/eclipse/osgi/internal/location/Locker_JavaNio.java
@@ -104,7 +104,7 @@ public class Locker_JavaNio implements Locker {
 					if (debug)
 						System.out.println(NLS.bind(Msg.location_cannotLock, lockFile));
 					// produce a more specific message for clients
-					String specificMessage = NLS.bind(Msg.location_cannotLockNIO, new Object[] {lockFile, ioe.getMessage(), "\"-D" + LocationHelper.PROP_OSGI_LOCKING + "=none\""}); //$NON-NLS-1$ //$NON-NLS-2$
+					String specificMessage = NLS.bind(Msg.location_cannotLockNIO, lockFile, ioe.getMessage(), "\"-D" + LocationHelper.PROP_OSGI_LOCKING + "=none\""); //$NON-NLS-1$ //$NON-NLS-2$
 					throw new IOException(specificMessage);
 				}
 				if (tempLock != null) {

--- a/bundles/org.eclipse.osgi/supplement/src/org/eclipse/osgi/util/NLS.java
+++ b/bundles/org.eclipse.osgi/supplement/src/org/eclipse/osgi/util/NLS.java
@@ -119,7 +119,7 @@ public abstract class NLS {
 	 * @return the manipulated String
 	 * @throws IllegalArgumentException if the text appearing within curly braces in the given message does not map to an integer
 	 */
-	public static String bind(String message, Object[] bindings) {
+	public static String bind(String message, Object... bindings) {
 		return internalBind(message, bindings, null, null);
 	}
 


### PR DESCRIPTION
This avoids the explicit array creation when invoking this method.

I wonder if change is binary compatible, but I didn't find anything in the JLS about _varargs_ or _ellipsis_:
https://docs.oracle.com/javase/specs/jls/se21/html/jls-13.html

Looking at the produced byte-code I only see
```
  // access flags 0x9
  public static bind(String, Object[]) : String
   L0
    LINENUMBER 123 L0
    ALOAD 0: message
...
```
becoming
```
  // access flags 0x89
  public static varargs bind(String, Object[]) : String
   L0
    LINENUMBER 123 L0
    ALOAD 0: message
...
```
with this change. So the only change is the additional `varargs` keyword.
@iloveeclipse can you tell if this would be binary compatible or where one could find this out?

From a source compatibility POV I only see errors in the `EquinoxContainer`, which is fixed along side (but was actually unnecessary) and in
https://github.com/eclipse-platform/eclipse.platform/blob/86aa0ac329edcb4246009fe19b4ac0d680d4c491/team/bundles/org.eclipse.jsch.ui/src/org/eclipse/jsch/internal/ui/KeyboardInteractiveDialog.java#L87

But that could be fixed easily and was also overly complex.