### PR TITLE
Improve check for visiting same child in a status cycle

### DIFF
--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/internal/runtime/PlatformLogWriter.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/internal/runtime/PlatformLogWriter.java
@@ -79,6 +79,7 @@ public class PlatformLogWriter implements SynchronousLogListener, LogFilter {
 			if (coreStatus != null) {
 				if (visited.add(coreStatus)) {
 					childlist.add(getLogImpl(coreStatus, visited));
+					visited.remove(coreStatus);
 				}
 			}
 		}
@@ -88,6 +89,7 @@ public class PlatformLogWriter implements SynchronousLogListener, LogFilter {
 			for (IStatus child : children) {
 				if (visited.add(child)) {
 					childlist.add(getLogImpl(child, visited));
+					visited.remove(child);
 				}
 			}
 		}


### PR DESCRIPTION
- We must prevent endless recursion if there is a cycle in status children, but we shouldn't prevent the same child from appearing more than once in the tree.