### PR TITLE
Make var-args overload of NLS.bind() generic

### DIFF
--- a/bundles/org.eclipse.equinox.common/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.common/forceQualifierUpdate.txt
@@ -6,3 +6,4 @@ Bug 566471 - I20200828-0150 - Comparator Errors Found
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation #1139
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2044
+https://github.com/eclipse-equinox/equinox/pull/939

--- a/bundles/org.eclipse.equinox.coordinator/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.coordinator/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@
 Bug 403352 - Update all parent versions to match our build stream
 Bug 509973 - Comparator errors in I20170105-0320
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659
+https://github.com/eclipse-equinox/equinox/pull/939

--- a/bundles/org.eclipse.equinox.metatype/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.metatype/forceQualifierUpdate.txt
@@ -3,3 +3,4 @@ Bug 403352 - Update all parent versions to match our build stream
 Bug 416896 - Some Equinox bundles need to be touched to get API descriptions back
 Bug 509973 - Comparator errors in I20170105-0320
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659
+https://github.com/eclipse-equinox/equinox/pull/939

--- a/bundles/org.eclipse.equinox.preferences/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.preferences/forceQualifierUpdate.txt
@@ -4,3 +4,4 @@ Bug 509973 - Comparator errors in I20170105-0320
 Incorrect org.osgi.service.prefs dependency in org.eclipse.equinox.preferences-3.10.0 #54
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation #1139
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1781
+https://github.com/eclipse-equinox/equinox/pull/939

--- a/bundles/org.eclipse.equinox.registry/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.registry/forceQualifierUpdate.txt
@@ -6,3 +6,4 @@ Bug 527899 [9] Implement JEP 280: Indify String Concatenation #1139
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1923
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2044
+https://github.com/eclipse-equinox/equinox/pull/939

--- a/bundles/org.eclipse.osgi/supplement/src/org/eclipse/osgi/util/NLS.java
+++ b/bundles/org.eclipse.osgi/supplement/src/org/eclipse/osgi/util/NLS.java
@@ -119,7 +119,8 @@ public abstract class NLS {
 	 * @return the manipulated String
 	 * @throws IllegalArgumentException if the text appearing within curly braces in the given message does not map to an integer
 	 */
-	public static String bind(String message, Object... bindings) {
+	@SafeVarargs
+	public static <T> String bind(String message, T... bindings) {
 		return internalBind(message, bindings, null, null);
 	}
 


### PR DESCRIPTION
This avoids a compiler warning if an explicit array of a sub-type of Object[] is passed as last argument:
`NLS.bind("message: {0} {1}", new String[] { "Hello", "World" })`

The byte-code generated for the `NLS.bind()` method and for all its callers is not changed by this adjustment. It just avoids what looks like a source-compatibility issues with the previous introduction of var-args in `NLS.bind()`. Although the example above works the same in all three states.

Follow-up on:
- https://github.com/eclipse-equinox/equinox/pull/936