### PR TITLE
Add version bumps for 4.37

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -391,3 +391,5 @@ pipeline {
 		}
 	}
 }
+
+// A dummy change to be removed, just to provoke version increments


### PR DESCRIPTION
Provoke version increment for 4.37.

Part of
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/3093