### PR TITLE
[Build] Use Eclipse Equinox Bot to commit built launcher binaries

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -111,7 +111,7 @@ pipeline {
 					script {
 						def authorMail = sh(script: 'git log -1 --pretty=format:"%ce" HEAD', returnStdout: true)
 						echo 'HEAD commit author: ' + authorMail
-						def buildBotMail = 'eclipse-releng-bot@eclipse.org'
+						def buildBotMail = 'equinox-bot@eclipse.org'
 						if (buildBotMail.equals(authorMail) && !params.any{ e -> e.key.startsWith('forceNativeBuilds-') && e.value }) {
 							// Prevent endless build-loops due to self triggering because of a previous automated native-build and the associated updates.
 							currentBuild.result = 'ABORTED'
@@ -119,7 +119,7 @@ pipeline {
 						}
 						sh """
 							git config --global user.email '${buildBotMail}'
-							git config --global user.name 'Eclipse Releng Bot'
+							git config --global user.name 'Eclipse Equinox Bot'
 							git remote set-url --push origin git@github.com:eclipse-equinox/equinox.git
 							git fetch --all --tags --quiet
 						"""


### PR DESCRIPTION
Use the `Eclipse Equinox Bot` to commit built launcher binaries with its correct email as recorded in the EF-API (https://api.eclipse.org/bots ) and that is also associated with it's Github account. Before the `Eclipse Releng Bot` was used for that, but with an incorrect email.

Not it's the same bot that is also used for version increments:
https://github.com/eclipse-equinox/equinox/blob/84219045d0efe0124a4bfc1a11ebf5d8625d28b8/.github/workflows/pr-checks.yml#L20-L21

I think that is more suitable than using the Releng Bot (even with a fixed mail).

Fixes
- https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/6227

@tjwatson, @laeubi any objection?