### PR TITLE
Swithch GHA build to windows-2022

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         config: 
           - { name: Linux, runner-os: ubuntu-latest, ws: gtk, os: linux, native-extension: so }
-          - { name: Windows, runner-os: windows-2019, ws: win32, os: win32, native-extension: dll }
+          - { name: Windows, runner-os: windows-2022, ws: win32, os: win32, native-extension: dll }
           - { name: MacOS, runner-os: macos-13, ws: cocoa, os: macosx, native-extension: so }
     name: Build ${{ matrix.config.name }}
     runs-on: ${{ matrix.config.runner-os }}


### PR DESCRIPTION
Fixes warning in the build caused by
https://github.com/actions/runner-images/issues/12045