### PR TITLE
enforce glibc version by building equinox binaries for linux-aarch64 on `platformreleng-debian-swtgtk3nativebuild:10`

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@
 
 def runOnNativeBuildAgent(String platform, Closure body) {
 	def final nativeBuildStageName = 'Perform native launcher build'
-	if (platform == 'gtk.linux.x86_64') {
+	if (platform == 'gtk.linux.x86_64' || platform == 'gtk.linux.aarch64') {
 		podTemplate(inheritFrom: 'basic' /* inherit general configuration */, containers: [
 			containerTemplate(name: 'launcherbuild', image: 'eclipse/platformreleng-debian-swtgtk3nativebuild:10',
 				resourceRequestCpu:'1000m', resourceRequestMemory:'512Mi',
@@ -209,7 +209,10 @@ pipeline {
 									withEnv(["JAVA_HOME=${WORKSPACE}/jdk.resources", "EXE_OUTPUT_DIR=${WORKSPACE}/libs", "LIB_OUTPUT_DIR=${WORKSPACE}/libs"]) {
 										dir(ws) {
 											if (isUnix()) {
-												sh "sh build.sh -ws ${ws} -os ${os} -arch ${arch} checklibs install"
+												sh """
+												sh build.sh clean
+												sh build.sh -ws ${ws} -os ${os} -arch ${arch} checklibs install
+												"""
 											} else {
 												bat "cmd /c build.bat -ws ${ws} -os ${os} -arch ${arch} install"
 											}

--- a/features/org.eclipse.equinox.executable.feature/library/gtk/check_dependencies.sh
+++ b/features/org.eclipse.equinox.executable.feature/library/gtk/check_dependencies.sh
@@ -19,9 +19,23 @@ SCRIPT=$( basename "${BASH_SOURCE[0]}" )
 # Check that executable/so ${FILE}
 # use glibc symbols no greater than ${ALLOWED_GLIBC_VERSION} and depend on
 # no libs other than ${ALLOWED_LIBS}
+ARCH=$1; shift
 FILE=$1; shift
 ALLOWED_GLIBC_VERSION=$1; shift
 ALLOWED_LIBS="$@"; shift
+
+if [[ "${ARCH}" != "x86_64" && "${ARCH}" != "aarch64" ]]; then
+    # We don't enforce max version and library sets on these architectures because
+    # 1. We build on native hardware for those platforms so we don't have
+    #    ability to use docker to adjust dependency versions as easily
+    # 2. The other platforms that are newer are generally faster moving
+    #    and it is less likely to break users to have harder version
+    #    requirements.
+    # As we get bigger user base on these architectures we should start enforcing
+    # upper bounds for them too.
+    echo "We do not enforce glibc version or library dependencies for ${ARCH} architecture so far. All good."
+    exit 0
+fi
 
 # Check for permitted libraries using `readelf -d` looking for shared
 # libraries that are listed as needed. e.g. lines like:

--- a/features/org.eclipse.equinox.executable.feature/library/gtk/make_linux.mak
+++ b/features/org.eclipse.equinox.executable.feature/library/gtk/make_linux.mak
@@ -142,25 +142,12 @@ $(DLL): $(DLL_OBJS) $(COMMON_OBJS)
 # on the widest range on Linuxes.
 # All other error handling regarding missing/problematic libraries
 # can be done at runtime.
-ifeq ($(DEFAULT_OS_ARCH),x86_64)
 PERMITTED_LIBRARIES=libc.so.6 libpthread.so.0 libdl.so.2
 PERMITTED_GLIBC_VERSION=2.7
 checklibs: all
 	$(info Verifying $(EXEC) $(DLL) have permitted dependencies)
-	./check_dependencies.sh $(EXEC) $(PERMITTED_GLIBC_VERSION) $(PERMITTED_LIBRARIES)
-	./check_dependencies.sh $(DLL) $(PERMITTED_GLIBC_VERSION) $(PERMITTED_LIBRARIES)
-else
-# We don't enforce max version and library sets on non-x86-64 because
-# 1. We build on native hardware for those platforms so we don't have
-#    ability to use docker to adjust dependency versions as easily
-# 2. The other platforms that are newer are generally faster moving
-#    and it is less likely to break users to have harder version
-#    requirements.
-# As we get bigger user base on non-x86-64 we should start enforcing
-# upper bounds for them too.
-checklibs: all
-endif
-
+	./check_dependencies.sh $(DEFAULT_OS_ARCH) $(EXEC) $(PERMITTED_GLIBC_VERSION) $(PERMITTED_LIBRARIES)
+	./check_dependencies.sh $(DEFAULT_OS_ARCH) $(DLL) $(PERMITTED_GLIBC_VERSION) $(PERMITTED_LIBRARIES)
 
 install: all
 	$(info Install into: EXE_OUTPUT_DIR:$(EXE_OUTPUT_DIR) LIB_OUTPUT_DIR:$(LIB_OUTPUT_DIR))


### PR DESCRIPTION
This PR expands the work done in https://github.com/eclipse-equinox/equinox/pull/834 by re-using `platformreleng-debian-swtgtk3nativebuild:10` to build native binaries for Linux on AArch64. This would allow the launcher to run on Debian 10 for AArch64.

Caveat: SWT still requires glibc 2.34. Additional work is needed to make Eclipse fully operational on Debian 10 for AArch64.

Fixes #1037.