### PR TITLE
Update MarkerIgnoringBase with AbstractLogger

### DIFF
--- a/bundles/org.eclipse.equinox.slf4j/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.slf4j/META-INF/MANIFEST.MF
@@ -10,6 +10,7 @@ Import-Package: org.eclipse.equinox.log;version="[1.1.0,2.0.0)",
  org.osgi.service.log;version="[1.5.0,2.0.0)",
  org.osgi.util.tracker;version="[1.5.0,2.0.0)",
  org.slf4j;version="[2.0.0,3.0.0)",
+ org.slf4j.event;version="[2.0.0,3.0.0)",
  org.slf4j.helpers;version="[2.0.0,3.0.0)",
  org.slf4j.spi;version="[2.0.0,3.0.0)"
 Require-Bundle: org.eclipse.equinox.common;bundle-version="[3.20.0,4.0.0)"

--- a/bundles/org.eclipse.equinox.slf4j/src/org/eclipse/equinox/slf4j/EquinoxLogger.java
+++ b/bundles/org.eclipse.equinox.slf4j/src/org/eclipse/equinox/slf4j/EquinoxLogger.java
@@ -10,14 +10,17 @@
  *
  * Contributors:
  *     Christoph Läubrich - initial API and implementation
+ *     IBM Corporation -  Update deprecated logger 
  *******************************************************************************/
 package org.eclipse.equinox.slf4j;
 
 import org.osgi.service.log.Logger;
+import org.slf4j.Marker;
+import org.slf4j.event.Level;
 import org.slf4j.helpers.FormattingTuple;
 import org.slf4j.helpers.MessageFormatter;
 
-class EquinoxLogger extends org.slf4j.helpers.MarkerIgnoringBase {
+class EquinoxLogger extends org.slf4j.helpers.AbstractLogger {
 
 	private static final long serialVersionUID = 1L;
 	private final Logger logger;
@@ -240,6 +243,41 @@ class EquinoxLogger extends org.slf4j.helpers.MarkerIgnoringBase {
 			FormattingTuple tp = MessageFormatter.arrayFormat(format, argArray);
 			logger.error(tp.getMessage(), tp.getThrowable());
 		}
+	}
+
+	@Override
+	public boolean isTraceEnabled(Marker marker) {
+		return isTraceEnabled();
+	}
+
+	@Override
+	public boolean isDebugEnabled(Marker marker) {
+		return isDebugEnabled();
+	}
+
+	@Override
+	public boolean isInfoEnabled(Marker marker) {
+		return isInfoEnabled();
+	}
+
+	@Override
+	public boolean isWarnEnabled(Marker marker) {
+		return isWarnEnabled();
+	}
+
+	@Override
+	public boolean isErrorEnabled(Marker marker) {
+		return isErrorEnabled();
+	}
+
+	@Override
+	protected String getFullyQualifiedCallerName() {
+		return this.name;
+	}
+
+	@Override
+	protected void handleNormalizedLoggingCall(Level level, Marker marker, String messagePattern, Object[] arguments,
+			Throwable throwable) {		
 	}
 
 }


### PR DESCRIPTION
This commit replaces org.slf4j.helpers.MarkerIgnoringBase with org.slf4j.helpers.AbstractLogger implementation

based on : https://github.com/eclipse-equinox/equinox/issues/843#issuecomment-2655675412

Fixes : https://github.com/eclipse-equinox/equinox/issues/843