### PR TITLE
Do not leak internal API into public packages

### DIFF
--- a/bundles/org.eclipse.equinox.preferences/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.preferences/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.preferences; singleton:=true
-Bundle-Version: 3.11.500.qualifier
+Bundle-Version: 3.12.0.qualifier
 Bundle-Activator: org.eclipse.core.internal.preferences.Activator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
@@ -11,7 +11,7 @@ Require-Bundle: org.eclipse.equinox.common;bundle-version="[3.18.0,4.0.0)",
  org.osgi.service.prefs;bundle-version="[1.1.0,1.2.0)";visibility:=reexport
 Export-Package: org.eclipse.core.internal.preferences;x-friends:="org.eclipse.core.resources,org.eclipse.core.runtime,org.eclipse.equinox.p2.engine",
  org.eclipse.core.internal.preferences.exchange;x-friends:="org.eclipse.core.runtime",
- org.eclipse.core.runtime.preferences;version="3.5.0";uses:="org.eclipse.core.runtime,org.osgi.service.prefs,org.eclipse.core.internal.preferences"
+ org.eclipse.core.runtime.preferences;version="3.6.0";uses:="org.eclipse.core.runtime,org.osgi.service.prefs"
 Bundle-ActivationPolicy: lazy; exclude:="org.eclipse.core.internal.preferences.exchange"
 Import-Package: org.eclipse.osgi.framework.log,
  org.eclipse.osgi.service.datalocation,

--- a/bundles/org.eclipse.equinox.preferences/src/org/eclipse/core/internal/preferences/AbstractScope.java
+++ b/bundles/org.eclipse.equinox.preferences/src/org/eclipse/core/internal/preferences/AbstractScope.java
@@ -13,43 +13,11 @@
  *******************************************************************************/
 package org.eclipse.core.internal.preferences;
 
-import java.util.Objects;
-import org.eclipse.core.runtime.preferences.IEclipsePreferences;
-import org.eclipse.core.runtime.preferences.IScopeContext;
-
 /**
- * Abstract super-class for scope context object contributed by the Platform.
- *
- * @since 3.0
+ * @deprecated use the public API instead of this internal class, this class
+ *             will be removed with the next release (2025-12)
  */
-public abstract class AbstractScope implements IScopeContext {
-
-	/*
-	 * Default path hierarchy for nodes is /<scope>/<qualifier>.
-	 *
-	 * @see
-	 * org.eclipse.core.runtime.preferences.IScopeContext#getNode(java.lang.String)
-	 */
-	@Override
-	public IEclipsePreferences getNode(String qualifier) {
-		if (qualifier == null) {
-			throw new IllegalArgumentException();
-		}
-		return (IEclipsePreferences) PreferencesService.getDefault().getRootNode().node(getName()).node(qualifier);
-	}
-
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj) {
-			return true;
-		}
-		return obj instanceof IScopeContext other //
-				&& getName().equals(other.getName()) //
-				&& Objects.equals(getLocation(), other.getLocation());
-	}
-
-	@Override
-	public int hashCode() {
-		return Objects.hash(getName(), getLocation());
-	}
+@Deprecated(forRemoval = true, since = "2025-09")
+public abstract class AbstractScope extends org.eclipse.core.runtime.preferences.AbstractScope {
+	// only for backward compatibility
 }

--- a/bundles/org.eclipse.equinox.preferences/src/org/eclipse/core/runtime/preferences/AbstractScope.java
+++ b/bundles/org.eclipse.equinox.preferences/src/org/eclipse/core/runtime/preferences/AbstractScope.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2004, 2015 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.core.runtime.preferences;
+
+import java.util.Objects;
+import org.eclipse.core.internal.preferences.PreferencesService;
+
+/**
+ * Abstract super-class for scope context object contributed by the Platform.
+ *
+ * @since 3.12
+ */
+public abstract class AbstractScope implements IScopeContext {
+
+	/*
+	 * Default path hierarchy for nodes is /<scope>/<qualifier>.
+	 *
+	 * @see
+	 * org.eclipse.core.runtime.preferences.IScopeContext#getNode(java.lang.String)
+	 */
+	@Override
+	public IEclipsePreferences getNode(String qualifier) {
+		if (qualifier == null) {
+			throw new IllegalArgumentException();
+		}
+		return (IEclipsePreferences) PreferencesService.getDefault().getRootNode().node(getName()).node(qualifier);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		return obj instanceof IScopeContext other //
+				&& getName().equals(other.getName()) //
+				&& Objects.equals(getLocation(), other.getLocation());
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(getName(), getLocation());
+	}
+}

--- a/bundles/org.eclipse.equinox.preferences/src/org/eclipse/core/runtime/preferences/BundleDefaultsScope.java
+++ b/bundles/org.eclipse.equinox.preferences/src/org/eclipse/core/runtime/preferences/BundleDefaultsScope.java
@@ -13,7 +13,6 @@
  *******************************************************************************/
 package org.eclipse.core.runtime.preferences;
 
-import org.eclipse.core.internal.preferences.AbstractScope;
 import org.eclipse.core.runtime.IPath;
 
 /**

--- a/bundles/org.eclipse.equinox.preferences/src/org/eclipse/core/runtime/preferences/ConfigurationScope.java
+++ b/bundles/org.eclipse.equinox.preferences/src/org/eclipse/core/runtime/preferences/ConfigurationScope.java
@@ -14,7 +14,6 @@
 package org.eclipse.core.runtime.preferences;
 
 import java.net.URL;
-import org.eclipse.core.internal.preferences.AbstractScope;
 import org.eclipse.core.internal.preferences.PreferencesOSGiUtils;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.osgi.service.datalocation.Location;

--- a/bundles/org.eclipse.equinox.preferences/src/org/eclipse/core/runtime/preferences/DefaultScope.java
+++ b/bundles/org.eclipse.equinox.preferences/src/org/eclipse/core/runtime/preferences/DefaultScope.java
@@ -13,7 +13,6 @@
  *******************************************************************************/
 package org.eclipse.core.runtime.preferences;
 
-import org.eclipse.core.internal.preferences.AbstractScope;
 import org.eclipse.core.runtime.IPath;
 
 /**

--- a/bundles/org.eclipse.equinox.preferences/src/org/eclipse/core/runtime/preferences/InstanceScope.java
+++ b/bundles/org.eclipse.equinox.preferences/src/org/eclipse/core/runtime/preferences/InstanceScope.java
@@ -13,7 +13,6 @@
  *******************************************************************************/
 package org.eclipse.core.runtime.preferences;
 
-import org.eclipse.core.internal.preferences.AbstractScope;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.osgi.service.datalocation.Location;
 

--- a/bundles/org.eclipse.equinox.preferences/src/org/eclipse/core/runtime/preferences/UserScope.java
+++ b/bundles/org.eclipse.equinox.preferences/src/org/eclipse/core/runtime/preferences/UserScope.java
@@ -13,7 +13,6 @@
  *******************************************************************************/
 package org.eclipse.core.runtime.preferences;
 
-import org.eclipse.core.internal.preferences.AbstractScope;
 import org.eclipse.core.runtime.IPath;
 
 /**


### PR DESCRIPTION
Currently all scopes are leaking the internal package due to the use of the (internal) AbstractScope class what is also used in platform itself to implement ProjectScope.

This now makes this abstract class public and makes the old class deprecated for removal with the next release (as it is only an internal class) in case there are other references outside the platform.