### PR TITLE
Drop invalid package providers when adding a permutation

### DIFF
--- a/bundles/org.eclipse.osgi/felix/src/org/apache/felix/resolver/Backlog.java
+++ b/bundles/org.eclipse.osgi/felix/src/org/apache/felix/resolver/Backlog.java
@@ -56,7 +56,7 @@ public class Backlog {
     public Candidates getNext() {
         Candidates candidates;
         while ((candidates = session.getNextPermutation()) != null) {
-            ResolutionError substituteError = candidates.checkSubstitutes();
+            candidates.process(session.getLogger());
             FaultyResourcesReport report = candidates.getFaultyResources();
             if (!report.isMissing() || session.isCancelled()) {
                 return candidates;

--- a/bundles/org.eclipse.osgi/felix/src/org/apache/felix/resolver/Candidates.java
+++ b/bundles/org.eclipse.osgi/felix/src/org/apache/felix/resolver/Candidates.java
@@ -58,6 +58,10 @@ class Candidates
 {
     private static final boolean FILTER_USES = Boolean
             .parseBoolean(System.getProperty("felix.resolver.candidates.filteruses", "true"));
+
+    private static final boolean FILTER_INVALID_PACKAGE_PROVIDER = Boolean
+            .parseBoolean(System.getProperty("felix.resolver.candidates.filterpackages", "true"));
+
     static class PopulateResult {
         boolean success;
         ResolutionError error;
@@ -1358,6 +1362,18 @@ class Candidates
             }
         }
         return null;
+    }
+
+    public void process(Logger logger) {
+        checkSubstitutes();
+        if (FILTER_INVALID_PACKAGE_PROVIDER) {
+            for (Requirement requirement : m_candidateMap.keySet().toArray(new Requirement[0])) {
+                if (requirement == null) {
+                    continue;
+                }
+                ProblemReduction.removeInvalidPackageProvider(this, requirement, logger);
+            }
+        }
     }
 
     public FaultyResourcesReport getFaultyResources() {

--- a/bundles/org.eclipse.osgi/felix/src/org/apache/felix/resolver/ProblemReduction.java
+++ b/bundles/org.eclipse.osgi/felix/src/org/apache/felix/resolver/ProblemReduction.java
@@ -51,9 +51,9 @@ class ProblemReduction {
         Resource targetResource = requirement.getResource();
         // fetch the current candidate for this requirement
         Capability currentCandidate = candidates.getFirstCandidate(requirement);
-		if (currentCandidate == null) {
-			return Collections.emptyList();
-		}
+        if (currentCandidate == null) {
+            return Collections.emptyList();
+        }
         Resource candidateResource = currentCandidate.getResource();
         // now check if it has any uses constraints
         Set<String> uses = new TreeSet<>(Util.getUses(currentCandidate));
@@ -61,7 +61,6 @@ class ProblemReduction {
             // there is nothing this one can conflict in this current set of candidates
             return Collections.emptyList();
         }
-
 
         if (logger.isDebugEnabled()) {
             logger.logRequirement("=== remove uses violations for %s", requirement);
@@ -106,6 +105,72 @@ class ProblemReduction {
             logger.logCandidates(targetResource, req -> getCapabilityList(candidates, req));
         }
         return dropped;
+    }
+
+    /**
+     * Removes all invalid package providers for a given {@link Requirement} and
+     * {@link Candidates} in a local search, that is if the requirement is a package
+     * and that package is used by any unique selected package for another import,
+     * then only the same provider can be a valid candidate without leading to a
+     * use-constraint violation otherwise.
+     * 
+     * @param candidates  candidates to filter
+     * @param requirement the requirement where the search should start
+     * @return a list of Candidates that where dropped as part of the filtering
+     */
+    static List<Candidates> removeInvalidPackageProvider(Candidates candidates, Requirement requirement,
+            Logger logger) {
+        List<Candidates> dropped = new ArrayList<>();
+        Resource targetResource = requirement.getResource();
+        List<Requirement> requirements = targetResource.getRequirements(PackageNamespace.PACKAGE_NAMESPACE);
+        boolean changed;
+        do {
+            changed = false;
+            for (Requirement packageRequirement : requirements) {
+                Capability singlePackageProvider = getSingleProvider(candidates, packageRequirement);
+                if (singlePackageProvider == null) {
+                    continue;
+                }
+                Capability capabilityForRequirement = getProviderCapabilityForRequirement(candidates,
+                        singlePackageProvider.getResource(), requirement);
+                if (capabilityForRequirement == null) {
+                    continue;
+                }
+                Set<String> uses = Util.getUses(singlePackageProvider);
+                if (uses.isEmpty() || !uses.contains(Util.getPackageName(capabilityForRequirement))) {
+                    continue;
+                }
+                // now we need to drop all providers that are before our provider
+                while (candidates.getFirstCandidate(requirement).getResource() != singlePackageProvider.getResource()) {
+                    dropped.add(candidates.copy());
+                    candidates.removeFirstCandidate(requirement);
+                    changed = true;
+                }
+            }
+        } while (changed);
+        return dropped;
+    }
+
+    private static Capability getProviderCapabilityForRequirement(Candidates candidates, Resource provider,
+            Requirement requirement) {
+        List<Capability> list = candidates.getCandidates(requirement);
+        if (list == null) {
+            return null;
+        }
+        for (Capability capability : list) {
+            if (capability.getResource() == provider) {
+                return capability;
+            }
+        }
+        return null;
+    }
+
+    private static Capability getSingleProvider(Candidates candidates, Requirement packageRequirement) {
+        List<Capability> providers = candidates.getCandidates(packageRequirement);
+        if (providers != null && providers.size() == 1) {
+            return providers.get(0);
+        }
+        return null;
     }
 
     private static Capability removeViolators(Candidates candidates, Resource candidateResource,


### PR DESCRIPTION
Currently a certain set of use-constraint violations occur when checking the classpath consistency that can be described in the following way:

- There is a package A provided by X and Y
- There is a package B provided by Y that uses A
- Consumer C imports package A + B
- There are now two eligible providers for A and if the resolver chooses for A = X and B = Y
- This results in a use-violation because A is reachable through two chains (C->X->Ax, C->B->Y->Ay)

This can be avoided by doing an initial scan of all providers that are singletons in the current permutation, have a use constraint on a package that is also provided by this provider, and has more than one candidate, then the only valid on is the provider of the singleton selection.

This currently adds a test-case that shows the situation and currently requires 7 permutations, where it should in the best case only require 1 (the initial one) because there is only one valid choice when these kind of exceptions occurs:

```
Chain 1:
  biz.aQute.repository [osgi.identity; type="osgi.bundle"; version:Version="7.1.0.202411251545"; osgi.identity="biz.aQute.repository"]
    import: (&(osgi.wiring.package=aQute.service.reporter)(&(version>=1.3.0)(!(version>=2.0.0))))
     |
    export: osgi.wiring.package: aQute.service.reporter
  aQute.libg [osgi.identity; type="osgi.bundle"; version:Version="7.1.0.202411251545"; osgi.identity="aQute.libg"]

Chain 2:
  biz.aQute.repository [osgi.identity; type="osgi.bundle"; version:Version="7.1.0.202411251545"; osgi.identity="biz.aQute.repository"]
    import: (&(osgi.wiring.package=aQute.bnd.build)(&(version>=4.6.0)(!(version>=5.0.0))))
     |
    export: osgi.wiring.package: aQute.bnd.build; uses:=aQute.service.reporter
    export: osgi.wiring.package=aQute.service.reporter
  biz.aQute.bndlib [osgi.identity; type="osgi.bundle"; version:Version="7.1.0.202411251545"; osgi.identity="biz.aQute.bndlib"])
```

Where the following choices exits:

```
    [?]Import-Package: aQute.service.reporter; version="[1.3.0,2.0.0)": 
        Export-Package: aQute.service.reporter; bundle-symbolic-name="aQute.libg"; bundle-version="7.1.0.202411251545"; version="1.3.0"
        Export-Package: aQute.service.reporter; bundle-symbolic-name="biz.aQute.bndlib"; bundle-version="7.1.0.202411251545"; version="1.3.0"
```

but the first one is invalid because of

```
    [!]Import-Package: aQute.bnd.service.repository; version="[1.7.0,2.0.0)": 
        Export-Package: aQute.bnd.service.repository; bundle-symbolic-name="biz.aQute.bndlib"; bundle-version="7.1.0.202411251545"; version="1.7.0"; uses:="aQute.bnd.service,aQute.bnd.util.dto,aQute.bnd.version,aQute.service.reporter,org.osgi.resource"
```

So `aQute.bnd.service.repository` uses `aQute.service.reporter`, both packages are provided by `biz.aQute.bndlib` so in the case of import only bndlib is a valid choice.