### PR TITLE
Do not print optional unresolved requirements in report

### DIFF
--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/container/ModuleContainer.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/container/ModuleContainer.java
@@ -682,7 +682,7 @@ public final class ModuleContainer implements DebugOptionsListener {
 		if (isRefreshingSystemModule()) {
 			return new ModuleResolutionReport(null, Collections.emptyMap(),
 					new ResolutionException("Unable to resolve while shutting down the framework."), -1, -1, -1, -1, //$NON-NLS-1$
-					-1);
+					-1, adaptor);
 		}
 		ResolutionReport report = null;
 		try (ResolutionLock.Permits resolutionPermits = _resolutionLock.acquire(1)) {
@@ -695,7 +695,7 @@ public final class ModuleContainer implements DebugOptionsListener {
 						if (be.getType() == BundleException.REJECTED_BY_HOOK
 								|| be.getType() == BundleException.STATECHANGE_ERROR) {
 							return new ModuleResolutionReport(null, Collections.emptyMap(),
-									new ResolutionException(be), -1, -1, -1, -1, -1);
+									new ResolutionException(be), -1, -1, -1, -1, -1, adaptor);
 						}
 					}
 					throw e;
@@ -704,7 +704,7 @@ public final class ModuleContainer implements DebugOptionsListener {
 		} catch (ResolutionLockException e) {
 			return new ModuleResolutionReport(null, Collections.emptyMap(),
 					new ResolutionException("Timeout acquiring lock for resolution", e, Collections.emptyList()), -1, //$NON-NLS-1$
-					-1, -1, -1, -1);
+					-1, -1, -1, -1, adaptor);
 		}
 		return report;
 	}
@@ -1373,7 +1373,7 @@ public final class ModuleContainer implements DebugOptionsListener {
 		if (!isRefreshingSystemModule()) {
 			return resolve(refreshTriggers, false, true);
 		}
-		return new ModuleResolutionReport(null, null, null, -1, -1, -1, -1, -1);
+		return new ModuleResolutionReport(null, null, null, -1, -1, -1, -1, -1, adaptor);
 	}
 
 	/**

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/container/ModuleRequirement.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/container/ModuleRequirement.java
@@ -24,6 +24,7 @@ import org.osgi.framework.namespace.PackageNamespace;
 import org.osgi.framework.wiring.BundleCapability;
 import org.osgi.framework.wiring.BundleRequirement;
 import org.osgi.resource.Namespace;
+import org.osgi.resource.Requirement;
 
 /**
  * An implementation of {@link BundleRequirement}. This requirement implements
@@ -151,6 +152,11 @@ public class ModuleRequirement implements BundleRequirement {
 		ModuleRequirement getOriginal() {
 			return ModuleRequirement.this;
 		}
+	}
+
+	static boolean isOptional(Requirement req) {
+		String resolution = req.getDirectives().get(Namespace.REQUIREMENT_RESOLUTION_DIRECTIVE);
+		return Namespace.RESOLUTION_OPTIONAL.equalsIgnoreCase(resolution);
 	}
 
 }

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/container/ModuleResolver.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/container/ModuleResolver.java
@@ -1024,7 +1024,7 @@ final class ModuleResolver {
 						BundleException be = (BundleException) e.getCause();
 						if (be.getType() == BundleException.REJECTED_BY_HOOK) {
 							return new ModuleResolutionReport(null, Collections.emptyMap(),
-									new ResolutionException(be), -1, -1, -1, -1, -1);
+									new ResolutionException(be), -1, -1, -1, -1, -1, adaptor);
 						}
 					}
 					throw e;
@@ -1068,7 +1068,7 @@ final class ModuleResolver {
 					if (DEBUG_WIRING) {
 						printWirings(result);
 					}
-					report = reportBuilder.build(result, re, logger);
+					report = reportBuilder.build(result, re, logger, adaptor);
 					if (DEBUG_REPORT) {
 						if (report.getResolutionException() != null) {
 							adaptor.traceThrowable(OPTION_REPORT, report.getResolutionException());


### PR DESCRIPTION
Currently ModuleResolutionReport prints all unresolved requirements what in case of optional requirements can bloat the report considerably and is often confusing to read as optional requirements can not lead to an unresolved state.

This now filters out all items from the report if the requirement is optional and adding a system property for the case someone wants to still enable the old behavior.

@tjwatson WDYT? This is the most annoying part when debugging resolution errors as one often not notice the real problem in the sea of optional things.