### PR TITLE
Make IPath serializable

### DIFF
--- a/bundles/org.eclipse.equinox.common/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.common/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.common; singleton:=true
-Bundle-Version: 3.20.200.qualifier
+Bundle-Version: 3.21.0.qualifier
 Bundle-Localization: plugin
 Export-Package: org.eclipse.core.internal.boot;x-friends:="org.eclipse.core.resources,org.eclipse.pde.build",
  org.eclipse.core.internal.runtime;common=split;mandatory:=common;
@@ -14,7 +14,7 @@ Export-Package: org.eclipse.core.internal.boot;x-friends:="org.eclipse.core.reso
    org.eclipse.core.runtime.compatibility,
    org.eclipse.core.filesystem,
    org.eclipse.equinox.security",
- org.eclipse.core.runtime;common=split;version="3.7.0";mandatory:=common;uses:="org.osgi.framework",
+ org.eclipse.core.runtime;common=split;version="3.8.0";mandatory:=common;uses:="org.osgi.framework",
  org.eclipse.core.text;version="3.14.0",
  org.eclipse.equinox.events;version="1.0.0"
 Bundle-Vendor: %providerName

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/IPath.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/IPath.java
@@ -15,6 +15,8 @@
  *******************************************************************************/
 package org.eclipse.core.runtime;
 
+import java.io.Serializable;
+
 /**
  * A path is an ordered collection of string segments, separated by a standard
  * separator character, "/". A path may also have a leading and/or a trailing
@@ -24,7 +26,7 @@ package org.eclipse.core.runtime;
  * independent path has <code>null</code> for a device id.
  * <p>
  * Note that paths are value objects; all operations on paths return a new path;
- * the path that is operated on is unscathed.
+ * the path that is operated on is unchanged.
  * </p>
  * <p>
  * UNC paths are denoted by leading double-slashes such as
@@ -43,7 +45,7 @@ package org.eclipse.core.runtime;
  * @noextend This interface is not intended to be extended by clients.
  * @noimplement This interface is not intended to be implemented by clients.
  */
-public interface IPath extends Cloneable {
+public interface IPath extends Cloneable, Serializable {
 
 	/**
 	 * Path separator character constant "/" used in paths.

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/Path.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/Path.java
@@ -15,6 +15,7 @@
 package org.eclipse.core.runtime;
 
 import java.io.File;
+import java.io.Serializable;
 import java.util.Arrays;
 
 /**
@@ -43,6 +44,7 @@ import java.util.Arrays;
  * @noextend This class is not intended to be subclassed by clients.
  */
 public final class Path implements IPath, Cloneable {
+	private static final long serialVersionUID = 1L;
 	/* masks for flag values: */
 	/**
 	 * if HAS_LEADING is set then Path starts with leading slash i.e. it is
@@ -127,7 +129,7 @@ public final class Path implements IPath, Cloneable {
 	private final String[] segments;
 
 	/** cached hash code */
-	private int hash;
+	private transient int hash;
 
 	/**
 	 * flags indicating separators (has leading, is UNC, has trailing, is for
@@ -1462,4 +1464,26 @@ public final class Path implements IPath, Cloneable {
 		String[] newSegments = Arrays.copyOf(s, count);
 		return new Path(device, newSegments, flags);
 	}
+
+	// magic method of Serializable interface
+	Object writeReplace() {
+		return new PortablePath(toPortableString());
+	}
+
+	static final class PortablePath implements Serializable {
+
+		private static final long serialVersionUID = 1L;
+		private String portableString;
+
+		public PortablePath(String portableString) {
+			this.portableString = portableString;
+		}
+
+		// magic method of Serializable interface
+		Object readResolve() {
+			return fromPortableString(portableString);
+		}
+
+	}
+
 }


### PR DESCRIPTION
I noticed that when working on https://github.com/eclipse-pde/eclipse.pde/pull/1898 that we need special handling for reading/writing a `IPath`.

As `IPath` is just a collection of strings and some flags I don't see why we should not support it even though it might not be portable (in wich case one would better use an own serialization way).