### PR TITLE
Remove source features and source bundles from the sdk features

### DIFF
--- a/features/org.eclipse.equinox.compendium.sdk/feature.properties
+++ b/features/org.eclipse.equinox.compendium.sdk/feature.properties
@@ -27,9 +27,9 @@ providerName=Eclipse Equinox Project
 updateSiteName=The Equinox Project Repository
 
 # "description" property - description of the feature
-description=A collection of Equinox bundles  and source that implement optional parts \
+description=A collection of Equinox bundles that implement optional parts \
 of the current OSGi specifications--the so called "Compendium Services". \n\
-This feature includes the corresponding source and is intended to be added to target \
+This feature is intended to be added to target \
 platforms at development time rather than deployed with end-user systems.
 
 # "copyright" property - text of the "Feature Update Copyright"

--- a/features/org.eclipse.equinox.compendium.sdk/feature.xml
+++ b/features/org.eclipse.equinox.compendium.sdk/feature.xml
@@ -24,15 +24,7 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.eclipse.equinox.app.source"
-         version="0.0.0"/>
-
-   <plugin
          id="org.eclipse.equinox.coordinator"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.equinox.coordinator.source"
          version="0.0.0"/>
 
    <plugin
@@ -40,15 +32,7 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.eclipse.equinox.cm.source"
-         version="0.0.0"/>
-
-   <plugin
          id="org.eclipse.equinox.device"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.equinox.device.source"
          version="0.0.0"/>
 
    <plugin
@@ -56,15 +40,7 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.eclipse.equinox.event.source"
-         version="0.0.0"/>
-
-   <plugin
          id="org.eclipse.equinox.metatype"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.equinox.metatype.source"
          version="0.0.0"/>
 
    <plugin
@@ -72,15 +48,7 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.eclipse.equinox.preferences.source"
-         version="0.0.0"/>
-
-   <plugin
          id="org.osgi.service.prefs"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.osgi.service.prefs.source"
          version="0.0.0"/>
 
    <plugin
@@ -88,15 +56,7 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.eclipse.equinox.useradmin.source"
-         version="0.0.0"/>
-
-   <plugin
          id="org.osgi.service.coordinator"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.osgi.service.coordinator.source"
          version="0.0.0"/>
 
 </feature>

--- a/features/org.eclipse.equinox.core.sdk/feature.properties
+++ b/features/org.eclipse.equinox.core.sdk/feature.properties
@@ -27,9 +27,9 @@ providerName=Eclipse Equinox Project
 updateSiteName=The Equinox Project Repository
 
 # "description" property - description of the feature
-description=A collection of core Equinox bundles and source including the Equinox framework \
+description=A collection of core Equinox bundles including the Equinox framework \
 implementation itself. \n\
-This feature includes the corresponding source and is intended \
+This feature is intended \
 to be added to target platforms at development time rather than \
 deployed with end-user systems.
 

--- a/features/org.eclipse.equinox.core.sdk/feature.xml
+++ b/features/org.eclipse.equinox.core.sdk/feature.xml
@@ -23,16 +23,8 @@
          id="org.eclipse.equinox.core.feature"
          version="0.0.0"/>
 
-   <includes
-         id="org.eclipse.equinox.core.feature.source"
-         version="0.0.0"/>
-
    <plugin
          id="org.eclipse.equinox.launcher"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.equinox.launcher.source"
          version="0.0.0"/>
 
    <plugin
@@ -40,15 +32,7 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.eclipse.equinox.supplement.source"
-         version="0.0.0"/>
-
-   <plugin
          id="org.eclipse.equinox.transforms.xslt"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.equinox.transforms.xslt.source"
          version="0.0.0"/>
 
    <plugin
@@ -56,15 +40,7 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.eclipse.equinox.transforms.hook.source"
-         version="0.0.0"/>
-
-   <plugin
          id="org.eclipse.equinox.concurrent"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.equinox.concurrent.source"
          version="0.0.0"/>
 
    <plugin
@@ -77,17 +53,7 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.eclipse.equinox.security.win32.source"
-         os="win32"
-         version="0.0.0"/>
-
-   <plugin
          id="org.eclipse.equinox.security.linux"
-         os="linux"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.equinox.security.linux.source"
          os="linux"
          version="0.0.0"/>
 
@@ -97,20 +63,7 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.eclipse.equinox.security.macosx.source"
-         os="macosx"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.equinox.security.source"
-         version="0.0.0"/>
-
-   <plugin
          id="org.eclipse.equinox.security.ui"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.equinox.security.ui.source"
          version="0.0.0"/>
 
    <plugin
@@ -118,23 +71,11 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.eclipse.equinox.region.source"
-         version="0.0.0"/>
-
-   <plugin
          id="org.eclipse.equinox.log.stream"
          version="0.0.0"/>
 
    <plugin
-         id="org.eclipse.equinox.log.stream.source"
-         version="0.0.0"/>
-
-   <plugin
          id="org.eclipse.equinox.console.ssh"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.equinox.console.ssh.source"
          version="0.0.0"/>
 
    <plugin
@@ -146,15 +87,7 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.eclipse.equinox.bidi.source"
-         version="0.0.0"/>
-
-   <plugin
          id="org.eclipse.equinox.weaving.caching"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.equinox.weaving.caching.source"
          version="0.0.0"/>
 
    <plugin
@@ -162,15 +95,7 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.eclipse.equinox.weaving.caching.j9.source"
-         version="0.0.0"/>
-
-   <plugin
          id="org.eclipse.equinox.weaving.hook"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.equinox.weaving.hook.source"
          version="0.0.0"/>
 
    <plugin
@@ -178,15 +103,7 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.osgi.service.log.stream.source"
-         version="0.0.0"/>
-
-   <plugin
          id="org.osgi.util.pushstream"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.osgi.util.pushstream.source"
          version="0.0.0"/>
 
 </feature>

--- a/features/org.eclipse.equinox.sdk/feature.properties
+++ b/features/org.eclipse.equinox.sdk/feature.properties
@@ -25,10 +25,10 @@ featureName=Equinox Target Components
 providerName=Eclipse Equinox Project
 
 # "description" property - description of the feature
-description=All of the bundles and source that are produced by the Equinox project.  \
+description=All of the bundles that are produced by the Equinox project.  \
 This includes basic OSGi framework support, all implemented compendium services, \
 the p2 provisioning platform and various server-side support bundles.\n\
-This feature includes the corresponding source and is intended \
+This feature is intended \
 to be added to target platforms at development time rather than \
 deployed with end-user systems.
 

--- a/features/org.eclipse.equinox.sdk/feature.xml
+++ b/features/org.eclipse.equinox.sdk/feature.xml
@@ -36,15 +36,7 @@
          version="0.0.0"/>
 
    <includes
-         id="org.eclipse.equinox.server.core.source"
-         version="0.0.0"/>
-
-   <includes
          id="org.eclipse.equinox.server.jetty"
-         version="0.0.0"/>
-
-   <includes
-         id="org.eclipse.equinox.server.jetty.source"
          version="0.0.0"/>
 
    <requires>
@@ -56,15 +48,7 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.eclipse.equinox.http.servletbridge.source"
-         version="0.0.0"/>
-
-   <plugin
          id="org.eclipse.equinox.jsp.jasper"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.equinox.jsp.jasper.source"
          version="0.0.0"/>
 
    <plugin
@@ -72,15 +56,7 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.eclipse.equinox.jsp.jasper.registry.source"
-         version="0.0.0"/>
-
-   <plugin
          id="org.eclipse.equinox.servletbridge"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.equinox.servletbridge.source"
          version="0.0.0"/>
 
 </feature>


### PR DESCRIPTION
- The repositories and products that use these SDK features use includeAllSources to ensure that sources are available.

https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3206