### PR TITLE
Do not add the inital candidate to the session

### DIFF
--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/container/TestModuleContainer.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/container/TestModuleContainer.java
@@ -4362,7 +4362,7 @@ public class TestModuleContainer extends AbstractTest {
 	public void testLocalUseConstraintViolations() throws Exception {
 		ResolutionReport result = resolveTestSet("set1");
 		// TODO get down permutation count!
-		assertSucessfulWith(result, 49);
+		assertSucessfulWith(result, 48);
 		assertNotMoreThanPermutationCreated(result, ResolutionReport::getSubstitutionPermutations, 20);
 	}
 


### PR DESCRIPTION
Currently the inital candidate is added to the session as us USES permutation. This is not only confusing because it is not a permutation of the initial problem and not caused by a sue constraint violation, this also gives false statistics reported as always one uses permutation is assumed even if the problem can be solved without any permutation.

To prevent his and to allow further improvements that can act at the time a permutation is really removed from the stack, this now passes the initial permutation to the method that uses it.