### PR TITLE
Support GTK4 in native launcher

### DIFF
--- a/features/org.eclipse.equinox.executable.feature/library/eclipse.c
+++ b/features/org.eclipse.equinox.executable.feature/library/eclipse.c
@@ -445,20 +445,6 @@ JNIEXPORT int run(int argc, _TCHAR* argv[], _TCHAR* vmArgs[])
 	setenv(firstThreadEnvVariable, "1", 1);
 #endif
 
-#ifdef LINUX
-	if (!noSplash) {
-		char *swtGtk4 = getenv("SWT_GTK4");
-		if (swtGtk4 != NULL && strcmp(swtGtk4, "1") == 0) {
-			// The eclipse launcher uses GTK3 exclusively, therefore when starting GTK4
-			// it must be started without a splash screen
-			// https://github.com/eclipse-equinox/equinox/issues/831
-			// If the user didn't already specify -nosplash print a warning and turn the splashscreen off
-			_ftprintf(stderr, "WARNING: SWT_GTK4 does not support splash screen yet. Therefore it has been disabled. To suppress this message launch with -nosplash\n");
-			noSplash = 1;
-		}
-	}
-#endif
-
 	return _run(argc, argv, vmArgs);
 }
 

--- a/features/org.eclipse.equinox.executable.feature/library/gtk/eclipseGtk.h
+++ b/features/org.eclipse.equinox.executable.feature/library/gtk/eclipseGtk.h
@@ -23,13 +23,17 @@ struct GTK_PTRS {
 	void		(*gtk_container_add)		(GtkContainer*, GtkWidget*);
 	gint		(*gtk_dialog_run)			(GtkDialog *);
 	GtkWidget*	(*gtk_image_new_from_pixbuf)(GdkPixbuf*);
+	GtkWidget*	(*gtk_picture_new_for_pixbuf)(GdkPixbuf*);
+	gboolean    (*gtk_init_check)           (); //GTK4 variant of the function has no params
 	gboolean	(*gtk_init_with_args)		(int*, char***, const char *, void *, const char *, GError **);
 	GtkWidget*	(*gtk_message_dialog_new)	(GtkWindow*, GtkDialogFlags, GtkMessageType, GtkButtonsType, const gchar*, ...);
 	void		(*gtk_widget_destroy)		(GtkWidget*);
 	void		(*gtk_widget_destroyed)		(GtkWidget*, GtkWidget**);
 	void		(*gtk_widget_show_all)		(GtkWidget*);
 	GtkWidget*	(*gtk_window_new)			(GtkWindowType);
+	void		(*gtk_window_present)		(GtkWindow*);
 	void		(*gtk_window_resize)		(GtkWindow*, gint, gint);
+	void		(*gtk_window_set_child)		(GtkWindow*, GtkWidget*);
 	void		(*gtk_window_set_title)		(GtkWindow*, const gchar*);
 	void		(*gtk_window_set_decorated)	(GtkWindow*, gboolean);
 	void		(*gtk_window_set_type_hint)	(GtkWindow*, int);
@@ -80,5 +84,7 @@ typedef struct {
 
 /* load the gtk libraries and initialize the function pointers */
 extern int loadGtk();
+
+extern gboolean isGtk4();
 
 #endif

--- a/features/org.eclipse.equinox.executable.feature/library/gtk/eclipseGtkCommon.c
+++ b/features/org.eclipse.equinox.executable.feature/library/gtk/eclipseGtkCommon.c
@@ -109,12 +109,18 @@ int initWindowSystem(int* pArgc, char* argv[])
 
 	/* Initialize GTK. */
     GError *error = NULL;
-    if (!gtk.gtk_init_with_args(0, NULL, NULL, NULL, NULL, &error)) {
-        if (error) {
-            fprintf(stderr, "%s: %s\n", getOfficialName(), error->message);
-            gtk.g_error_free(error);
-        }
-        return -1;
+    if (gtk.gtk_init_with_args) {
+		if (!gtk.gtk_init_with_args(0, NULL, NULL, NULL, NULL, &error)) {
+			if (error) {
+				fprintf(stderr, "%s: %s\n", getOfficialName(), error->message);
+				gtk.g_error_free(error);
+			}
+			return -1;
+		}
+    } else if (gtk.gtk_init_check) {
+    	if (!gtk.gtk_init_check()) {
+    		return -1;
+    	}
     }
 
 	/*_gdk_set_program_class(getOfficialName());*/

--- a/features/org.eclipse.equinox.executable.feature/library/gtk/make_linux.mak
+++ b/features/org.eclipse.equinox.executable.feature/library/gtk/make_linux.mak
@@ -76,6 +76,7 @@ DLL = $(PROGRAM_LIBRARY)
 LIBS = -lpthread -ldl
 GTK_LIBS = \
  -DGTK3_LIB="\"libgtk-3.so.0\"" -DGDK3_LIB="\"libgdk-3.so.0\"" \
+ -DGTK4_LIB="\"libgtk-4.so.1\"" -DGDK4_LIB="\"libgtk-4.so.1\"" \
  -DPIXBUF_LIB="\"libgdk_pixbuf-2.0.so.0\"" -DGOBJ_LIB="\"libgobject-2.0.so.0\"" \
  -DGIO_LIB="\"libgio-2.0.so.0\"" -DGLIB_LIB="\"libglib-2.0.so.0\""
 LFLAGS = ${M_ARCH} -shared -fpic -Wl,--export-dynamic 


### PR DESCRIPTION
Splash is shown correctly.
When workbench takes over (after workspace chooser) the splash image is not visible anymore but this is SWT not launcher problem.