### PR TITLE
Log and assert actually processed permutations

### DIFF
--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/container/TestModuleContainer.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/container/TestModuleContainer.java
@@ -1982,17 +1982,17 @@ public class TestModuleContainer extends AbstractTest {
 	 */
 	@Test
 	public void testUses5Importer() throws BundleException, IOException {
-		doTestUses5("uses.k.importer.MF", 3, 0, 3, 0);
+		doTestUses5("uses.k.importer.MF", 2, 0, 3, 0);
 	}
 
 	@Test
 	public void testUses5ReqCap() throws BundleException, IOException {
-		doTestUses5("uses.k.reqCap.MF", 3, 0, 3, 0);
+		doTestUses5("uses.k.reqCap.MF", 2, 0, 3, 0);
 	}
 
 	@Test
 	public void testUses5Requirer() throws BundleException, IOException {
-		doTestUses5("uses.k.requirer.MF", 3, 0, 3, 0);
+		doTestUses5("uses.k.requirer.MF", 2, 0, 3, 0);
 	}
 
 	public void doTestUses5(String kManifest, int maxTotal, int maxSub, int maxUse, int maxPkg)
@@ -3939,14 +3939,13 @@ public class TestModuleContainer extends AbstractTest {
 			modules.add(installDummyModule(manifest, manifest, container));
 		}
 		report = container.resolve(modules, true);
-		assertSucessfulWith(report, 114, 62, 47, 5);
+		assertSucessfulWith(report, 15, 62, 47, 5);
 	}
 
-	protected void assertSucessfulWith(ResolutionReport report, int maxTotalPermutations, int maxSubstitution,
+	protected void assertSucessfulWith(ResolutionReport report, int maxProcessed, int maxSubstitution,
 			int maxUses, int maxImport) {
 		assertNull("Failed to resolve test.", report.getResolutionException());
-		assertNotMoreThanPermutationCreated(report, ResolutionReport::getTotalPermutations, maxTotalPermutations,
-				"total");
+		assertNotMoreThanPermutationCreated(report, ResolutionReport::getProcessedPermutations, maxProcessed, "processed");
 		assertNotMoreThanPermutationCreated(report, ResolutionReport::getSubstitutionPermutations, maxSubstitution,
 				"substitution");
 		assertNotMoreThanPermutationCreated(report, ResolutionReport::getUsesPermutations, maxUses, "uses");
@@ -4369,29 +4368,26 @@ public class TestModuleContainer extends AbstractTest {
 	@Test
 	public void testLocalUseConstraintViolations() throws Exception {
 		ResolutionReport result = resolveTestSet("set1");
-		// TODO get down permutation count!
-		assertSucessfulWith(result, 49, 20, 23, 6);
+		assertSucessfulWith(result, 6, 20, 23, 6);
 	}
 
 	@Test
 
 	public void testLocalUseConstraintViolations2() throws Exception {
 		ResolutionReport result = resolveTestSet("set2");
-		// TODO get down permutation count!
-		assertSucessfulWith(result, 7, 3, 1, 3);
+		assertSucessfulWith(result, 3, 3, 1, 3);
 	}
 
 	@Test
 	public void testSubstitutionPackageResolution() throws Exception {
 		ResolutionReport result = resolveTestSet("set3");
-		// TODO get down permutation count
 		// In this example we see the following:
 		// - libg has two possible choices for its substitution package, the internal one is chosen in first iteration -> resolved
 		// - util has two possible choices for its substitution package, the external one is chosen in first iteration -> libg
 		// - now util has to be removed as a provider only having libg as the only one left
 		// - bndlib now can only use libg for exceptions package but this conflicts with  result from util that has use constraint on exceptions package
 		// - on second iteration now libg chose external and drops it exports removing it from util+bndlib -> resolved state
-		assertSucessfulWith(result, 3, 2, 1, 0);
+		assertSucessfulWith(result, 1, 2, 1, 0);
 	}
 
 	private ResolutionReport resolveTestSet(String testSetName) throws Exception {

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/container/ModuleResolver.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/container/ModuleResolver.java
@@ -477,10 +477,11 @@ final class ModuleResolver {
 		class ResolveLogger extends Logger {
 			private Map<Resource, ResolutionException> errors = null;
 			public int totalPerm;
-			public int processedPerm;
+			public int totalProcessedPerm;
 			public int usesPerm;
 			public int importPerm;
 			public int subPerm;
+			public int processedPerm;
 
 			public ResolveLogger() {
 				super(DEBUG_USES ? Logger.LOG_DEBUG : 0);
@@ -609,6 +610,11 @@ final class ModuleResolver {
 
 			@Override
 			public void logProcessPermutation(PermutationType type) {
+				totalProcessedPerm++;
+			}
+
+			@Override
+			public void logPermutationProcessed(ResolutionError error) {
 				processedPerm++;
 			}
 

--- a/bundles/org.eclipse.osgi/felix/src/org/apache/felix/resolver/Logger.java
+++ b/bundles/org.eclipse.osgi/felix/src/org/apache/felix/resolver/Logger.java
@@ -185,4 +185,20 @@ public class Logger
     {
         // do nothing by default
     }
+
+    /**
+     * Called whenever a permutation was processed and if processing yields any
+     * error (usually a uses-contraint violation but also unresolved resources),
+     * this reflects actual work to be performed, while
+     * {@link #logPermutationAdded(PermutationType)} and
+     * {@link #logProcessPermutation(PermutationType)} indicate that a permutations
+     * is added for later examination or pulled from the stack for further
+     * processing.
+     * 
+     * @param error if this permutation resulted in an error or was successful in
+     *              which case the value is <code>null</code>
+     */
+    public void logPermutationProcessed(ResolutionError error) {
+
+    }
 }

--- a/bundles/org.eclipse.osgi/felix/src/org/apache/felix/resolver/ResolverImpl.java
+++ b/bundles/org.eclipse.osgi/felix/src/org/apache/felix/resolver/ResolverImpl.java
@@ -289,8 +289,10 @@ public class ResolverImpl implements Resolver
             ResolutionError currentError = session.getCurrentError();
             if (currentError == null && report.getUnresolvedRequirements().isEmpty()) {
                 // Success!
+                m_logger.logPermutationProcessed(null);
                 break;
             }
+            m_logger.logPermutationProcessed(currentError == null ? report : currentError);
             if (bestCandidate == null || report.isBetterThan(bestCandidate.getFaultyResources())) {
                 bestCandidate = current;
                 if (currentError == null && report.isMissingMandatory()) {


### PR DESCRIPTION
Currently we log the actual number of permutation removed from the stack and also assert the counts for the individual permutation types added. Now as we have the Backlog actually filtering out candidates that are likely not good solutions the actual number of processed permutations becomes much more interesting.

This now adds a new logger method for that case and uses it in the tests to assert that no more than a certain number of permutations are actually processed in the resolver loop.