### PR TITLE
Use faulty resources as a first discriminator

### DIFF
--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/container/TestModuleContainer.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/container/TestModuleContainer.java
@@ -1988,12 +1988,12 @@ public class TestModuleContainer extends AbstractTest {
 
 	@Test
 	public void testUses5ReqCap() throws BundleException, IOException {
-		doTestUses5("uses.k.reqCap.MF", 2, 0, 3, 0);
+		doTestUses5("uses.k.reqCap.MF", 3, 0, 3, 0);
 	}
 
 	@Test
 	public void testUses5Requirer() throws BundleException, IOException {
-		doTestUses5("uses.k.requirer.MF", 2, 0, 3, 0);
+		doTestUses5("uses.k.requirer.MF", 3, 0, 3, 0);
 	}
 
 	public void doTestUses5(String kManifest, int maxTotal, int maxSub, int maxUse, int maxPkg)
@@ -4394,7 +4394,7 @@ public class TestModuleContainer extends AbstractTest {
 	@Test
 	public void testLargeSet() throws Exception {
 		ResolutionReport result = resolveModuleDatabaseDump("big", TimeUnit.MINUTES.toSeconds(5));
-		assertSucessfulWith(result, 2661, 29, 31623, 9272);
+		assertSucessfulWith(result, 1821, 29, 26359, 6736);
 	}
 
 	private ResolutionReport resolveModuleDatabaseDump(String testSetName, long batchTimeoutSeconds) throws Exception {


### PR DESCRIPTION
Currently we extract the failed requirement of a use-constrain violation but this actually results in the whole resource to be unresolved. This leads to the situation that a solution that has one optional requirement not satisfied is compared equal to one that is failing on an optional requirement with uses-violation what is wrong.

This now store the map directly and uses it as a first selection criteria to decide one solution is better than the other.

This already reduces the processed permutation for the large set from 2661 > 1821