### PR TITLE
Init system module and assert all modules are resolved

### DIFF
--- a/bundles/org.eclipse.osgi.tests/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.osgi.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Core OSGi Tests
 Bundle-SymbolicName: org.eclipse.osgi.tests;singleton:=true
-Bundle-Version: 3.22.300.qualifier
+Bundle-Version: 3.22.400.qualifier
 Bundle-Vendor: Eclipse.org
 Require-Bundle: 
  org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",

--- a/bundles/org.eclipse.osgi.tests/pom.xml
+++ b/bundles/org.eclipse.osgi.tests/pom.xml
@@ -19,7 +19,7 @@
   </parent>
   <groupId>org.eclipse.platform</groupId>
   <artifactId>org.eclipse.osgi.tests</artifactId>
-  <version>3.22.300-SNAPSHOT</version>
+  <version>3.22.400-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <properties>


### PR DESCRIPTION
When using a module database as a testcase this now makes the actual resolving a bit more like it happens on runtime that is the system module is init (and resolved) first and then the other bundles are resolved. Beside that we also assert that all modules are resolved in the end to make sure we not just missing them in the report.

@tjwatson as it is a test-only change would you be fine with merging this for RC2?