### PR TITLE
Replace org.eclipse.core.runtime split-package imports with bundle req

### DIFF
--- a/bundles/org.eclipse.equinox.cm.test/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.cm.test/META-INF/MANIFEST.MF
@@ -3,9 +3,8 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Test Plug-in
 Bundle-Vendor: Eclipse.org - Equinox
 Bundle-SymbolicName: org.eclipse.equinox.cm.test
-Bundle-Version: 1.2.0.qualifier
-Import-Package: org.eclipse.core.runtime,
- org.eclipse.equinox.log,
+Bundle-Version: 1.2.100.qualifier
+Import-Package: org.eclipse.equinox.log,
  org.junit;version="4.12.0",
  org.junit.function;version="4.12.0",
  org.junit.runner;version="4.12.0",
@@ -17,4 +16,5 @@ Import-Package: org.eclipse.core.runtime,
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: org.eclipse.equinox.cm.test
-Require-Bundle: org.eclipse.equinox.cm
+Require-Bundle: org.eclipse.equinox.cm,
+ org.eclipse.core.runtime

--- a/bundles/org.eclipse.equinox.common.tests/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.common.tests/META-INF/MANIFEST.MF
@@ -3,17 +3,17 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Common Eclipse Runtime Tests
 Bundle-Vendor: Eclipse.org - Equinox
 Bundle-SymbolicName: org.eclipse.equinox.common.tests;singleton:=true
-Bundle-Version: 3.17.500.qualifier
+Bundle-Version: 3.17.600.qualifier
 Automatic-Module-Name: org.eclipse.equinox.common.tests
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.junit,
  org.eclipse.equinox.common;bundle-version="3.18.0",
+ org.eclipse.core.runtime,
  org.eclipse.core.tests.harness;bundle-version="3.11.400",
  org.eclipse.equinox.registry;bundle-version="3.8.200"
 Import-Package: org.eclipse.osgi.service.localization,
  org.osgi.framework,
- org.eclipse.core.runtime,
  org.osgi.service.log,
  org.osgi.service.packageadmin,
  org.osgi.util.tracker

--- a/bundles/org.eclipse.equinox.preferences.tests/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.preferences.tests/META-INF/MANIFEST.MF
@@ -4,11 +4,11 @@ Bundle-Name: Preferences Tests
 Bundle-Vendor: Eclipse.org - Equinox
 Bundle-Category: test
 Bundle-SymbolicName: org.eclipse.equinox.preferences.tests
-Bundle-Version: 3.10.400.qualifier
-Require-Bundle: org.junit
+Bundle-Version: 3.10.500.qualifier
+Require-Bundle: org.junit,
+ org.eclipse.core.runtime
 Import-Package: 
  org.eclipse.core.internal.preferences,
- org.eclipse.core.runtime;version="3.5.0",
  org.eclipse.core.runtime.jobs,
  org.eclipse.core.runtime.preferences;version="3.3.0",
  org.eclipse.osgi.service.datalocation;version="1.4.0",

--- a/bundles/org.eclipse.equinox.region.tests/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.region.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Equinox Region Tests
 Bundle-SymbolicName: org.eclipse.equinox.region.tests
-Bundle-Version: 1.6.200.qualifier
+Bundle-Version: 1.6.300.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Import-Package: junit.framework;version="4.8.1",
  org.aspectj.internal.lang.annotation;version="[1.6.3,2.0.0)";resolution:=optional,
@@ -11,7 +11,6 @@ Import-Package: junit.framework;version="4.8.1",
  org.aspectj.lang.reflect;version="[1.6.3,2.0.0)";resolution:=optional,
  org.aspectj.runtime.internal;version="[1.6.3,2.0.0)";resolution:=optional,
  org.aspectj.runtime.reflect;version="[1.6.3,2.0.0)";resolution:=optional,
- org.eclipse.core.runtime;version="3.7.0",
  org.eclipse.core.tests.harness,
  org.eclipse.equinox.region;version="1.1.0",
  org.eclipse.osgi.service.urlconversion;version="1.0.0",
@@ -29,6 +28,7 @@ Import-Package: junit.framework;version="4.8.1",
  org.osgi.resource;version="[1.0.0,1.1.0)",
  org.osgi.service.url,
  org.osgi.util.tracker;version="1.5.0"
+Require-Bundle: org.eclipse.core.runtime
 Bundle-ClassPath: stubs/org.eclipse.virgo.teststubs.osgi.jar,
  .
 Eclipse-BundleShape: dir


### PR DESCRIPTION
org.eclipse.core.runtime is split across
  equinox/org.eclipse.equinox.common
and
  eclipse.platform/org.eclipse.core.runtime

which can lead to dependency resolution errors.

Replace Import-Packge with Require-Bundle to make sure eclipse.platform/org.eclipse.core.runtime
is actually included.

See also https://github.com/eclipse-tycho/tycho/pull/5362 which will make this problem visible as it reduces the implicit target platform content.