### PR TITLE
[Build] Get MacOS entitlement from github-raw URL

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -245,7 +245,7 @@ pipeline {
 												# Sign MacOS launcher executable and library
 												signerUrl='https://cbi.eclipse.org/macos/codesign/sign'
 												fnSignFile eclipse_*.so "${signerUrl}"
-												curl --output 'sdk.entitlement' 'https://download.eclipse.org/eclipse/relengScripts/entitlement/sdk.entitlement'
+												curl --output 'sdk.entitlement' 'https://raw.githubusercontent.com/eclipse-platform/eclipse.platform.releng.aggregator/refs/heads/master/eclipse.platform.releng.tychoeclipsebuilder/entitlement/sdk.entitlement'
 												fnSignFile eclipse "${signerUrl}" '--form entitlements=@sdk.entitlement'
 											
 											elif [[ ${PLATFORM} == gtk.linux.* ]]; then


### PR DESCRIPTION
This avoids the need to deploy the entitlement files to the Eclipse storage server.

Required for
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3400