### PR TITLE
Add debug/loader/package/list trace option to the framework

### DIFF
--- a/bundles/org.eclipse.osgi/.options
+++ b/bundles/org.eclipse.osgi/.options
@@ -8,6 +8,8 @@ org.eclipse.osgi/debug/location = false
 org.eclipse.osgi/debug/loader=false
 # Prints out CDS class loading debug information
 org.eclipse.osgi/debug/loader/cds=false
+# Prints out class loading debug information for specified packages. Comma separated list of packages.
+org.eclipse.osgi/debug/loader/packages=
 # Prints out event (FrameworkEvent/BundleEvent/ServiceEvent) and listener debug information
 org.eclipse.osgi/debug/events=false
 # Prints out OSGi service debug information (registration/getting/ungetting etc.)

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/loader/classpath/ClasspathManager.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/loader/classpath/ClasspathManager.java
@@ -14,8 +14,6 @@
 
 package org.eclipse.osgi.internal.loader.classpath;
 
-import static org.eclipse.osgi.internal.debug.Debug.OPTION_DEBUG_LOADER;
-
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -666,10 +664,12 @@ public class ClasspathManager {
 	}
 
 	private Class<?> findClassImpl(String name, ClasspathEntry classpathEntry, List<ClassLoaderHook> hooks) {
-		if (debug.DEBUG_LOADER)
-			debug.trace(OPTION_DEBUG_LOADER,
+		String loaderTrace = debug.loaderWithClass(name);
+		if (loaderTrace != null) {
+			debug.trace(loaderTrace,
 					"ModuleClassLoader[" + classloader.getBundleLoader() + " - " + classpathEntry.getBundleFile() //$NON-NLS-1$ //$NON-NLS-2$
 					+ "].findClassImpl(" + name + ")"); //$NON-NLS-1$ //$NON-NLS-2$
+		}
 		String filename = name.replace('.', '/').concat(".class"); //$NON-NLS-1$
 
 		BundleEntry entry = classpathEntry.findEntry(filename);
@@ -680,22 +680,23 @@ public class ClasspathManager {
 		try {
 			classbytes = entry.getBytes();
 		} catch (IOException e) {
-			if (debug.DEBUG_LOADER)
-				debug.trace(OPTION_DEBUG_LOADER,
+			if (loaderTrace != null)
+				debug.trace(loaderTrace,
 						"  IOException reading " + filename + " from " + classpathEntry.getBundleFile()); //$NON-NLS-1$ //$NON-NLS-2$
 			throw (LinkageError) new LinkageError("Error reading class bytes: " + name).initCause(e); //$NON-NLS-1$
 		}
-		if (debug.DEBUG_LOADER) {
-			debug.trace(OPTION_DEBUG_LOADER,
+		if (loaderTrace != null) {
+			debug.trace(loaderTrace,
 					"  read " + classbytes.length + " bytes from " + classpathEntry.getBundleFile() + "!/" + filename); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-			debug.trace(OPTION_DEBUG_LOADER, "  defining class " + name); //$NON-NLS-1$
+			debug.trace(loaderTrace, "  defining class " + name); //$NON-NLS-1$
 		}
 
 		try {
 			return defineClass(name, classbytes, classpathEntry, entry, hooks);
 		} catch (Error e) {
-			if (debug.DEBUG_LOADER)
-				debug.trace(OPTION_DEBUG_LOADER, "  error defining class " + name); //$NON-NLS-1$
+			if (loaderTrace != null) {
+				debug.trace(loaderTrace, "  error defining class " + name); //$NON-NLS-1$
+			}
 			throw e;
 		}
 	}


### PR DESCRIPTION
The org.eclipse.osgi/debug/loader/packages trace option is String
that specifies a comma separate list of package names to trace for
class loading.

Like other framework trace options; this new trace option can be
configured with the OSGi LoggerAdmin. In order to map into LoggerAdmin's
LoggerContext the logger name includes the package name for example

The Map<String,LogLevel> logLevels set with a LoggerContext may use the
following values

org.eclipse.osgi/debug/loader/packages=DEBUG
org.eclipse.osgi/debug/loader/packages/+/pkgname1=DEBUG
org.eclipse.osgi/debug/loader/packages/+/pkgname2=DEBUG

This ends up setting into Equinox trace options a String like
org.eclipse.osgi/debug/loader/packages=packagename1,packagename2

Note that the root logger org.eclipse.osgi/debug/loader/packages
must be set to debug or trace to get the messages becuase that is
the logger name the framework uses for all packages that are traced.