### PR TITLE
Add a new thin abstraction layer over the creation of resolver instances

### DIFF
--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/container/ModuleResolver.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/container/ModuleResolver.java
@@ -42,13 +42,13 @@ import java.util.function.Function;
 import org.apache.felix.resolver.Logger;
 import org.apache.felix.resolver.PermutationType;
 import org.apache.felix.resolver.ResolutionError;
-import org.apache.felix.resolver.ResolverImpl;
 import org.eclipse.osgi.container.ModuleRequirement.DynamicModuleRequirement;
 import org.eclipse.osgi.container.namespaces.EquinoxFragmentNamespace;
 import org.eclipse.osgi.internal.container.InternalUtils;
 import org.eclipse.osgi.internal.container.NamespaceList;
 import org.eclipse.osgi.internal.framework.EquinoxConfiguration;
 import org.eclipse.osgi.internal.framework.EquinoxContainer;
+import org.eclipse.osgi.internal.framework.ResolverFactory;
 import org.eclipse.osgi.internal.messages.Msg;
 import org.eclipse.osgi.report.resolution.ResolutionReport;
 import org.eclipse.osgi.report.resolution.ResolutionReport.Entry;
@@ -1204,7 +1204,8 @@ final class ModuleResolver {
 			Map<Resource, List<Wire>> interimResults = null;
 			try {
 				transitivelyResolveFailures.addAll(revisions);
-				interimResults = new ResolverImpl(logger, this).resolve(this);
+				Resolver resolver = ResolverFactory.createFrameworkResolver(adaptor, logger, this);
+				interimResults = resolver.resolve(this);
 				applyInterimResultToWiringCopy(interimResults);
 				if (DEBUG_ROOTS) {
 					adaptor.trace(OPTION_ROOTS, "Resolver: resolved " + interimResults.size() + " bundles."); //$NON-NLS-1$ //$NON-NLS-2$
@@ -1502,7 +1503,8 @@ final class ModuleResolver {
 		}
 
 		private Map<Resource, List<Wire>> resolveDynamic() throws ResolutionException {
-			return new ResolverImpl(new Logger(0), null).resolveDynamic(this, wirings.get(dynamicReq.getResource()),
+			Resolver resolver = ResolverFactory.createDynamicResolver(adaptor);
+			return resolver.resolveDynamic(this, wirings.get(dynamicReq.getResource()),
 					dynamicReq.getOriginal());
 		}
 

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/framework/ResolverFactory.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/framework/ResolverFactory.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Christoph Läubrich and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.osgi.internal.framework;
+
+import java.util.concurrent.Executor;
+import org.apache.felix.resolver.Logger;
+import org.apache.felix.resolver.ResolverImpl;
+import org.eclipse.osgi.container.ModuleContainerAdaptor;
+import org.osgi.service.resolver.Resolver;
+
+/**
+ * The {@link ResolverFactory} abstract the creation of resolver instance, this
+ * allows to exchange or further customize the instance based on e.g. the caller
+ * or context.
+ */
+public class ResolverFactory {
+
+	/**
+	 * Creates a resolver instance that is used to be registered in the OSGi service
+	 * factory, this method is usually only called once in the life-time of a
+	 * framework.
+	 * 
+	 * @param container the container this instance is created for to maybe further
+	 *                  customize the instance
+	 * @return a new resolver instance
+	 */
+	static Resolver createResolverService(EquinoxContainer container) {
+		return new ResolverImpl(new Logger(0), null);
+	}
+
+	/**
+	 * Creates a resolver instance that is used in the Equinox framework directly,
+	 * this method is called whenever a resolve of bundles is performed
+	 * 
+	 * @param container the container this instance is created for to maybe further
+	 *                  customize the instance
+	 * @param logger    a logger to emit log messages
+	 * @param executor  an executor to use to perform session related tasks
+	 * @return a new resolver instance
+	 */
+	public static Resolver createFrameworkResolver(ModuleContainerAdaptor container, Logger logger, Executor executor) {
+		return new ResolverImpl(logger, executor);
+	}
+
+	/**
+	 * Creates a resolver instance for dynamic requirement resolving, this method is
+	 * called whenever a new dynmic requirement resolve operation is needed
+	 * 
+	 * @param container the container this instance is created for to maybe further
+	 *                  customize the instance
+	 * @return a new resolver instance
+	 */
+	public static Resolver createDynamicResolver(ModuleContainerAdaptor container) {
+		return new ResolverImpl(new Logger(0), null);
+	}
+
+}

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/framework/SystemBundleActivator.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/framework/SystemBundleActivator.java
@@ -21,8 +21,6 @@ import java.util.ArrayList;
 import java.util.Dictionary;
 import java.util.Hashtable;
 import java.util.List;
-import org.apache.felix.resolver.Logger;
-import org.apache.felix.resolver.ResolverImpl;
 import org.eclipse.equinox.plurl.Plurl;
 import org.eclipse.equinox.plurl.PlurlContentHandlerFactory;
 import org.eclipse.equinox.plurl.PlurlStreamHandlerFactory;
@@ -121,7 +119,8 @@ public class SystemBundleActivator implements BundleActivator {
 
 		props.clear();
 		props.put(Constants.SERVICE_RANKING, Integer.MIN_VALUE);
-		register(bc, Resolver.class, new ResolverImpl(new Logger(0), null), false, props);
+		Resolver resolver = ResolverFactory.createResolverService(equinoxContainer);
+		register(bc, Resolver.class, resolver, false, props);
 
 		register(bc, DebugOptions.class, dbgOptions, null);
 


### PR DESCRIPTION
Currently Equinox directly reference the implementation of the (felix) resolver even though it never uses any specific API (except the logger), this makes it currently hard to allow other implementations especially as the is an unfortunate relation between the startup of launches and tests, so if another  implementation is used and might be buggy the framework possibly not start up and tests can not be executed or debugged.

This now adds a thin abstraction layer over the creation of resolver instances that basically distinguish the three cases we have where an instance is created allowing to later e.g. return dynamically based on the context (e.g. testrun) a different resolver instance.

### Background

Of the past months I struggled with analyze and optimize the current resolver implementation that works fast most of the time but in some cases can badly fail, see for example:

- https://github.com/eclipse-equinox/equinox/pull/1148
- https://github.com/eclipse-equinox/equinox/pull/1125
- https://github.com/eclipse-equinox/equinox/pull/469

I made several attempts already (and many failed) to improve this and sometimes it is possible to improve for a certain case but often it reveals then other corner cases and I identified some blockers that hinder making progress:

1. There is a high inherited risk to break everything, doing it "wrong" not only break tests it sometimes prevents the whole SDK and test launches from startup, this makes it hard to develop and hard to merge incremental improvements
2. Due to the Felix Impl is (intentionally) a separated place some useful methods in Equinox can only be indirectly called.
3. Some of the problems seem inherit by the used datastructure but major refactorings are hard to accomplish
4. Some limitations are imposed by the OSGi specification that do not matter for internal use cases.

To mitigate I would like to get this abstraction in place what will allow:

- Let dynamically exchange the resolver at runtime, so it is possible to run tests multiple times with different resolver implementations
- We can create different resolver instances per usecase (and maybe even optimized for a certain use-case!), e.g. think about a resolver that is not capable of resolve dynamic or violates some contracts of what the Resolver service imposes
- It would be possible to ship with a "classic" and a "new" resolver implementation so there is less of a risk for releases as users can choose or use a fallback.
