### PR TITLE
Mark deprecated constants in Equinox for removal

### DIFF
--- a/bundles/org.eclipse.equinox.http.jetty/src/org/eclipse/equinox/http/jetty/JettyConstants.java
+++ b/bundles/org.eclipse.equinox.http.jetty/src/org/eclipse/equinox/http/jetty/JettyConstants.java
@@ -81,28 +81,28 @@ public interface JettyConstants {
 	 * @deprecated
 	 * @since 1.3
 	 */
-	@Deprecated
+	@Deprecated(forRemoval = true, since = "2026-03")
 	public static final String MULTIPART_FILESIZETHRESHOLD = "multipart.fileSizeThreshold"; //$NON-NLS-1$
 
 	/**
 	 * @deprecated
 	 * @since 1.3
 	 */
-	@Deprecated
+	@Deprecated(forRemoval = true, since = "2026-03")
 	public static final String MULTIPART_LOCATION = "multipart.location"; //$NON-NLS-1$
 
 	/**
 	 * @deprecated
 	 * @since 1.3
 	 */
-	@Deprecated
+	@Deprecated(forRemoval = true, since = "2026-03")
 	public static final String MULTIPART_MAXFILESIZE = "multipart.maxFileSize"; //$NON-NLS-1$
 
 	/**
 	 * @deprecated
 	 * @since 1.3
 	 */
-	@Deprecated
+	@Deprecated(forRemoval = true, since = "2026-03")
 	public static final String MULTIPART_MAXREQUESTSIZE = "multipart.maxRequestSize"; //$NON-NLS-1$
 
 	/**

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/service/resolver/BundleDelta.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/service/resolver/BundleDelta.java
@@ -71,6 +71,7 @@ public interface BundleDelta extends Comparable<BundleDelta> {
 	 * @see BundleDelta#getType
 	 * @deprecated this type is no longer valid
 	 */
+	@Deprecated(forRemoval = true, since = "2026-03")
 	public static final int LINKAGE_CHANGED = 0x20;
 
 	/**
@@ -80,6 +81,7 @@ public interface BundleDelta extends Comparable<BundleDelta> {
 	 * @see BundleDelta#getType
 	 * @deprecated this type is no longer valid
 	 */
+	@Deprecated(forRemoval = true, since = "2026-03")
 	public static final int OPTIONAL_LINKAGE_CHANGED = 0x40;
 
 	/**

--- a/bundles/org.eclipse.osgi/osgi/src/org/osgi/framework/Constants.java
+++ b/bundles/org.eclipse.osgi/osgi/src/org/osgi/framework/Constants.java
@@ -130,6 +130,7 @@ public interface Constants {
 	 * 
 	 * @deprecated As of 1.2.
 	 */
+	@Deprecated(forRemoval = true, since = "2026-03")
 	String	EXPORT_SERVICE							= "Export-Service";
 
 	/**
@@ -163,6 +164,7 @@ public interface Constants {
 	 * 
 	 * @deprecated As of 1.2.
 	 */
+	@Deprecated(forRemoval = true, since = "2026-03")
 	String	IMPORT_SERVICE							= "Import-Service";
 
 	/**
@@ -849,6 +851,7 @@ public interface Constants {
 	 * @since 1.3
 	 * @deprecated As of 1.9.
 	 */
+	@Deprecated(forRemoval = true, since = "2026-03")
 	String	EXTENSION_BOOTCLASSPATH					= "bootclasspath";
 
 	/**
@@ -1036,6 +1039,7 @@ public interface Constants {
 	 * @since 1.3
 	 * @deprecated As of 1.10.
 	 */
+	@Deprecated(forRemoval = true, since = "2026-03")
 	String	SUPPORTS_BOOTCLASSPATH_EXTENSION		= "org.osgi.supports.bootclasspath.extension";
 
 	/**

--- a/bundles/org.eclipse.osgi/osgi/src/org/osgi/framework/PackagePermission.java
+++ b/bundles/org.eclipse.osgi/osgi/src/org/osgi/framework/PackagePermission.java
@@ -66,6 +66,7 @@ public final class PackagePermission extends BasicPermission {
 	 * 
 	 * @deprecated As of 1.5. Use {@code exportonly} instead.
 	 */
+	@Deprecated(forRemoval = true, since = "2026-03")
 	public final static String						EXPORT				= "export";
 
 	/**


### PR DESCRIPTION
Mark deprecated constants in the Equinox repo to indicate planned removal in the future release.