### PR TITLE
Fix missing version increments

### DIFF
--- a/bundles/org.eclipse.equinox.transforms.hook/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.transforms.hook/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.equinox.transforms.hook
-Bundle-Version: 1.4.500.qualifier
+Bundle-Version: 1.4.400.qualifier
 Fragment-Host: org.eclipse.osgi;bundle-version="[3.10.0,4.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Localization: transformsHook


### PR DESCRIPTION
It seems adding the readme files has trigger some kind of version increments needed, this PR is to check for this and we should likely filter out readme at all...