### PR TITLE
[Build] Set test timeout of 25min for o.e.osgi.tests

### DIFF
--- a/bundles/org.eclipse.osgi.tests/pom.xml
+++ b/bundles/org.eclipse.osgi.tests/pom.xml
@@ -27,6 +27,7 @@
     <testSuite>${project.artifactId}</testSuite>
     <testClass>org.eclipse.osgi.tests.AutomatedTests</testClass>
     <skipAPIAnalysis>true</skipAPIAnalysis>
+    <surefire.timeout>1500</surefire.timeout><!-- timeout in seconds -->
   </properties>
 
   <build>
@@ -34,7 +35,6 @@
       <plugin>
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>target-platform-configuration</artifactId>
-        <version>${tycho.version}</version>
         <configuration>
           <dependency-resolution>
             <extraRequirements>


### PR DESCRIPTION
This extends the general timeout, which could be too strict in this case and is introduced via
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3427