### PR TITLE
Temporarily restore EquinoxBundle#getModuleClassLoader(boolean)

### DIFF
--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/framework/EquinoxBundle.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/framework/EquinoxBundle.java
@@ -695,6 +695,17 @@ public class EquinoxBundle implements Bundle, BundleReference {
 		return new ResolvedModuleClassLoader(cl, report);
 	}
 
+	// This method is only preserved as a temporary workaround for consumers that
+	// reflectively access it until they are adapted, such as Jetty OSGi's
+	// DefaultBundleClassLoaderHelper
+	// (see https://github.com/jetty/jetty.project/pull/14086)
+	@Deprecated
+	protected ModuleClassLoader getModuleClassLoader(boolean unused) {
+		System.err.println(
+				"WARNING: Reflective call to EquinoxBundle#getModuleClassLoader(boolean) detected. This method will be removed soon."); //$NON-NLS-1$
+		return getModuleClassLoader().moduleClassLoader;
+	}
+
 	@Override
 	public Enumeration<URL> getResources(String name) throws IOException {
 		try {


### PR DESCRIPTION
The private method `EquinoxBundle#getModuleClassLoader(boolean)` was recently (https://github.com/eclipse-equinox/equinox/pull/1157) replaced by a method with a different signature. Some relevant consumers (at least Jetty OSGi's [DefaultBundleClassLoaderHelper](https://github.com/jetty/jetty.project/blob/c0c432b079d6d506d1e598a4d1a6cc7a3a381af4/jetty-core/jetty-osgi/src/main/java/org/eclipse/jetty/osgi/util/DefaultBundleClassLoaderHelper.java#L233-L241)) reflectively access the replaced method. To avoid that compatibility of such consumers breaks, this change temporarily reintroduces the replaced method. It prints an according warning about the upcoming removal to stderr. It is supposed to be removed once the known consumers are adapted.

This proposal is based on the discussion on the PR that changed the method start with this comment: https://github.com/eclipse-equinox/equinox/pull/1157#issuecomment-3574481401

I have already tested the change with one of our Jetty products. It (1) solves the issue of failing to properly start the Jetty product and (2) prints the error message as expected because of the readded method being called.

@laeubi I am happy to adapt this in any desired way. I chose to use `System.err` instead of `System.out` to make it a bit better visible within all the output you get especially when running a Jetty product. I will also raise an issue in the Jetty project today.