### PR TITLE
Remove autoscale upper limit to match SWT DPIUtil

### DIFF
--- a/features/org.eclipse.equinox.executable.feature/library/win32/eclipseWin.c
+++ b/features/org.eclipse.equinox.executable.feature/library/win32/eclipseWin.c
@@ -326,9 +326,6 @@ int showSplash( const _TCHAR* featureImage )
 		case AUTOSCALE_DEFAULT:
 		case AUTOSCALE_INTEGER:
 			dpiX = ((int)((dpiX + 24) / 96 )) * 96;
-			if (autoScaleValue == AUTOSCALE_DEFAULT) {
-				if (dpiX > 192) dpiX = 192;
-			}
 			break;
 		default:
 			dpiX = (96 * autoScaleValue + 50) / 100;


### PR DESCRIPTION
The `showSplash` method was adapted in 3ba28b7d220540aa3e73c37aaf43a9dfee38e1fd to bring the scaling logic back in sync with` org.eclipse.swt.internal.DPIUtil`. During this change, the upper limit for the autoscale value (200) was taken directly from `SWT `and added in `showSplash`. However, following  https://github.com/eclipse-platform/eclipse.platform.swt/pull/111, the `SWT.autoscale` upper limit was removed.

This change removes the upper limit here as well, ensuring the scaling logic remains consistent and the splash screen renders correctly across different DPI settings.

This Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/2792 


### Steps to reproduce the fix:

1)Clone the repo and run /org.eclipse.equinox.executable.feature/library/win32/build.bat to generate **eclipse_11916.dll**. 
2)Download a eclipse ibuild and extract its contents to **<ECLIPSE_INSTALL_DIR>**
3)Then, copy the DLL file in step 1 to **<ECLIPSE_INSTALL_DIR>/plugins/<EQUINOX_LAUNCHER_FOLDER>**.

Start the IDE in ibuild at 300% zoom. Without this change, the issue mentioned in  https://github.com/eclipse-platform/eclipse.platform.swt/issues/2792   would appear. 

before 

https://github.com/user-attachments/assets/61ca02e6-a992-4e7a-8962-ffbfa6da6841

with the change


https://github.com/user-attachments/assets/bd850eda-9b0d-47df-ad37-9cd750d30948



