### PR TITLE
[Build] Adapt to move of macOS entitlement in platform.releng.aggregator

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -245,7 +245,7 @@ pipeline {
 												# Sign MacOS launcher executable and library
 												signerUrl='https://cbi.eclipse.org/macos/codesign/sign'
 												fnSignFile eclipse_*.so "${signerUrl}"
-												curl --output 'sdk.entitlement' 'https://raw.githubusercontent.com/eclipse-platform/eclipse.platform.releng.aggregator/refs/heads/master/eclipse.platform.releng.tychoeclipsebuilder/entitlement/sdk.entitlement'
+												curl --output 'sdk.entitlement' --fail 'https://raw.githubusercontent.com/eclipse-platform/eclipse.platform.releng.aggregator/refs/heads/master/products/eclipse.entitlement'
 												fnSignFile eclipse "${signerUrl}" '--form entitlements=@sdk.entitlement'
 											
 											elif [[ ${PLATFORM} == gtk.linux.* ]]; then


### PR DESCRIPTION
Consequence of
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3480

This shouldn't be submitted before the linked PR is.