### PR TITLE
Fix warnings from PluginVersionIdentifierTest

### DIFF
--- a/bundles/org.eclipse.equinox.common.tests/src/org/eclipse/equinox/common/tests/PluginVersionIdentifierTest.java
+++ b/bundles/org.eclipse.equinox.common.tests/src/org/eclipse/equinox/common/tests/PluginVersionIdentifierTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -14,34 +14,35 @@
 package org.eclipse.equinox.common.tests;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import org.eclipse.core.runtime.PluginVersionIdentifier;
 import org.junit.Test;
 
 @Deprecated
+@SuppressWarnings("removal")
 public class PluginVersionIdentifierTest {
 
 	@Deprecated
 	@Test
 	public void testConstructor() {
 
-		assertEquals("1.0", "123.456.789", new PluginVersionIdentifier(123, 456, 789).toString());
-		assertEquals("1.1", "123.456.789", new PluginVersionIdentifier("123.456.789").toString());
-		assertEquals("1.2", "123.456.0", new PluginVersionIdentifier("123.456").toString());
+		assertEquals("123.456.789", new PluginVersionIdentifier(123, 456, 789).toString());
+		assertEquals("123.456.789", new PluginVersionIdentifier("123.456.789").toString());
+		assertEquals("123.456.0", new PluginVersionIdentifier("123.456").toString());
 
-		assertTrue("2.0", "0.123.456" != new PluginVersionIdentifier("123.456").toString());
+		assertNotEquals("0.123.456", new PluginVersionIdentifier("123.456").toString());
 
-		try {
-			new PluginVersionIdentifier("-1.123.456");
-		} catch (Exception e) {
-			assertTrue("3.0", true);
-		}
+		assertThrows(Exception.class,()->
+			new PluginVersionIdentifier("-1.123.456"));
 
 		PluginVersionIdentifier plugin = new PluginVersionIdentifier("1.123.456");
-		assertTrue("4.0", plugin.getMajorComponent() == 1);
-		assertTrue("4.1", plugin.getMinorComponent() == 123);
-		assertTrue("4.2", plugin.getServiceComponent() == 456);
+		assertEquals(1, plugin.getMajorComponent());
+		assertEquals(123, plugin.getMinorComponent());
+		assertEquals(456, plugin.getServiceComponent());
 
 	}
 
@@ -50,9 +51,8 @@ public class PluginVersionIdentifierTest {
 	@Test
 	public void testEqual() {
 
-		assertTrue("1.0",
-				new PluginVersionIdentifier(123, 456, 789).equals(new PluginVersionIdentifier("123.456.789")));
-		assertTrue("1.1", !new PluginVersionIdentifier(123, 456, 789).equals(new PluginVersionIdentifier("123.456")));
+		assertTrue(new PluginVersionIdentifier(123, 456, 789).equals(new PluginVersionIdentifier("123.456.789")));
+		assertFalse(new PluginVersionIdentifier(123, 456, 789).equals(new PluginVersionIdentifier("123.456")));
 
 	}
 
@@ -65,16 +65,16 @@ public class PluginVersionIdentifierTest {
 		PluginVersionIdentifier plugin3 = new PluginVersionIdentifier("2.123.456");
 		PluginVersionIdentifier plugin4 = new PluginVersionIdentifier("2.123.222");
 
-		assertTrue("1.0", plugin1.isGreaterThan(plugin2));
-		assertTrue("1.1", plugin3.isGreaterThan(plugin2));
-		assertTrue("1.2", !plugin1.isGreaterThan(plugin4));
+		assertTrue(plugin1.isGreaterThan(plugin2));
+		assertTrue(plugin3.isGreaterThan(plugin2));
+		assertFalse(plugin1.isGreaterThan(plugin4));
 
-		assertTrue("2.0", plugin3.isEquivalentTo(plugin4));
-		assertTrue("2.1", !plugin1.isEquivalentTo(plugin2));
-		assertTrue("2.2", !plugin1.isEquivalentTo(plugin3));
+		assertTrue(plugin3.isEquivalentTo(plugin4));
+		assertFalse(plugin1.isEquivalentTo(plugin2));
+		assertFalse(plugin1.isEquivalentTo(plugin3));
 
-		assertTrue("3.0", plugin1.isCompatibleWith(plugin2));
-		assertTrue("3.1", !plugin1.isCompatibleWith(plugin3));
+		assertTrue(plugin1.isCompatibleWith(plugin2));
+		assertFalse(plugin1.isCompatibleWith(plugin3));
 
 	}
 
@@ -82,24 +82,24 @@ public class PluginVersionIdentifierTest {
 	@Test
 	public void testValidate() {
 		// success cases
-		assertTrue("1.0", PluginVersionIdentifier.validateVersion("1").isOK());
-		assertTrue("1.1", PluginVersionIdentifier.validateVersion("1.0").isOK());
-		assertTrue("1.2", PluginVersionIdentifier.validateVersion("1.0.2").isOK());
-		assertTrue("1.3", PluginVersionIdentifier.validateVersion("1.0.2.3456").isOK());
-		assertTrue("1.3", PluginVersionIdentifier.validateVersion("1.2.3.-4").isOK());
+		assertTrue(PluginVersionIdentifier.validateVersion("1").isOK());
+		assertTrue(PluginVersionIdentifier.validateVersion("1.0").isOK());
+		assertTrue(PluginVersionIdentifier.validateVersion("1.0.2").isOK());
+		assertTrue(PluginVersionIdentifier.validateVersion("1.0.2.3456").isOK());
+		assertTrue(PluginVersionIdentifier.validateVersion("1.2.3.-4").isOK());
 
 		// failure cases
-		assertTrue("2.0", !PluginVersionIdentifier.validateVersion("").isOK());
-		assertTrue("2.1", !PluginVersionIdentifier.validateVersion("-1").isOK());
-		assertTrue("2.2", !PluginVersionIdentifier.validateVersion(null).isOK());
-		assertTrue("2.3", !PluginVersionIdentifier.validateVersion("/").isOK());
-		assertTrue("2.4", !PluginVersionIdentifier.validateVersion("1.foo.2").isOK());
-		assertTrue("2.5", !PluginVersionIdentifier.validateVersion("1./.3").isOK());
-		assertTrue("2.6", !PluginVersionIdentifier.validateVersion(".").isOK());
-		assertTrue("2.7", !PluginVersionIdentifier.validateVersion(".1").isOK());
-		assertTrue("2.8", !PluginVersionIdentifier.validateVersion("1.2.").isOK());
-		assertTrue("2.9", !PluginVersionIdentifier.validateVersion("1.2.3.4.5").isOK());
-		assertTrue("2.10", !PluginVersionIdentifier.validateVersion("1.-2").isOK());
-		assertTrue("2.11", !PluginVersionIdentifier.validateVersion("1.2.-3").isOK());
+		assertFalse(PluginVersionIdentifier.validateVersion("").isOK());
+		assertFalse(PluginVersionIdentifier.validateVersion("-1").isOK());
+		assertFalse(PluginVersionIdentifier.validateVersion(null).isOK());
+		assertFalse(PluginVersionIdentifier.validateVersion("/").isOK());
+		assertFalse(PluginVersionIdentifier.validateVersion("1.foo.2").isOK());
+		assertFalse(PluginVersionIdentifier.validateVersion("1./.3").isOK());
+		assertFalse(PluginVersionIdentifier.validateVersion(".").isOK());
+		assertFalse(PluginVersionIdentifier.validateVersion(".1").isOK());
+		assertFalse(PluginVersionIdentifier.validateVersion("1.2.").isOK());
+		assertFalse(PluginVersionIdentifier.validateVersion("1.2.3.4.5").isOK());
+		assertFalse(PluginVersionIdentifier.validateVersion("1.-2").isOK());
+		assertFalse(PluginVersionIdentifier.validateVersion("1.2.-3").isOK());
 	}
 }


### PR DESCRIPTION
This one generates a lot of noise in the workspace. Silence deprecation warnings, simplify asserts, use assertThrows, drop useless messages,etc.