### PR TITLE
Migrate security tests to JUnit 5

### DIFF
--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/bundles/SystemBundleTests.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/bundles/SystemBundleTests.java
@@ -91,7 +91,7 @@ import org.eclipse.osgi.service.environment.EnvironmentInfo;
 import org.eclipse.osgi.service.urlconversion.URLConverter;
 import org.eclipse.osgi.storage.url.reference.Handler;
 import org.eclipse.osgi.tests.OSGiTestsActivator;
-import org.eclipse.osgi.tests.security.BaseSecurityTest;
+import org.eclipse.osgi.tests.security.SecurityTestUtil;
 import org.eclipse.osgi.tests.securityadmin.SecurityManagerTests;
 import org.junit.Assert;
 import org.junit.Assume;
@@ -2479,7 +2479,7 @@ public class SystemBundleTests extends AbstractBundleTests {
 			return;
 		}
 		File testDestination = OSGiTestsActivator.getContext().getDataFile(getName() + ".framework.jar");
-		BaseSecurityTest.copy(new FileInputStream(f), testDestination);
+		SecurityTestUtil.copy(new FileInputStream(f), testDestination);
 		FilePath userDir = new FilePath(System.getProperty("user.dir"));
 		FilePath testPath = new FilePath(testDestination);
 		String relative = userDir.makeRelative(testPath);

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/security/BundleToJarInputStreamTest.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/security/BundleToJarInputStreamTest.java
@@ -14,13 +14,13 @@
 
 package org.eclipse.osgi.tests.security;
 
-import static org.eclipse.osgi.tests.security.BaseSecurityTest.copy;
-import static org.eclipse.osgi.tests.security.BaseSecurityTest.getEntryFile;
-import static org.eclipse.osgi.tests.security.BaseSecurityTest.getTestJarPath;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.eclipse.osgi.tests.security.SecurityTestUtil.copy;
+import static org.eclipse.osgi.tests.security.SecurityTestUtil.getEntryFile;
+import static org.eclipse.osgi.tests.security.SecurityTestUtil.getTestJarPath;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -41,7 +41,7 @@ import java.util.zip.ZipInputStream;
 import org.eclipse.osgi.internal.signedcontent.BundleToJarInputStream;
 import org.eclipse.osgi.storage.bundlefile.DirBundleFile;
 import org.eclipse.osgi.tests.OSGiTestsActivator;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.osgi.framework.BundleContext;
 
 public class BundleToJarInputStreamTest {
@@ -109,8 +109,8 @@ public class BundleToJarInputStreamTest {
 						byte[] extractedBytes = getBytes(jarInput);
 						byte[] originalBytes = getBytes(
 								jarFile.getInputStream(jarFile.getEntry(extractedEntry.getName())));
-						assertArrayEquals("Wrong entry content: " + extractedEntry.getName(), originalBytes,
-								extractedBytes);
+						assertArrayEquals(originalBytes, extractedBytes,
+								"Wrong entry content: " + extractedEntry.getName());
 						validated.add(extractedEntry.getName());
 					}
 				}
@@ -121,12 +121,12 @@ public class BundleToJarInputStreamTest {
 			if (first.toUpperCase().endsWith("META-INF/")) {
 				first = validpaths.next();
 			}
-			assertEquals("Expected manifest.", JarFile.MANIFEST_NAME, first.toUpperCase());
+			assertEquals(JarFile.MANIFEST_NAME, first.toUpperCase(), "Expected manifest.");
 			// If there are signature files, make sure they are before all other entries
 			AtomicReference<String> foundNonSignatureFile = new AtomicReference<>();
 			validpaths.forEachRemaining(s -> {
 				if (isSignatureFile(s)) {
-					assertNull("Found non signature file before.", foundNonSignatureFile.get());
+					assertNull(foundNonSignatureFile.get(), "Found non signature file before.");
 				} else {
 					foundNonSignatureFile.compareAndSet(null, s);
 				}
@@ -137,7 +137,7 @@ public class BundleToJarInputStreamTest {
 				ZipEntry originalEntry = originalEntries.nextElement();
 				validated.remove(originalEntry.getName());
 			}
-			assertTrue("More paths extracted content: " + validated, validated.isEmpty());
+			assertTrue(validated.isEmpty(), "More paths extracted content: " + validated);
 		}
 	}
 

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/security/SecurityTestSuite.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/security/SecurityTestSuite.java
@@ -13,11 +13,11 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.security;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({ //
+@Suite
+@SelectClasses({ //
 		BundleToJarInputStreamTest.class, //
 		KeyStoreTrustEngineTest.class, //
 		SignedBundleTest.class, //


### PR DESCRIPTION
The test class `SignedBundleTest` relies on the JUnit-3-specific ConfigurationSessionTest. The SessionTestExtension has been introduced as a JUnit-5-based replacement. This change adapts the test class to be executed with JUnit 5, using the SessionTestExtension. It also adapts other test classes in that package to JUnit 5, removing the existing inheritance hierarchy via BaseSecurityTest, as well as the according test suite.

This is a follow up to:
- https://github.com/eclipse-equinox/equinox/pull/1223

Which accidentally contained an incomplete migration of `SignedBundleTest`.