### PR TITLE
Migrate EclipseStarterConfigIniTest to JUnit 5

### DIFF
--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/configuration/EclipseStarterConfigIniTest.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/configuration/EclipseStarterConfigIniTest.java
@@ -22,54 +22,61 @@ import java.io.ByteArrayOutputStream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 import junit.framework.AssertionFailedError;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
-import org.eclipse.core.tests.session.ConfigurationSessionTestSuite;
+import org.eclipse.core.tests.harness.session.CustomSessionConfiguration;
+import org.eclipse.core.tests.harness.session.ExecuteInHost;
+import org.eclipse.core.tests.harness.session.SessionTestExtension;
 import org.eclipse.osgi.tests.OSGiTestsActivator;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 
-public class EclipseStarterConfigIniTest extends TestCase {
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class EclipseStarterConfigIniTest {
 
-	public static Test suite() {
-		TestSuite suite = new TestSuite(EclipseStarterConfigIniTest.class.getName());
+	private static CustomSessionConfiguration sessionConfiguration = createSessionConfiguration();
 
-		ConfigurationSessionTestSuite falseCompatBootDelegation = new ConfigurationSessionTestSuite(PI_OSGI_TESTS,
-				EclipseStarterConfigIniTest.class.getName());
-		addRequiredOSGiTestsBundles(falseCompatBootDelegation);
-		falseCompatBootDelegation.addTest(new EclipseStarterConfigIniTest("testFalseCompatBootDelegation"));
-		falseCompatBootDelegation.setConfigIniValue("osgi.compatibility.bootdelegation", "false");
-		suite.addTest(falseCompatBootDelegation);
+	@RegisterExtension
+	static SessionTestExtension extension = SessionTestExtension.forPlugin(PI_OSGI_TESTS)
+			.withCustomization(sessionConfiguration).create();
 
-		ConfigurationSessionTestSuite defaultCompatBootDelegation = new ConfigurationSessionTestSuite(PI_OSGI_TESTS,
-				EclipseStarterConfigIniTest.class.getName());
-		addRequiredOSGiTestsBundles(defaultCompatBootDelegation);
-		defaultCompatBootDelegation.addTest(new EclipseStarterConfigIniTest("testDefaultCompatBootDelegation"));
-		suite.addTest(defaultCompatBootDelegation);
-		return suite;
+	private static CustomSessionConfiguration createSessionConfiguration() {
+		CustomSessionConfiguration configuration = SessionTestExtension.createCustomConfiguration().setCascaded();
+		configuration.setConfigIniValue("osgi.compatibility.bootdelegation", "false");
+		addRequiredOSGiTestsBundles(configuration);
+		return configuration;
 	}
 
-	public EclipseStarterConfigIniTest(String name) {
-		super(name);
-	}
-
+	@Test
+	@Order(1)
 	public void testFalseCompatBootDelegation() throws Exception {
-		doTestCompatBootDelegation(true);
+		doTestCompatBootDelegation("compat.false", true);
 	}
 
+	@Test
+	@Order(2)
+	@ExecuteInHost
+	public void setDefaultCompatBootDelegation() {
+		sessionConfiguration.setConfigIniValue("osgi.compatibility.bootdelegation", null);
+	}
+
+	@Test
+	@Order(3)
 	public void testDefaultCompatBootDelegation() throws Exception {
-		doTestCompatBootDelegation(false);
+		doTestCompatBootDelegation("compat.default", false);
 	}
 
-	public void doTestCompatBootDelegation(boolean expectFailure) throws Exception {
+	public void doTestCompatBootDelegation(String bundleName, boolean expectFailure) throws Exception {
 		BundleContext context = OSGiTestsActivator.getContext();
 		ByteArrayOutputStream bytesOut = new ByteArrayOutputStream();
 		ZipOutputStream zipOut = new ZipOutputStream(bytesOut);
 		zipOut.putNextEntry(new ZipEntry("nothing"));
 		zipOut.closeEntry();
 		zipOut.close();
-		Bundle b = context.installBundle(getName(), new ByteArrayInputStream(bytesOut.toByteArray()));
+		Bundle b = context.installBundle(bundleName, new ByteArrayInputStream(bytesOut.toByteArray()));
 		String testClassName = javax.net.SocketFactory.class.getName();
 		// The bundle does not import anything so should not find javax stuff
 		if (expectFailure) {


### PR DESCRIPTION
This migrates the test case `EclipseStarterConfigIniTest`to use the JUnit 5 SessionTestExtension instead of the existing JUnit-3-based ConfigurationSessionTestSuite.

Requires:
- https://github.com/eclipse-platform/eclipse.platform/pull/2309