### PR TITLE
Migrate LocationAreaSessionTest to JUnit 5

### DIFF
--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/services/datalocation/AllTests.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/services/datalocation/AllTests.java
@@ -13,11 +13,11 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.services.datalocation;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({ //
+@Suite
+@SelectClasses({ //
 		LocationAreaSessionTest.class, //
 		BasicLocationTests.class, //
 		SimpleTests.class, //


### PR DESCRIPTION
This migrates the test case `LocationAreaSessionTest` to use the JUnit 5 SessionTestExtension instead of the existing JUnit-3-based ConfigurationSessionTestSuite.

Requires:
- https://github.com/eclipse-platform/eclipse.platform/pull/2313