### PR TITLE
Migrate test suites in org.eclipse.osgi.tests to JUnit 5

### DIFF
--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/equinox/log/test/AllExtendedLogServiceTests.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/equinox/log/test/AllExtendedLogServiceTests.java
@@ -10,11 +10,11 @@
  ******************************************************************************/
 package org.eclipse.equinox.log.test;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({ //
+@Suite
+@SelectClasses({ //
 		ExtendedLogServiceTest.class, //
 		ExtendedLogReaderServiceTest.class //
 })

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/equinox/log/test/AllLogServiceTests.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/equinox/log/test/AllLogServiceTests.java
@@ -10,11 +10,11 @@
  ******************************************************************************/
 package org.eclipse.equinox.log.test;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({ //
+@Suite
+@SelectClasses({ //
 		LogServiceTest.class, //
 		LogReaderServiceTest.class, //
 		LogPermissionCollectionTest.class //

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/equinox/log/test/AllTests.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/equinox/log/test/AllTests.java
@@ -13,11 +13,11 @@
  *******************************************************************************/
 package org.eclipse.equinox.log.test;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({ //
+@Suite
+@SelectClasses({ //
 		AllLogServiceTests.class, //
 		AllExtendedLogServiceTests.class, //
 		LogEquinoxTraceTest.class, //

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/bundles/BundleTests.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/bundles/BundleTests.java
@@ -13,11 +13,11 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.bundles;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({ //
+@Suite
+@SelectClasses({ //
 		ConnectTests.class, //
 		ExceptionMessageTest.class, //
 		ImportJavaSEPackagesTests.class, //

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/container/AllTests.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/container/AllTests.java
@@ -13,11 +13,11 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.container;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({ //
+@Suite
+@SelectClasses({ //
 		TestModuleContainer.class, //
 		ResolutionReportTest.class, //
 		ModuleContainerUsageTest.class, //

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/eclipseadaptor/AllTests.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/eclipseadaptor/AllTests.java
@@ -13,11 +13,11 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.eclipseadaptor;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({ //
+@Suite
+@SelectClasses({ //
 		EnvironmentInfoTest.class, //
 		FilePathTest.class, //
 		LocaleTransformationTest.class //

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/hooks/framework/AllFrameworkHookTests.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/hooks/framework/AllFrameworkHookTests.java
@@ -13,11 +13,11 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.hooks.framework;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({ //
+@Suite
+@SelectClasses({ //
 		StorageHookTests.class, //
 		ClassLoaderHookTests.class, //
 		BundleFileWrapperFactoryHookTests.class, //

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/perf/AllTests.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/perf/AllTests.java
@@ -13,11 +13,11 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.perf;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({ //
+@Suite
+@SelectClasses({ //
 		StatePerformanceTest.class, //
 		StateUsesPerformanceTest.class //
 })

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/permissions/AllTests.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/permissions/AllTests.java
@@ -13,11 +13,11 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.permissions;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({ //
+@Suite
+@SelectClasses({ //
 		AdminPermissionTests.class, //
 		ServicePermissionTests.class, //
 		PackagePermissionTests.class //

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resource/AllTests.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/resource/AllTests.java
@@ -13,11 +13,11 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.resource;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({ //
+@Suite
+@SelectClasses({ //
 		BasicTest.class, //
 		ResolverHookTests.class //
 })

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/securityadmin/AllSecurityAdminTests.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/securityadmin/AllSecurityAdminTests.java
@@ -13,11 +13,11 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.securityadmin;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({ //
+@Suite
+@SelectClasses({ //
 		SecurityAdminUnitTests.class, //
 		SecurityManagerTests.class //
 })

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/serviceregistry/AllTests.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/serviceregistry/AllTests.java
@@ -13,11 +13,11 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.serviceregistry;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({ //
+@Suite
+@SelectClasses({ //
 		ServiceRegistryTests.class, //
 		ServiceExceptionTests.class, //
 		ServiceHookTests.class, //

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/services/datalocation/AllTests.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/services/datalocation/AllTests.java
@@ -13,11 +13,11 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.services.datalocation;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({ //
+@Suite
+@SelectClasses({ //
 		LocationAreaSessionTest.class, //
 		BasicLocationTests.class, //
 		SimpleTests.class, //

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/services/resolver/AllTests.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/services/resolver/AllTests.java
@@ -13,11 +13,12 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.services.resolver;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({ SubstitutableExportsTest.class, //
+@Suite
+@SelectClasses({ //
+		SubstitutableExportsTest.class, //
 		DisabledInfoTest.class, //
 		PlatformAdminTest.class, //
 		StateResolverTest.class, //

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/services/resolver/R4ResolverTest.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/services/resolver/R4ResolverTest.java
@@ -47,11 +47,11 @@ import org.eclipse.osgi.tests.resolver.TestRFC79_007;
 import org.eclipse.osgi.tests.resolver.TestVersion_001;
 import org.eclipse.osgi.tests.resolver.TestVersion_002;
 import org.eclipse.osgi.tests.resolver.TestVersion_003;
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({ //
+@Suite
+@SelectClasses({ //
 		TestAttributes_001.class, //
 		TestBSN_001.class, //
 		TestCycle_001.class, //

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/url/AllTests.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/url/AllTests.java
@@ -13,11 +13,11 @@
  *******************************************************************************/
 package org.eclipse.osgi.tests.url;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({ //
+@Suite
+@SelectClasses({ //
 		BundleURLConnectionTest.class //
 })
 public class AllTests {


### PR DESCRIPTION
The main test suite of the `org.eclipse.osgi.tests` bundle has already been migrated to JUnit 5 and those included test suites that contain JUnit 5 tests have been migrated as well. This change adapts all other test suites in that bundle to use JUnit 5.