### PR TITLE
Eliminate includes of 3rd party bundles in features.

### DIFF
--- a/features/org.eclipse.equinox.compendium.sdk/feature.xml
+++ b/features/org.eclipse.equinox.compendium.sdk/feature.xml
@@ -48,15 +48,7 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.osgi.service.prefs"
-         version="0.0.0"/>
-
-   <plugin
          id="org.eclipse.equinox.useradmin"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.osgi.service.coordinator"
          version="0.0.0"/>
 
 </feature>

--- a/features/org.eclipse.equinox.core.feature/feature.xml
+++ b/features/org.eclipse.equinox.core.feature/feature.xml
@@ -15,6 +15,26 @@
       %license
    </license>
 
+   <requires>
+      <import plugin="org.apache.felix.gogo.command" version="1.1.2" match="compatible"/>
+      <import plugin="org.apache.felix.gogo.runtime" version="1.1.6" match="compatible"/>
+      <import plugin="org.apache.felix.gogo.shell" version="1.1.4" match="compatible"/>
+      <import plugin="org.osgi.service.cm" version="1.6.1" match="compatible"/>
+      <import plugin="org.osgi.service.component" version="1.5.1" match="compatible"/>
+      <import plugin="org.osgi.service.device" version="1.1.1" match="compatible"/>
+      <import plugin="org.osgi.service.event" version="1.4.1" match="compatible"/>
+      <import plugin="org.osgi.service.metatype" version="1.4.1" match="compatible"/>
+      <import plugin="org.osgi.service.provisioning" version="1.2.0" match="compatible"/>
+      <import plugin="org.osgi.service.upnp" version="1.2.1" match="compatible"/>
+      <import plugin="org.osgi.service.useradmin" version="1.1.1" match="compatible"/>
+      <import plugin="org.osgi.service.wireadmin" version="1.0.2" match="compatible"/>
+      <import plugin="org.osgi.util.function" version="1.2.0" match="compatible"/>
+      <import plugin="org.osgi.util.measurement" version="1.0.2" match="compatible"/>
+      <import plugin="org.osgi.util.position" version="1.0.1" match="compatible"/>
+      <import plugin="org.osgi.util.promise" version="1.3.0" match="compatible"/>
+      <import plugin="org.osgi.util.xml" version="1.0.2" match="compatible"/>
+   </requires>
+
    <plugin
          id="org.eclipse.osgi"
          version="0.0.0"/>
@@ -49,74 +69,6 @@
 
    <plugin
          id="org.eclipse.equinox.console"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.apache.felix.gogo.command"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.apache.felix.gogo.runtime"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.apache.felix.gogo.shell"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.osgi.util.function"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.osgi.util.promise"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.osgi.util.measurement"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.osgi.util.position"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.osgi.util.xml"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.osgi.service.cm"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.osgi.service.component"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.osgi.service.device"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.osgi.service.event"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.osgi.service.metatype"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.osgi.service.provisioning"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.osgi.service.upnp"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.osgi.service.useradmin"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.osgi.service.wireadmin"
          version="0.0.0"/>
 
 </feature>

--- a/features/org.eclipse.equinox.core.sdk/feature.xml
+++ b/features/org.eclipse.equinox.core.sdk/feature.xml
@@ -98,12 +98,4 @@
          id="org.eclipse.equinox.weaving.hook"
          version="0.0.0"/>
 
-   <plugin
-         id="org.osgi.service.log.stream"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.osgi.util.pushstream"
-         version="0.0.0"/>
-
 </feature>

--- a/features/org.eclipse.equinox.server.core/feature.xml
+++ b/features/org.eclipse.equinox.server.core/feature.xml
@@ -15,16 +15,26 @@
       %license
    </license>
 
+   <requires>
+      <import plugin="org.apache.felix.scr" version="2.2.14" match="compatible"/>
+      <import plugin="org.osgi.service.cm" version="1.6.1" match="compatible"/>
+      <import plugin="org.osgi.service.component" version="1.5.1" match="compatible"/>
+      <import plugin="org.osgi.service.device" version="1.1.1" match="compatible"/>
+      <import plugin="org.osgi.service.event" version="1.4.1" match="compatible"/>
+      <import plugin="org.osgi.service.metatype" version="1.4.1" match="compatible"/>
+      <import plugin="org.osgi.service.provisioning" version="1.2.0" match="compatible"/>
+      <import plugin="org.osgi.service.upnp" version="1.2.1" match="compatible"/>
+      <import plugin="org.osgi.service.useradmin" version="1.1.1" match="compatible"/>
+      <import plugin="org.osgi.service.wireadmin" version="1.0.2" match="compatible"/>
+      <import plugin="org.osgi.util.function" version="1.2.0" match="compatible"/>
+      <import plugin="org.osgi.util.measurement" version="1.0.2" match="compatible"/>
+      <import plugin="org.osgi.util.position" version="1.0.1" match="compatible"/>
+      <import plugin="org.osgi.util.promise" version="1.3.0" match="compatible"/>
+      <import plugin="org.osgi.util.xml" version="1.0.2" match="compatible"/>
+   </requires>
+
    <plugin
          id="org.eclipse.osgi"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.osgi.services"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.osgi.util"
          version="0.0.0"/>
 
    <plugin
@@ -49,66 +59,6 @@
 
    <plugin
          id="org.eclipse.osgi.compatibility.state"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.apache.felix.scr"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.osgi.util.function"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.osgi.util.promise"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.osgi.util.measurement"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.osgi.util.position"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.osgi.util.xml"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.osgi.service.cm"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.osgi.service.component"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.osgi.service.device"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.osgi.service.event"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.osgi.service.metatype"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.osgi.service.provisioning"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.osgi.service.upnp"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.osgi.service.useradmin"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.osgi.service.wireadmin"
          version="0.0.0"/>
 
 </feature>


### PR DESCRIPTION
- For org.eclipse.equinox.compendium.sdk, we don't need org.osgi.service.prefs nor org.osgi.service.coordinator because they're required by org.eclipse.equinox.preferences and
org.eclipse.equinox.coordinator.
- For org.eclipse.equinox.core.feature, convert the includes to imports.
- For eclipse.equinox.core.sdk, we don't need org.osgi.service.log.stream nor org.osgi.util.pushstream because they are required by org.eclipse.equinox.log.stream.
- For org.eclipse.equinox.server.core, convert includes to imports.

https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/3585