### PR TITLE
Adapt Win32 launcher DPI awareness and autoscale configuration

### DIFF
--- a/features/org.eclipse.equinox.executable.feature/library/win32/eclipse.exe.manifest
+++ b/features/org.eclipse.equinox.executable.feature/library/win32/eclipse.exe.manifest
@@ -10,6 +10,7 @@
 	<asmv3:application>
 		<asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">
 			<ms_windowsSettings:dpiAware xmlns:ms_windowsSettings="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</ms_windowsSettings:dpiAware>
+			<ms_windowsSettings:dpiAwareness xmlns:ms_windowsSettings="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</ms_windowsSettings:dpiAwareness>
 		</asmv3:windowsSettings>
 	</asmv3:application>
 	<compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">

--- a/features/org.eclipse.equinox.executable.feature/library/win32/eclipseWin.c
+++ b/features/org.eclipse.equinox.executable.feature/library/win32/eclipseWin.c
@@ -318,12 +318,12 @@ int showSplash( const _TCHAR* featureImage )
 		case AUTOSCALE_FALSE:
 			dpiX = 96;
 			break;
+		case AUTOSCALE_DEFAULT:
 		case AUTOSCALE_QUARTER:
 			dpiX = ((dpiX + 12) / 24) * 24;
 			break;
 		case AUTOSCALE_EXACT:
 			break;
-		case AUTOSCALE_DEFAULT:
 		case AUTOSCALE_INTEGER:
 			dpiX = ((int)((dpiX + 24) / 96 )) * 96;
 			break;
@@ -699,8 +699,15 @@ static void CALLBACK detectJvmExit( HWND hwnd, UINT uMsg, UINT id, DWORD dwTime 
 void processVMArgs(_TCHAR **vmargs[] ) {
 	_TCHAR** arg;
 	for (arg = *vmargs; *arg != NULL; arg++) {
+		// see org.eclipse.swt.internal.DPIUtil.getZoomForAutoscaleProperty()
+		if (_tcsncmp(*arg, _T("-Dswt.autoScale.updateOnRuntime="), 32) == 0) {
+			_TCHAR* value = *arg + 32;
+			if (_tcsicmp(value, _T("false")) == 0) {
+				/* when monitor-specific scaling is disabled, default is "integer" */
+				autoScaleValue = AUTOSCALE_INTEGER;
+			}
+		}
 		if (_tcsncmp(*arg, _T("-Dswt.autoScale="), 16) == 0) {
-			// see org.eclipse.swt.internal.DPIUtil.getZoomForAutoscaleProperty()
 			_TCHAR* value = *arg + 16;
 			if (_tcsicmp(value, _T("false")) == 0) {
 				autoScaleValue = AUTOSCALE_FALSE;


### PR DESCRIPTION
Eclipse products use monitor-specific scaling by default for several releases now. The products apply that scaling to the window created for the workbench and adapt the DPI awareness for the UI thread of that window. The whole application process is still executed in "System" DPI awareness (used for the whole application before monitor-specific scaling was available) as defined by the Equinox launcher's manifest. Since SWT also still used non-monitor-specific scaling as default, the splash screen initialized by the Equinox launcher was still processed without monitor-specific scaling (with some tweaks in the `Workbench` implementation to make that work as expected).

With SWT using monitor-specific scaling on Windows by default (see https://github.com/eclipse-platform/eclipse.platform.swt/pull/2955), a fitting process DPI awareness ("PerMonitorV2") must be used by the Equinox native launcher to have a proper splash screen experience. In addition, this will adapt the Equinox launcher to the current defaults of Eclipse products and of the JDK itself (which by default uses PerMonitorV2 as well).

As with monitor-specific scaling the default `swt.autoScale` value on Windows changes from "integer" to "quarter", this behavior is also adapted in the `eclipseWin.c` to align with the implementation in SWT's `DPIUtil`. In case monitor-specific scaling is deactivated via system property, the `swt.autoScale` value still defaults to "integer", which is also reflected in this change to conform to SWT behavior.

### Question

A consequence of this will be that if using a new Equinox release together with an older than the upcoming SWT and/or Eclipse UI release, the autoscaling of the splash screen may be inconsistent. This is always the case when autoscaling adaptations are made as they implicitly have to be aligned (as also documented in `eclipseWin.c`). Just recently, a missing alignment for several years was fixed (https://github.com/eclipse-equinox/equinox/pull/1213).
Is there any intended way to ensure the usage of consistent SWT and Equinox (and/or Platform UI) versions? Since I don't see that there are any specific version dependencies (in particular, I don't think that anything in Platform explicitly depends on the Equinox launcher), the only possibility I see is to define a system property in the Equinox launcher that is ready by the Platform to identify if an adapted version of Equinox is used, so that the (splash screen) behavior can be adapted. That might be a system property specific to the actual change or some kind of version of the Equinox autoscaling behavior that the Platform could adapt to. But I am also not sure if it is worth the effort or whether it is safe to assume that people should use consistent Equinox/SWT/Platform versions for their products.

Opinions on this or input on how this is intended to work are highly appreciated (maybe @akurtakov?).

Since we plan to merge the SWT adaptation for 2026-03 M2, it would be great to have the according adaptation of the Equinox launcher as well, such that everything stays consistent.

### How it looks

The change is difficult to fully capture in a video:
- It particularly improves the appearance when moving the splash from one monitor to another with a different zoom
- It particularly improves the appearance of more complex splash screens than the one used by Eclipse itself (i.e., with more controls in it).

Still, the following captures at least demonstrate that the splash screen and contained control sizes now properly fit to the monitor scale and to each other.

#### Before
![splash_old](https://github.com/user-attachments/assets/c7cac58e-cf06-472d-9f7d-f0facaf0eaad)

#### After
![splash_new](https://github.com/user-attachments/assets/4fe6349c-f77c-4bb7-a0f3-dedfc27761d6)