### PR TITLE
Update documentation of Windows HiDPI issues

### DIFF
--- a/docs/_launcher/launcher_issues.md
+++ b/docs/_launcher/launcher_issues.md
@@ -106,12 +106,12 @@ openFile
 
 #### DPI Scaling
 
-**Issue**: On high-DPI displays, Eclipse may appear blurry or have scaling issues.
+**Issue**: On high-DPI displays, Eclipse may have scaling issues when using multiple monitors with different zooms (monitor-specific scaling support).
 
-**Workaround**: Add to `eclipse.ini`:
+**Workaround**: Switch back to previous single-zoom support by disabling monitor-specific scaling. Add to `eclipse.ini`:
 ```
 -vmargs
--Dswt.autoScale=200
+-Dswt.autoScale.updateOnRuntime=false
 ```
 
 ### Linux


### PR DESCRIPTION
With recent changes to the Windows Equinox launcher (default DPI awareness and default autoscaling mode), the information on potential DPI issues became outdated.
- https://github.com/eclipse-equinox/equinox/pull/1239

This change adapts the documentation to mention the most common issue that may occur now.