### PR TITLE
Bump minor version of Windows launcher fragments

### DIFF
--- a/bundles/org.eclipse.equinox.launcher.win32.win32.aarch64/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.launcher.win32.win32.aarch64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.equinox.launcher.win32.win32.aarch64;singleton:=true
-Bundle-Version: 1.2.1500.qualifier
+Bundle-Version: 1.3.0.qualifier
 Fragment-Host: org.eclipse.equinox.launcher;bundle-version="[1.7.0,1.8.0)"
 Eclipse-PlatformFilter: (& (osgi.ws=win32) (osgi.os=win32) (osgi.arch=aarch64))
 Bundle-Localization: launcher.win32.win32.aarch64

--- a/bundles/org.eclipse.equinox.launcher.win32.win32.x86_64/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.launcher.win32.win32.x86_64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.equinox.launcher.win32.win32.x86_64;singleton:=true
-Bundle-Version: 1.2.1500.qualifier
+Bundle-Version: 1.3.0.qualifier
 Fragment-Host: org.eclipse.equinox.launcher;bundle-version="[1.7.0,1.8.0)"
 Eclipse-PlatformFilter: (& (osgi.ws=win32) (osgi.os=win32) (osgi.arch=x86_64))
 Bundle-Localization: launcher.win32.win32.x86_64


### PR DESCRIPTION
The recent changes of the Windows native launcher (DPI awareness, default autoscaling mode) significantly change the experience of the launcher behavior:
- https://github.com/eclipse-equinox/equinox/pull/1239
 
This change bumps the minor version of the fragments to reflect the relevance of the changes.

This is just a proposal as there is no clear definition when to bump the minor version upon changes of the native implementation parts. I consider a minor bump reasonable for the mentioned changes, but it's up to the committers to decide if the bump should be applied.