### PR TITLE
Protect against NPE via slf4j.EquinoxLogger

### DIFF
--- a/bundles/org.eclipse.equinox.slf4j/src/org/eclipse/equinox/slf4j/EquinoxLogger.java
+++ b/bundles/org.eclipse.equinox.slf4j/src/org/eclipse/equinox/slf4j/EquinoxLogger.java
@@ -109,9 +109,9 @@ class EquinoxLogger extends org.slf4j.helpers.AbstractLogger {
 			String formattedMessage = safeBasicArrayFormat(messagePattern, arguments);
 			logger.info(formattedMessage, loggerArguments);
 		}
-		if(level == Level.ERROR && logger.isInfoEnabled()) {
+		if(level == Level.ERROR && logger.isErrorEnabled()) {
 			String formattedMessage = safeBasicArrayFormat(messagePattern, arguments);
-			logger.info(formattedMessage, loggerArguments);
+			logger.error(formattedMessage, loggerArguments);
 		}
 	}
 


### PR DESCRIPTION
Some callers of SLF4J log null messages which OSGi Logger does not allow.

Fixes: #1253