### PR TITLE
Wait for STARTED event before adding test listener

### DIFF
--- a/bundles/org.eclipse.osgi.tests/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.osgi.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Core OSGi Tests
 Bundle-SymbolicName: org.eclipse.osgi.tests;singleton:=true
-Bundle-Version: 3.22.500.qualifier
+Bundle-Version: 3.22.600.qualifier
 Bundle-Vendor: Eclipse.org
 Require-Bundle: 
  org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",

--- a/bundles/org.eclipse.osgi.tests/pom.xml
+++ b/bundles/org.eclipse.osgi.tests/pom.xml
@@ -19,7 +19,7 @@
   </parent>
   <groupId>org.eclipse.platform</groupId>
   <artifactId>org.eclipse.osgi.tests</artifactId>
-  <version>3.22.500-SNAPSHOT</version>
+  <version>3.22.600-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <properties>

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/equinox/log/test/LogEquinoxTraceTest.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/equinox/log/test/LogEquinoxTraceTest.java
@@ -27,6 +27,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import org.eclipse.equinox.log.SynchronousLogListener;
 import org.eclipse.osgi.internal.debug.Debug;
 import org.eclipse.osgi.launch.Equinox;
@@ -39,6 +41,7 @@ import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.BundleException;
 import org.osgi.framework.Constants;
+import org.osgi.framework.FrameworkEvent;
 import org.osgi.framework.ServiceReference;
 import org.osgi.service.condition.Condition;
 import org.osgi.service.log.LogEntry;
@@ -87,16 +90,28 @@ public class LogEquinoxTraceTest extends AbstractBundleTests {
 		Map<String, Object> configuration = new HashMap<>();
 		configuration.put(Constants.FRAMEWORK_STORAGE, config.getAbsolutePath());
 		equinox = new Equinox(configuration);
-		equinox.start();
-		loggerAdmin = equinox.getBundleContext()
-				.getService(equinox.getBundleContext().getServiceReference(LoggerAdmin.class));
-		LogReaderService logReader = equinox.getBundleContext()
-				.getService(equinox.getBundleContext().getServiceReference(LogReaderService.class));
-
-		testListener = new TestListener();
-		logReader.addLogListener(testListener);
+		equinox.init();
 
 		BundleContext systemContext = equinox.getBundleContext();
+		CountDownLatch frameworkStarted = new CountDownLatch(1);
+		systemContext.addFrameworkListener((e) -> {
+			if (FrameworkEvent.STARTED == e.getType()) {
+				frameworkStarted.countDown();
+			}
+		});
+
+		equinox.start();
+		// Need to wait for the STARTED event before continuing to ensure
+		// all events are flushed before adding the test log listener
+		frameworkStarted.await(1, TimeUnit.MINUTES);
+
+		loggerAdmin = systemContext.getService(systemContext.getServiceReference(LoggerAdmin.class));
+		testListener = new TestListener();
+
+		LogReaderService logReader = systemContext
+				.getService(systemContext.getServiceReference(LogReaderService.class));
+		logReader.addLogListener(testListener);
+
 		debugOptions = systemContext.getService(systemContext.getServiceReference(DebugOptions.class));
 	}
 


### PR DESCRIPTION
Async framework event may still be getting delivered and we need to make sure no pending events are waiting to be logged before adding the test listener; otherwise timing issues could happen with unexpected logs for the pending events from starting the framework.

Fixes #1259