### PR TITLE
[Build] Ensure availability guards in macOS native launcher and clean up

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,6 +15,7 @@
 
 def runOnNativeBuildAgent(String platform, Closure body) {
 	def final nativeBuildStageName = 'Perform native launcher build'
+	def agentLabel = 'native.builder-' + platform
 	if (platform == 'gtk.linux.x86_64') {
 		podTemplate(inheritFrom: 'basic' /* inherit general configuration */, containers: [
 			containerTemplate(name: 'launcherbuild', image: 'eclipse/platformreleng-debian-swtgtk3nativebuild:10',
@@ -25,12 +26,9 @@ def runOnNativeBuildAgent(String platform, Closure body) {
 			node(POD_LABEL) { stage(nativeBuildStageName) { container('launcherbuild') { body() } } }
 		}
 	} else {
-		if (platform == 'cocoa.macosx.x86_64') {
-			platform = 'cocoa.macosx.aarch64'
-		}
 		// See the Definition of the RelEng Jenkins instance in
 		// https://github.com/eclipse-cbi/jiro/tree/master/instances/eclipse.platform.releng
-		node('native.builder-' + platform) { stage(nativeBuildStageName) { body() } }
+		node(agentLabel) { stage(nativeBuildStageName) { body() } }
 	}
 }
 

--- a/bundles/org.eclipse.equinox.launcher.cocoa.macosx.aarch64/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.launcher.cocoa.macosx.aarch64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.equinox.launcher.cocoa.macosx.aarch64;singleton:=true
-Bundle-Version: 1.2.1400.qualifier
+Bundle-Version: 1.2.1500.qualifier
 Fragment-Host: org.eclipse.equinox.launcher;bundle-version="[1.7.0,1.8.0)"
 Eclipse-PlatformFilter: (& (osgi.ws=cocoa) (osgi.os=macosx) (osgi.arch=aarch64) )
 Bundle-Localization: launcher.cocoa.macosx.aarch64

--- a/bundles/org.eclipse.equinox.launcher.cocoa.macosx.x86_64/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.launcher.cocoa.macosx.x86_64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.equinox.launcher.cocoa.macosx.x86_64;singleton:=true
-Bundle-Version: 1.2.1400.qualifier
+Bundle-Version: 1.2.1500.qualifier
 Fragment-Host: org.eclipse.equinox.launcher;bundle-version="[1.7.0,1.8.0)"
 Eclipse-PlatformFilter: (& (osgi.ws=cocoa) (osgi.os=macosx) (osgi.arch=x86_64) )
 Bundle-Localization: launcher.cocoa.macosx.x86_64

--- a/features/org.eclipse.equinox.executable.feature/library/cocoa/build.sh
+++ b/features/org.eclipse.equinox.executable.feature/library/cocoa/build.sh
@@ -61,7 +61,6 @@ echo "build $defaultOSArch"
 PROGRAM_OUTPUT="$programOutput"
 DEFAULT_OS="$defaultOS"
 DEFAULT_WS="$defaultWS"
-DEPLOYMENT_TARGET=11.0
 if [ "$BINARIES_DIR" = "" ]; then BINARIES_DIR="../../../../../equinox.binaries"; fi
 
 if [ "$defaultOSArch" == "arm64" ] || [ "$defaultOSArch" == "aarch64" ]
@@ -84,7 +83,7 @@ fi
 ARCHS="-arch $defaultOSArch"
 
 export PROGRAM_OUTPUT DEFAULT_OS DEFAULT_OS_ARCH DEFAULT_WS ARCHS JAVA_HEADERS EXE_OUTPUT_DIR LIB_OUTPUT_DIR 
-export MACOSX_DEPLOYMENT_TARGET=$DEPLOYMENT_TARGET
+export MACOSX_DEPLOYMENT_TARGET=11
 
 if [ "$extraArgs" != "" ]; then
 	make -f $makefile $extraArgs

--- a/features/org.eclipse.equinox.executable.feature/library/cocoa/make_cocoa.mak
+++ b/features/org.eclipse.equinox.executable.feature/library/cocoa/make_cocoa.mak
@@ -44,7 +44,8 @@ ifeq ($(ARCHS),-arch x86_64)
 endif
 
 CFLAGS = -O \
-	-Wall \
+	-Wall -Werror \
+	-Wunguarded-availability \
 	-DCOCOA -xobjective-c \
 	$(ARCHS) \
 	-DMACOSX \


### PR DESCRIPTION
Also build native launchers for macOS on agents of the targeted architecture.

This also aligns the Equinox pipeline with SWT:
- https://github.com/eclipse-platform/eclipse.platform.swt/pull/3182
