### PR TITLE
[Build] Build macOS native launcher binaries on macOS 15 agents

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,6 +15,10 @@
 
 def runOnNativeBuildAgent(String platform, Closure body) {
 	def final nativeBuildStageName = 'Perform native launcher build'
+	// Use x86 agent for aarch64 build to ensure that the baseline macOS SDK (the oldest) is used consistently for all binary builds
+	if (platform == 'cocoa.macosx.aarch64') {
+		platform = 'cocoa.macosx.x86_64'
+	}
 	def agentLabel = 'native.builder-' + platform
 	if (platform == 'gtk.linux.x86_64') {
 		podTemplate(inheritFrom: 'basic' /* inherit general configuration */, containers: [


### PR DESCRIPTION
With recent changes, the macOS native launcher binaries are built on the Jenkins agents with the fitting architecture. This includes the usage of different macOS SDKs. For the x86 build, a macOS 15 SDK is used, whereas the aarch64 build uses a macOS 26 SDK. After that change, the behavior of applications using the binaries built with macOS 26 SDK show significantly changed behavior and appearance (such as title bar text alignment, background colors, invisible lists and the like), rendering applications hardly usable or even partly unusable. See, e.g.:
- https://github.com/eclipse-platform/eclipse.platform.ui/issues/3884
- https://github.com/eclipse-platform/eclipse.platform.ui/issues/3885
- https://github.com/eclipse-platform/eclipse.platform.swt/issues/3230

With this change, the binaries are always built on the x86 agent, which runs macOS 15 and uses the according SDK, to restore existing behavior. This is supposed to be a temporary solution until the Eclipse Platform has been updated to be compatible with the macOS 26 SDK behavior. See https://github.com/eclipse-platform/eclipse.platform.ui/issues/3884#issuecomment-4241839229.

The aarch64 binary is now properly built with/against macOS 15 SDK now: https://ci.eclipse.org/releng/job/equinox/view/change-requests/job/PR-1273/5/execution/node/3/ws/equinox.binaries/org.eclipse.equinox.launcher.cocoa.macosx.aarch64/
```
vtool -show eclipse_11921.so     
eclipse_11921.so:
Load command 8
      cmd LC_BUILD_VERSION
  cmdsize 32
 platform MACOS
    minos 11.0
      sdk 15.5
   ntools 1
     tool LD
  version 1167.5
Load command 9
      cmd LC_SOURCE_VERSION
  cmdsize 16
  version 0.0
```

<s>
> [!WARNING]
>For now, this is for testing purposes. I am not even sure if it is possible to compile aarch64 binaries on an x86 system. We just did it vice versa before.
</s>