### PR TITLE
Add apache.commons.commons-fileupload to equinox.server.jetty feature

### DIFF
--- a/features/org.eclipse.equinox.server.jetty/feature.xml
+++ b/features/org.eclipse.equinox.server.jetty/feature.xml
@@ -15,6 +15,10 @@
       %license
    </license>
 
+   <requires>
+      <import plugin="org.apache.commons.commons-fileupload"/>
+   </requires>
+
    <plugin
          id="org.eclipse.equinox.http.jetty"
          version="0.0.0"/>

--- a/features/org.eclipse.equinox.server.jetty/feature.xml
+++ b/features/org.eclipse.equinox.server.jetty/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.equinox.server.jetty"
       label="%featureName"
-      version="1.11.1000.qualifier"
+      version="1.11.1100.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">


### PR DESCRIPTION
The `org.eclipse.equinox.http.servlet` bundle requires Apache's `commons-fileupload` only optionally
https://github.com/eclipse-equinox/equinox/blob/36de39bde95dcbf3cd4364fe09dfc931264a1389/bundles/org.eclipse.equinox.http.servlet/META-INF/MANIFEST.MF#L23-L25

And the only hard requirement to it are currently just tests. In case they are removed from the Eclipse repository as proposed in
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3772

... `commons-fileupload` would vanish from the Eclipse repository, without further changes.

As the `commons-fileupload` looks small and innocent I propose to at least require it in the `equinox.server.jetty` feature.
Alternatively `org.eclipse.equinox.http.servlet` could also make the dependency on `commons-fileupload` mandatory. I have to admit that I don't understand why it's optional at all.
In case we just make it mandatory, https://github.com/eclipse-equinox/equinox/pull/1275 could become even simpler and the clean-up should instead be included here.