### PR TITLE
Simplify optional registration of of MultipartSupportFactoryImpl

### DIFF
--- a/bundles/org.eclipse.equinox.http.servlet/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.http.servlet/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.equinox.http.servlet
-Bundle-Version: 1.8.600.qualifier
+Bundle-Version: 1.8.700.qualifier
 Bundle-Activator: org.eclipse.equinox.http.servlet.internal.Activator
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/bundles/org.eclipse.equinox.http.servlet/META-INF/services/org.eclipse.equinox.http.servlet.internal.multipart.MultipartSupportFactory
+++ b/bundles/org.eclipse.equinox.http.servlet/META-INF/services/org.eclipse.equinox.http.servlet.internal.multipart.MultipartSupportFactory
@@ -1,1 +1,0 @@
-org.eclipse.equinox.http.servlet.internal.multipart.MultipartSupportFactoryImpl

--- a/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/registration/ServletRegistration.java
+++ b/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/registration/ServletRegistration.java
@@ -17,14 +17,13 @@
 package org.eclipse.equinox.http.servlet.internal.registration;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.List;
 import javax.servlet.*;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.Part;
 import org.eclipse.equinox.http.servlet.internal.context.ContextController;
 import org.eclipse.equinox.http.servlet.internal.context.ServiceHolder;
-import org.eclipse.equinox.http.servlet.internal.multipart.MultipartSupport;
-import org.eclipse.equinox.http.servlet.internal.multipart.MultipartSupportFactory;
+import org.eclipse.equinox.http.servlet.internal.multipart.*;
 import org.osgi.framework.ServiceReference;
 import org.osgi.service.http.context.ServletContextHelper;
 import org.osgi.service.http.runtime.dto.ServletDTO;
@@ -35,19 +34,10 @@ public class ServletRegistration extends EndpointRegistration<ServletDTO> {
 	private static MultipartSupportFactory factory;
 
 	static {
-		ServiceLoader<MultipartSupportFactory> loader = ServiceLoader.load(MultipartSupportFactory.class);
-
-		Iterator<MultipartSupportFactory> iterator = loader.iterator();
-
-		while (iterator.hasNext()) {
-			try {
-				// Note: we intentionally trigger next() inside the try/catch block
-				// to fail early if optional imports are missing
-				factory = iterator.next();
-				break;
-			} catch (Throwable t) {
-				// ignore ServiceConfigurationError, it means our optional imports are missing.
-			}
+		try {
+			factory = new MultipartSupportFactoryImpl();
+		} catch (NoClassDefFoundError e) {
+			// ignore NoClassDefFoundError, it means our optional imports are missing.
 		}
 	}
 

--- a/features/org.eclipse.equinox.server.jetty/feature.xml
+++ b/features/org.eclipse.equinox.server.jetty/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.equinox.server.jetty"
       label="%featureName"
-      version="1.11.1000.qualifier"
+      version="1.11.1100.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">


### PR DESCRIPTION
It's sufficient to catch a potential `NoClassDefFoundError` when creating the `MultipartSupportFactoryImpl` instance. The indirection using a ServiceLoader is not necessary for that.

I did a test with a simple Java application and still `ServletRegistration` as initialized cleanly as expected when the `commons-fileupload` jar was absent.