### PR TITLE
Suppress stack trace on resolution-error BundleException

### DIFF
--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/container/Module.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/container/Module.java
@@ -25,6 +25,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.eclipse.osgi.container.ModuleContainerAdaptor.ModuleEvent;
 import org.eclipse.osgi.framework.util.ThreadInfoReport;
 import org.eclipse.osgi.internal.container.EquinoxReentrantLock;
+import org.eclipse.osgi.internal.container.InternalUtils;
 import org.eclipse.osgi.internal.messages.Msg;
 import org.eclipse.osgi.report.resolution.ResolutionReport;
 import org.eclipse.osgi.util.NLS;
@@ -492,7 +493,7 @@ public abstract class Module implements BundleReference, BundleStartLevel, Compa
 					return;
 				if (getState().equals(State.INSTALLED)) {
 					String reportMessage = report.getResolutionReportMessage(getCurrentRevision());
-					throw new BundleException(Msg.Module_ResolveError + reportMessage, BundleException.RESOLVE_ERROR);
+					throw InternalUtils.newResolveError(Msg.Module_ResolveError + reportMessage);
 				}
 			}
 

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/container/SystemModule.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/container/SystemModule.java
@@ -20,6 +20,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.eclipse.osgi.container.ModuleContainer.ContainerStartLevel;
 import org.eclipse.osgi.container.ModuleContainerAdaptor.ContainerEvent;
 import org.eclipse.osgi.container.ModuleContainerAdaptor.ModuleEvent;
+import org.eclipse.osgi.internal.container.InternalUtils;
 import org.eclipse.osgi.internal.messages.Msg;
 import org.eclipse.osgi.report.resolution.ResolutionReport;
 import org.osgi.framework.AdminPermission;
@@ -88,7 +89,7 @@ public abstract class SystemModule extends Module {
 					return;
 				if (getState().equals(State.INSTALLED)) {
 					String reportMessage = report.getResolutionReportMessage(getCurrentRevision());
-					throw new BundleException(Msg.Module_ResolveError + reportMessage, BundleException.RESOLVE_ERROR);
+					throw InternalUtils.newResolveError(Msg.Module_ResolveError + reportMessage);
 				}
 			}
 

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/container/InternalUtils.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/container/InternalUtils.java
@@ -26,6 +26,7 @@ import java.util.RandomAccess;
 import java.util.UUID;
 import org.eclipse.osgi.internal.framework.EquinoxConfiguration;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleException;
 import org.osgi.framework.BundlePermission;
 import org.osgi.framework.CapabilityPermission;
 import org.osgi.framework.PackagePermission;
@@ -200,6 +201,35 @@ public class InternalUtils {
 			leastSignificantBits = (leastSignificantBits << 8) | (uuidBytes[i] & 0xff);
 		}
 		return new UUID(mostSignificantBits, leastSignificantBits).toString();
+	}
+
+	/**
+	 * System property to include the full stack trace on resolution-error
+	 * {@link BundleException}s. When not set (the default), resolution errors omit
+	 * their stack trace since the message already identifies the bundle and the
+	 * unresolved requirement; the stack is always the same OSGi event-dispatch
+	 * chain and carries no diagnostic value. Set to {@code true} to restore the
+	 * stack trace for debugging.
+	 */
+	public static final String PROP_RESOLVER_ERROR_STACKTRACE = "equinox.resolver.errorStacktrace"; //$NON-NLS-1$
+
+	/**
+	 * Creates a {@link BundleException} of type {@link BundleException#RESOLVE_ERROR}.
+	 * The stack trace is suppressed unless
+	 * {@link #PROP_RESOLVER_ERROR_STACKTRACE} is set — see that property for why.
+	 */
+	public static BundleException newResolveError(String message) {
+		if (Boolean.getBoolean(PROP_RESOLVER_ERROR_STACKTRACE)) {
+			return new BundleException(message, BundleException.RESOLVE_ERROR);
+		}
+		return new BundleException(message, BundleException.RESOLVE_ERROR) {
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			public synchronized Throwable fillInStackTrace() {
+				return this;
+			}
+		};
 	}
 
 	public static <E> Enumeration<E> asEnumeration(Iterator<E> it) {

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/framework/EquinoxBundle.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/framework/EquinoxBundle.java
@@ -650,7 +650,7 @@ public class EquinoxBundle implements Bundle, BundleReference {
 			ResolutionReport report = resolvedClassLoader.report;
 			if (report != null) {
 				String reportMessage = report.getResolutionReportMessage(module.getCurrentRevision());
-				BundleException bundleException = new BundleException(reportMessage, BundleException.RESOLVE_ERROR);
+				BundleException bundleException = InternalUtils.newResolveError(reportMessage);
 				equinoxContainer.getEventPublisher().publishFrameworkEvent(FrameworkEvent.ERROR, this, bundleException);
 				throw new ClassNotFoundException(name, bundleException);
 			}


### PR DESCRIPTION
## Summary

- The stack trace on a `RESOLVE_ERROR` `BundleException` is always the same OSGi event-dispatch / start-level chain and carries no diagnostic value — the message already identifies the bundle and the unresolved requirement.
- Suppress the trace by default so bundle-resolution failure logs show only the actionable information.
- Set the system property `equinox.resolver.errorStacktrace=true` to restore the full stack trace for debugging.
- Other `BundleException` types (`ACTIVATOR_ERROR`, `NATIVECODE_ERROR`, `STATECHANGE_ERROR`, etc.) are unaffected — their stack traces point at the actual culprit and remain useful.

### Before

```
org.osgi.framework.BundleException: Could not resolve module: org.eclipse.pde.spy.css [326]
  Unresolved requirement: Require-Bundle: org.eclipse.jface; bundle-version="3.39.0"

    at org.eclipse.osgi.container.Module.start(Module.java:495)
    at org.eclipse.osgi.container.ModuleContainer$ContainerStartLevel$2.run(ModuleContainer.java:2110)
    at org.eclipse.osgi.internal.framework.EquinoxContainerAdaptor$1$1.execute(EquinoxContainerAdaptor.java:146)
    at org.eclipse.osgi.container.ModuleContainer$ContainerStartLevel.incStartLevel(ModuleContainer.java:2101)
    ... (several more frames of OSGi internals)
```

### After

```
org.osgi.framework.BundleException: Could not resolve module: org.eclipse.pde.spy.css [326]
  Unresolved requirement: Require-Bundle: org.eclipse.jface; bundle-version="3.39.0"
```

### Affected throw sites

- `Module.java:495` — bundle start fails due to unresolved requirements
- `SystemModule.java:91` — system bundle init fails due to unresolved requirements
- `EquinoxBundle.java:653` — class load fails because the bundle cannot resolve

### Implementation

Added a shared helper `InternalUtils.newResolveError(String)` that constructs a `BundleException` whose `fillInStackTrace()` is a no-op by default. When `equinox.resolver.errorStacktrace=true` is set, a regular `BundleException` is constructed so the trace is available for debugging.

## Test plan

- [ ] Trigger a resolution failure (e.g. install a bundle requiring a missing package) and verify the log contains only the message, no stack trace
- [ ] Set `-Dequinox.resolver.errorStacktrace=true` and verify the full stack trace is restored
- [ ] Trigger a non-resolution `BundleException` (e.g. a failing BundleActivator) and verify its stack trace is still present
- [ ] Existing `org.eclipse.osgi.tests` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)