### PR TITLE
Added loongarch64 support

### DIFF
--- a/features/org.eclipse.equinox.executable.feature/build.properties
+++ b/features/org.eclipse.equinox.executable.feature/build.properties
@@ -33,6 +33,9 @@ root.linux.gtk.ppc64le.permissions.755=launcher
 root.linux.gtk.aarch64=bin/gtk/linux/aarch64,gtk_root
 root.linux.gtk.aarch64.permissions.755=launcher
 
+root.linux.gtk.loongarch64=bin/gtk/linux/loongarch64,gtk_root
+root.linux.gtk.loongarch64.permissions.755=launcher
+
 root.macosx.cocoa.x86_64=bin/cocoa/macosx/x86_64
 root.macosx.cocoa.x86_64.permissions.755=Eclipse.app/Contents/MacOS/launcher
 

--- a/features/org.eclipse.equinox.executable.feature/feature.xml
+++ b/features/org.eclipse.equinox.executable.feature/feature.xml
@@ -52,6 +52,13 @@
          version="0.0.0"/>
 
    <plugin
+         id="org.eclipse.equinox.launcher.gtk.linux.loongarch64"
+         os="linux"
+         ws="gtk"
+         arch="loongarch64"
+         version="0.0.0"/>
+
+   <plugin
          id="org.eclipse.equinox.launcher.gtk.linux.x86_64"
          os="linux"
          ws="gtk"

--- a/features/org.eclipse.equinox.executable.feature/pom.xml
+++ b/features/org.eclipse.equinox.executable.feature/pom.xml
@@ -77,6 +77,7 @@
                         <include name="cocoa/macosx/aarch64/**/*"/>
                         <include name="gtk/linux/ppc64le/**/*"/>
                         <include name="gtk/linux/aarch64/**/*"/>
+                        <include name="gtk/linux/loongarch64/**/*"/>
                         <include name="gtk/linux/riscv64/**/*"/>
                         <include name="gtk/linux/x86_64/**/*"/>
                         <include name="win32/win32/aarch64/**/*"/>

--- a/features/org.eclipse.equinox.executable.feature/resources/build.xml
+++ b/features/org.eclipse.equinox.executable.feature/resources/build.xml
@@ -131,6 +131,7 @@
 		<antcall target="rootFileslinux_gtk_ppc64le"/>
 		<antcall target="rootFileslinux_gtk_aarch64"/>
 		<antcall target="rootFileslinux_gtk_x86_64"/>
+		<antcall target="rootFileslinux_gtk_loongarchs64"/>
 		<antcall target="rootFileslinux_gtk_riscv64"/>
 	</target>
 

--- a/pom.xml
+++ b/pom.xml
@@ -227,6 +227,7 @@
 		    <module>bundles/org.eclipse.equinox.launcher.cocoa.macosx.x86_64</module>
 		    <module>bundles/org.eclipse.equinox.launcher.cocoa.macosx.aarch64</module>
 		    <module>bundles/org.eclipse.equinox.launcher.gtk.linux.aarch64</module>
+			<module>bundles/org.eclipse.equinox.launcher.gtk.linux.loongarch64</module>
 		    <module>bundles/org.eclipse.equinox.launcher.gtk.linux.ppc64le</module>
 		    <module>bundles/org.eclipse.equinox.launcher.gtk.linux.riscv64</module>
 		    <module>bundles/org.eclipse.equinox.launcher.gtk.linux.x86_64</module>


### PR DESCRIPTION
The [LoongArch](https://wiki.debian.org/LoongArch) architecture is a RISC-style ISA developed by [Loongson](https://www.loongson.cn/)
LoongArch64 is the 64-bit version of [LoongArch](https://wiki.debian.org/LoongArch). I prepare to make dbeaver eclipse etc. to run on loongarch64, so start from this side. Here I built success on my loongarch64 3A5000 and commit this pr. Anything else needed pls feel free to contact me. Thanks. 