### PR TITLE
Show splash-screen using standalone SWT in Equinox launcher

### DIFF
--- a/bundles/org.eclipse.equinox.launcher/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.launcher/META-INF/MANIFEST.MF
@@ -4,6 +4,7 @@ Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.launcher;singleton:=true
 Bundle-Version: 1.7.100.qualifier
 Main-Class: org.eclipse.equinox.launcher.Main
+Require-Bundle: org.eclipse.swt;bundle-version="3.134.0"
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Localization: launcher

--- a/bundles/org.eclipse.equinox.launcher/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.launcher/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.launcher;singleton:=true
-Bundle-Version: 1.7.100.qualifier
+Bundle-Version: 1.7.200.qualifier
 Main-Class: org.eclipse.equinox.launcher.Main
 Require-Bundle: org.eclipse.swt;bundle-version="3.134.0"
 Bundle-Vendor: %providerName

--- a/bundles/org.eclipse.equinox.launcher/src/org/eclipse/equinox/launcher/JNIBridge.java
+++ b/bundles/org.eclipse.equinox.launcher/src/org/eclipse/equinox/launcher/JNIBridge.java
@@ -26,14 +26,6 @@ class JNIBridge {
 
 	private native void _set_launcher_info(String launcher, String name);
 
-	private native void _update_splash();
-
-	private native long _get_splash_handle();
-
-	private native void _show_splash(String bitmap);
-
-	private native void _takedown_splash();
-
 	private native String _get_os_recommended_folder();
 
 	private final String library;
@@ -83,44 +75,6 @@ class JNIBridge {
 		}
 	}
 
-	public boolean showSplash(String bitmap) {
-		try {
-			_show_splash(bitmap);
-			return true;
-		} catch (UnsatisfiedLinkError e) {
-			if (!libraryLoaded) {
-				loadLibrary();
-				return showSplash(bitmap);
-			}
-			return false;
-		}
-	}
-
-	public boolean updateSplash() {
-		try {
-			_update_splash();
-			return true;
-		} catch (UnsatisfiedLinkError e) {
-			if (!libraryLoaded) {
-				loadLibrary();
-				return updateSplash();
-			}
-			return false;
-		}
-	}
-
-	public long getSplashHandle() {
-		try {
-			return _get_splash_handle();
-		} catch (UnsatisfiedLinkError e) {
-			if (!libraryLoaded) {
-				loadLibrary();
-				return getSplashHandle();
-			}
-			return -1;
-		}
-	}
-
 	/**
 	 * Whether or not we loaded the shared library here from java.
 	 * False does not imply the library is not available, it could have
@@ -130,19 +84,6 @@ class JNIBridge {
 	 */
 	boolean isLibraryLoadedByJava() {
 		return libraryLoaded;
-	}
-
-	public boolean takeDownSplash() {
-		try {
-			_takedown_splash();
-			return true;
-		} catch (UnsatisfiedLinkError e) {
-			if (!libraryLoaded) {
-				loadLibrary();
-				return takeDownSplash();
-			}
-			return false;
-		}
 	}
 
 	public String getOSRecommendedFolder() {

--- a/bundles/org.eclipse.equinox.launcher/src/org/eclipse/equinox/launcher/Main.java
+++ b/bundles/org.eclipse.equinox.launcher/src/org/eclipse/equinox/launcher/Main.java
@@ -145,6 +145,7 @@ public class Main {
 	private List<String> extensionPaths = null;
 
 	private JNIBridge bridge = null;
+	private SplashScreen splashScreen = null;
 
 	// splash handling
 	private boolean showSplash = false;
@@ -161,8 +162,8 @@ public class Main {
 
 		//Called reflectively by org.eclipse.core.runtime.internal.adaptor.DefaultStartupMonitor
 		public void updateSplash() {
-			if (bridge != null && !splashDown) {
-				bridge.updateSplash();
+			if (splashScreen != null && !splashDown) {
+				splashScreen.update();
 			}
 		}
 	}
@@ -2017,6 +2018,20 @@ public class Main {
 		return location.openStream();
 	}
 
+	//TODO: Check new doc
+	/*
+	 * To display a splash screen before starting the java vm, the launcher should be started
+	* with the location of the splash bitmap to use:
+	* -showsplash <path/to/splash.bmp>
+	* Otherwise, when the Java program starts, it should determine the location of
+	* the splash bitmap to be used and use the JNI method show_splash.
+	*
+	* When the Java program initialization is complete, the splash window
+	* is brought down by calling the JNI method takedown_splash.
+	*
+	* The Java program can also call the get_splash_handle method to get the handle to the splash
+	* window.  This can be passed to SWT to create SWT widgets in the splash screen.
+	   */
 	/*
 	 * Handle splash screen.
 	 *  The splash screen is displayed natively.  Whether or not the splash screen
@@ -2037,7 +2052,7 @@ public class Main {
 	private void handleSplash() {
 		// run without splash if we are initializing or nosplash
 		// was specified (splashdown = true)
-		if (initialize || splashDown || bridge == null) {
+		if (initialize || splashDown) {
 			showSplash = false;
 			endSplash = null;
 			return;
@@ -2072,14 +2087,14 @@ public class Main {
 		if (splashLocation == null) {
 			return;
 		}
-
-		bridge.setLauncherInfo(System.getProperty(PROP_LAUNCHER), System.getProperty(PROP_LAUNCHER_NAME));
-		bridge.showSplash(splashLocation);
-		long handle = bridge.getSplashHandle();
-		if (handle != 0 && handle != -1) {
-			System.setProperty(SPLASH_HANDLE, String.valueOf(handle));
+		if (bridge != null) {
+			bridge.setLauncherInfo(System.getProperty(PROP_LAUNCHER), System.getProperty(PROP_LAUNCHER_NAME));;
+		}
+		splashScreen = SplashScreen.show(Path.of(splashLocation), configurationLocation, ws + "." + os + "." + arch); //$NON-NLS-1$ //$NON-NLS-2$
+		if (splashScreen != null) {
+			System.setProperty(SPLASH_HANDLE, String.valueOf(splashScreen.getHandle()));
 			System.setProperty(SPLASH_LOCATION, splashLocation);
-			bridge.updateSplash();
+			splashScreen.update();
 		} else {
 			// couldn't show the splash screen for some reason
 			splashDown = true;
@@ -2090,11 +2105,11 @@ public class Main {
 	 * Take down the splash screen.
 	 */
 	private void takeDownSplash() {
-		if (splashDown || bridge == null) { // splash is already down
+		if (splashDown || splashScreen == null) { // splash is already down
 			return;
 		}
 
-		splashDown = bridge.takeDownSplash();
+		splashDown = splashScreen.takeDown();
 		System.clearProperty(SPLASH_HANDLE);
 
 		try {

--- a/bundles/org.eclipse.equinox.launcher/src/org/eclipse/equinox/launcher/SplashScreen.java
+++ b/bundles/org.eclipse.equinox.launcher/src/org/eclipse/equinox/launcher/SplashScreen.java
@@ -1,0 +1,172 @@
+/*******************************************************************************
+ * Copyright (c) 2026, 2026 Hannes Wellmann and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Hannes Wellmann - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.equinox.launcher;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.graphics.Rectangle;
+import org.eclipse.swt.layout.FillLayout;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Shell;
+
+public abstract class SplashScreen {
+
+	public abstract long getHandle();
+
+	public abstract void update();
+
+	public abstract boolean takeDown();
+
+	static SplashScreen show(Path splashLocation, URL configurationLocation, String platformConfiguration) {
+		try {
+			URLClassLoader loader = createSWTClassLoader(configurationLocation, platformConfiguration);
+			if (loader != null) {
+				try (loader) {
+					Class<?> clz = loader.loadClass(SplashScreen.class.getName() + "$SWTSplashLoader"); //$NON-NLS-1$
+					Method load = clz.getDeclaredMethod("load", Path.class); //$NON-NLS-1$
+					SplashScreen splash = (SplashScreen) load.invoke(null, splashLocation);
+					splash.update(); // Update once to ensure everything is loaded
+					return splash;
+				}
+			}
+		} catch (Exception e) {
+			throw new IllegalStateException("Failed to create splash screen", e); //$NON-NLS-1$
+		}
+		return null;
+	}
+
+	private static final Pattern COMMA = Pattern.compile(","); //$NON-NLS-1$
+	private static final String REFERENCE_PREFIX = "reference:"; //$NON-NLS-1$
+
+	//TODO: Explain this construct and its rational here in code
+
+	private static URLClassLoader createSWTClassLoader(URL configurationLocation, String platformConfiguration) throws IOException, URISyntaxException {
+		List<String> swtBundleNames = List.of( //
+				"org.eclipse.swt." + platformConfiguration, //$NON-NLS-1$
+				"org.eclipse.swt.svg"); //$NON-NLS-1$
+
+		List<URL> swtBundles = new ArrayList<>();
+		String osgiBundles = System.getProperty("osgi.bundles"); //$NON-NLS-1$
+		if (osgiBundles != null) {
+			addBundleLocations(swtBundles, COMMA.splitAsStream(osgiBundles) //
+					.filter(b -> swtBundleNames.stream().anyMatch(b::contains)) //
+					.map(b -> b.startsWith(REFERENCE_PREFIX) ? b.substring(REFERENCE_PREFIX.length()) : b));
+
+		}
+		if (swtBundles.isEmpty()) {
+			long start = System.currentTimeMillis();
+			Path bundlesInfo = Path.of(configurationLocation.toURI()).resolve("org.eclipse.equinox.simpleconfigurator/bundles.info"); //$NON-NLS-1$
+			if (Files.isRegularFile(bundlesInfo)) {
+				try (var lines = Files.lines(bundlesInfo)) {
+					List<String> prefixes = swtBundleNames.stream().map(n -> n + ",").toList(); //$NON-NLS-1$
+					addBundleLocations(swtBundles, lines.filter(l -> prefixes.stream().anyMatch(p -> l.startsWith(p))).map(l -> l.split(",")[2])); //$NON-NLS-1$
+				}
+			}
+			System.out.println("Read took: " + (System.currentTimeMillis() - start));
+		}
+		if (swtBundles.isEmpty()) {
+			return null;
+		}
+		swtBundles.add(SplashScreen.class.getProtectionDomain().getCodeSource().getLocation());
+		return new URLClassLoader(swtBundles.toArray(URL[]::new), null) {
+			@Override
+			protected Class<?> findClass(String name) throws ClassNotFoundException {
+				//Ensure the splash-screen class is loaded from the application classloader, but everything that references SWT is loaded from this CL.
+				if (SplashScreen.class.getName().equals(name)) {
+					return SplashScreen.class;
+				}
+				return super.findClass(name);
+			}
+		};
+	}
+
+	static void addBundleLocations(List<URL> swtBundles, Stream<String> map) {
+		map.map(l -> {
+			try {
+				return URI.create(l).toURL();
+			} catch (MalformedURLException e) {
+				throw new IllegalArgumentException(e);
+			}
+		}).forEach(swtBundles::add);
+	}
+
+	public static class SWTSplashLoader {
+
+		public static SplashScreen load(Path imagePath) {
+			//TODO: Run this in a different thread and just interrupt it, when the splash is to take down?
+			Display display = new Display() {
+				@Override
+				protected void checkSubclass() {
+					// Permit sub-classing
+				}
+
+				@Override
+				protected void init() {
+					super.init();
+				}
+			};
+			Shell shell = new Shell(display, SWT.NO_TRIM | SWT.NO_MOVE);
+			shell.setLayout(new FillLayout());
+			Label label = new Label(shell, SWT.NONE);
+			Image image = new Image(display, imagePath.toString());
+			label.setImage(image);
+			shell.pack();
+
+			Rectangle displayBounds = display.getBounds();
+			Rectangle imageBounds = image.getBounds();
+			shell.setLocation(displayBounds.x + (displayBounds.width - imageBounds.width) / 2, displayBounds.y + (displayBounds.height - imageBounds.height) / 2);
+			shell.open();
+
+			return new SplashScreen() {
+				@Override
+				public long getHandle() {
+					//TODO: Check the exact value? The shells handle?
+					return shell.handle;
+				}
+
+				@Override
+				public void update() {
+					if (!shell.isDisposed()) {
+						display.readAndDispatch();
+					}
+				}
+
+				@Override
+				public boolean takeDown() {
+					image.dispose();
+					shell.dispose();
+					// display.dispose(); //TODO: This crashes the application (maybe related to the broken state of main SWT).
+					return true; //TODO: check this somehow?!
+				}
+			};
+		}
+
+	}
+
+}

--- a/features/org.eclipse.equinox.executable.feature/library/cocoa/eclipseCocoa.c
+++ b/features/org.eclipse.equinox.executable.feature/library/cocoa/eclipseCocoa.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -17,8 +17,6 @@
  *    Christian Georgi (SAP SE) - Fix VM path for new file layout (bug 469766)
  */
 
-/* MacOS X Cocoa specific logic for displaying the splash screen. */
-
 #include "eclipseOS.h"
 #include "eclipseCommon.h"
 #include "eclipseJNI.h"
@@ -33,7 +31,6 @@
 #include <mach-o/dyld.h>
 
 #define startupJarName "startup.jar"
-#define SPLASH_LAUNCHER "/Resources/Splash.app/Contents/"
 
 #define DEBUG 0
 
@@ -86,6 +83,8 @@ static NSWindow* window = nil;
 @interface KeyWindow : NSWindow { }
 - (BOOL)canBecomeKeyWindow;
 @end
+
+void dispatchMessages();
 
 @implementation KeyWindow
 - (BOOL)canBecomeKeyWindow {
@@ -253,34 +252,6 @@ int reuseWorkbench(_TCHAR** filePath, int timeout) {
 	return 0;
 }
 
-/* Show the Splash Window
- *
- * Create the splash window, load the bitmap and display the splash window.
- */
-int showSplash( const _TCHAR* featureImage )
-{
-	int result = 0;
-	NSAutoreleasePool* pool = [[NSAutoreleasePool alloc] init];
-	NSString *str = [[NSString stringWithUTF8String: featureImage] retain];
-	if ([NSThread isMainThread]) {
-		result = [KeyWindow show: str];
-	} else {
-		[KeyWindow performSelectorOnMainThread: @selector(show:) withObject: str waitUntilDone: 0];
-	}
-	[pool release];
-	return result;
-}
-
-void takeDownSplash() {
-	NSAutoreleasePool* pool = [[NSAutoreleasePool alloc] init];
-	if ([NSThread isMainThread]) {
-		[KeyWindow shutdown];
-	} else {
-		[KeyWindow performSelectorOnMainThread: @selector(shutdown) withObject: nil waitUntilDone: 0];
-	}
-	[pool release];
-}
-
 void dispatchMessages() {
 	NSAutoreleasePool* pool = [[NSAutoreleasePool alloc] init];
 	if ([NSThread isMainThread]) {
@@ -306,10 +277,6 @@ void installAppleEventHandler() {
 				  andEventID:kAEGetURL];
 //	[appleEventDelegate release];
 	[pool release];
-}
-
-jlong getSplashHandle() {
-	return (jlong)window;
 }
 
 /* Get the window system specific VM arguments */

--- a/features/org.eclipse.equinox.executable.feature/library/eclipse.c
+++ b/features/org.eclipse.equinox.executable.feature/library/eclipse.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -19,21 +19,9 @@
 /* Eclipse Program Launcher
  *
  * This file forms the base of the eclipse_*.dll/so.  This dll is loaded by eclipse.exe
- * to start a Java VM, or alternatively it is loaded from Java to show the splash
- * screen or write to the shared memory.  See eclipseJNI.c for descriptions of the methods
+ * to start a Java VM, or alternatively it is loaded from Java to write to the shared memory.
+ * See eclipseJNI.c for descriptions of the methods
  * exposed to the Java program using JNI.
- *
- * To display a splash screen before starting the java vm, the launcher should be started
- * with the location of the splash bitmap to use:
- * -showsplash <path/to/splash.bmp>
- * Otherwise, when the Java program starts, it should determine the location of
- * the splash bitmap to be used and use the JNI method show_splash.
- *
- * When the Java program initialization is complete, the splash window
- * is brought down by calling the JNI method takedown_splash.
- *
- * The Java program can also call the get_splash_handle method to get the handle to the splash
- * window.  This can be passed to SWT to create SWT widgets in the splash screen.
  *
  * The Java application will receive two other arguments:
  *    -exitdata <shared memory id>
@@ -68,9 +56,7 @@
  *  -os <opSys>                the operating system being run on
  *  -arch <osArch>             the hardware architecture of the OS: x86_64
  *  -ws <gui>                  the window system to be used: win32, gtk, cocoa, ...
- *  -nosplash                  do not display the splash screen. The java application will
- *                             not receive the -showsplash command.
- *  -showsplash <bitmap>	   show the given bitmap in the splash screen.
+ *  -nosplash                  do not display the splash screen.
  *  --launcher.noRestart       disables the restart behavior of exit codes 23 and 24.
  *  -name <name>               application name displayed in error message dialogs and
  *                             splash screen window. Default value is computed from the
@@ -104,7 +90,6 @@
  *     -name <application name>
  * 	   -library <eclipse library location>
  * 	   -startup <startup.jar location>
- *     [-showsplash]
  *     [-exitdata <shared memory id>]
  *     <userArgs>
  *     -vm <javaVM>
@@ -229,9 +214,6 @@ home directory.");
 #define OLD_STARTUP 		_T_ECLIPSE("startup.jar")
 #define CLASSPATH_PREFIX        _T_ECLIPSE("-Djava.class.path=")
 
-/* Splash screen names to look for when -showsplash points to a directory or plugin */
-#define SPLASH_IMAGES _T_ECLIPSE("splash.png\0" "splash.jpg\0" "splash.jpeg\0" "splash.gif\0" "splash.bmp\0" "\0")
-
 /* Define the variables to receive the option values. */
 static int     needConsole   = 0;				/* True: user wants a console	*/
 static int     debug         = 0;				/* True: output debugging info	*/
@@ -240,12 +222,7 @@ static int     noRestart     = 0;				/* True: disables the restart behavior of t
 static int	   suppressErrors = 0;				/* True: do not display errors dialogs */
        int     secondThread  = 0;				/* True: start the VM on a second thread */
 static int     appendVmargs = 0;                /* True: append cmdline vmargs to launcher.ini vmargs */
-#ifdef MACOSX
-static int     skipJava9ParamRemoval		 = 0;		/* Set to true only on macOS, if -vm was present on commandline or in eclipse.ini and points to a shared lib */
-#endif
 
-static _TCHAR*  showSplashArg = NULL;			/* showsplash data (main launcher window) */
-static _TCHAR*  splashBitmap  = NULL;			/* the actual splash bitmap */
 static _TCHAR * startupArg    = NULL;			/* path of the startup.jar the user wants to run relative to the program path */
 static _TCHAR*  vmName        = NULL;     		/* Java VM that the user wants to run */
 static _TCHAR*  name          = NULL;			/* program name */
@@ -277,8 +254,6 @@ typedef struct
 
 /* flags for the Option struct */
 #define VALUE_IS_FLAG 	1   /* value is an int*, if not set, value is a _TCHAR** or _TCHAR*** (VALUE_IS_LIST) */
-#define OPTIONAL_VALUE  2  	/* value is optional, if next arg does not start with '-', */
-							/* don't assign it and only remove (remove - 1) arguments  */
 #define ADJUST_PATH		4  	/* value is a path, do processing on relative paths to try and make them absolute */
 #define VALUE_IS_LIST	8  	/* value is a pointer to a tokenized _TCHAR* string for EE files, or a _TCHAR** list for the command line */
 #define INVERT_FLAG    16   /* invert the meaning of a flag, i.e. reset it */
@@ -287,7 +262,7 @@ static Option options[] = {
     { CONSOLE,		&needConsole,	VALUE_IS_FLAG,	0 },
     { CONSOLELOG,	&needConsole,	VALUE_IS_FLAG,	0 },
     { DEBUG_ARG,	&debug,			VALUE_IS_FLAG,	0 },
-    { NOSPLASH,     &noSplash,      VALUE_IS_FLAG,	1 },
+    { NOSPLASH,     &noSplash,      VALUE_IS_FLAG,	0 },
     { NORESTART,    &noRestart,     VALUE_IS_FLAG,	1 },
     { SUPRESSERRORS, &suppressErrors, VALUE_IS_FLAG, 1},
     { SECOND_THREAD, &secondThread, VALUE_IS_FLAG,  1 },
@@ -297,7 +272,6 @@ static Option options[] = {
     { INI,			&iniFile, 		0,			2 },
     { OS,			&osArg,			0,			2 },
     { OSARCH,		&osArchArg,		0,			2 },
-    { SHOWSPLASH,   &showSplashArg,	OPTIONAL_VALUE,	2 },
     { STARTUP,		&startupArg,	0,			2 },
     { VM,           &vmName,		0,			2 },
     { NAME,         &name,			0,			2 },
@@ -340,7 +314,6 @@ static _TCHAR** parseArgList( _TCHAR *data );
 static _TCHAR*  formatVmCommandMsg( _TCHAR* args[], _TCHAR* vmArgs[], _TCHAR* progArgs[] );
 static _TCHAR*  getDefaultOfficialName();
 static _TCHAR*  findStartupJar();
-static _TCHAR*  findSplash(_TCHAR* splashArg);
 static _TCHAR** getRelaunchCommand( _TCHAR **newLaucherArgs );
 static const _TCHAR* getVMArch();
 static int      _run(int argc, _TCHAR* argv[], _TCHAR* vmArgs[]);
@@ -582,15 +555,6 @@ static int _run(int argc, _TCHAR* argv[], _TCHAR* vmArgs[])
 	}
 #endif
 
-    /* If the showsplash option was given and we are using JNI */
-    if (!noSplash && showSplashArg)
-    {
-    	splashBitmap = findSplash(showSplashArg);
-    	if (splashBitmap != NULL && launchMode == LAUNCH_JNI) {
-	    	showSplash(splashBitmap);
-    	}
-    }
-
     /* not using JNI launching, need some shared data */
     if (launchMode == LAUNCH_EXE && createSharedData( &sharedID, MAX_SHARED_LENGTH )) {
         if (debug) {
@@ -767,7 +731,6 @@ static int _run(int argc, _TCHAR* argv[], _TCHAR* vmArgs[])
     if(launchMode == LAUNCH_JNI) free(cp);
     if(cpValue != NULL)		 	 free(cpValue);
     if(exitData != NULL)		 free(exitData);
-    if(splashBitmap != NULL)  	 free(splashBitmap);
     if(vmArgs != NULL)			 free(vmArgs);
 
     if (javaResults == NULL)
@@ -821,18 +784,14 @@ static void processDefaultAction(int argc, _TCHAR* argv[]) {
  * Parse arguments of the command.
  */
 static void parseArgs(int* pArgc, _TCHAR* argv[]) {
-	Option* option;
-	int remArgs;
 	int index;
-	int i;
-
 	/* For each user defined argument (excluding the program) */
 	for (index = 1; index < *pArgc; index++) {
-		remArgs = 0;
+		int remArgs = 0;
 
 		/* Find the corresponding argument is a option supported by the launcher */
-		option = NULL;
-		for (i = 0; option == NULL && i < optionsSize; i++) {
+		Option* option = NULL;
+		for (int i = 0; i < optionsSize; i++) {
 			if (_tcsicmp(argv[index], options[i].name) == 0) {
 				option = &options[i];
 				break;
@@ -841,7 +800,6 @@ static void parseArgs(int* pArgc, _TCHAR* argv[]) {
 
 		/* If the option is recognized by the launcher */
 		if (option != NULL) {
-			int optional = 0;
 			/* If the option requires a value and there is one, extract the value. */
 			if (option->value != NULL) {
 				if (option->flag & VALUE_IS_FLAG)
@@ -861,7 +819,7 @@ static void parseArgs(int* pArgc, _TCHAR* argv[]) {
 							option->remove = count;
 					}
 
-					for (i = 0; i < count; i++) {
+					for (int i = 0; i < count; i++) {
 						if ((index + i + 1) < *pArgc) {
 							_TCHAR * next = argv[index + i + 1];
 							if (option->flag & ADJUST_PATH)
@@ -871,9 +829,6 @@ static void parseArgs(int* pArgc, _TCHAR* argv[]) {
 									(*((_TCHAR***) option->value))[i] = next;
 								else
 									*((_TCHAR**) option->value) = next;
-							} else if (option->flag & OPTIONAL_VALUE) {
-								/* value was optional, and the next arg starts with '-' */
-								optional = 1;
 							}
 						}
 					}
@@ -881,12 +836,12 @@ static void parseArgs(int* pArgc, _TCHAR* argv[]) {
 			}
 
 			/* If the option requires a flag to be set, set it. */
-			remArgs = option->remove - optional;
+			remArgs = option->remove;
 		}
 
 		/* Remove any matched arguments from the list. */
 		if (remArgs > 0) {
-			for (i = (index + remArgs); i <= *pArgc; i++) {
+			for (int i = (index + remArgs); i <= *pArgc; i++) {
 				argv[i - remArgs] = argv[i];
 			}
 			index--;
@@ -1069,12 +1024,12 @@ static void getVMCommand( int launchMode, int argc, _TCHAR* argv[], _TCHAR **vmA
 	(*vmArgv)[dst] = NULL;
 
 	/* Program arguments */
-    /*  OS <os> + WS <ws> + ARCH <arch> + SHOWSPLASH <cmd> + LAUNCHER <program> + NAME <officialName>
+    /*  OS <os> + WS <ws> + ARCH <arch> + LAUNCHER <program> + NAME <officialName>
      *  + LIBRARY <eclipseLibrary> + STARTUP <jarFile> + PROTECT <protectMode> + APPEND/OVERRIDE + NORESTART
      *  + EXITDATA <sharedId> + argv[] + VM <jniLib/javaVM> + VMARGS + vmArg[] + eeVMarg[] + reqVMarg[]
      *  + NULL)
      */
-    totalProgArgs = 2 + 2 + 2 + 2 + 2 + 2
+    totalProgArgs = 2 + 2 + 2 + 2 + 2
                   + 2 + 2 + 2 + 1 + 1
                   + 2 + argc + 2 + 1 + nVMarg + nEEargs + nReqVMarg
                   + 1;
@@ -1089,14 +1044,6 @@ static void getVMCommand( int launchMode, int argc, _TCHAR* argv[], _TCHAR **vmA
     if (_tcslen(osArchArg) > 0) {
         (*progArgv)[ dst++ ] = OSARCH;
         (*progArgv)[ dst++ ] = osArchArg;
-    }
-
-	/* Append the show splash window command, if defined. */
-    if (!noSplash)
-    {
-        (*progArgv)[ dst++ ] = SHOWSPLASH;
-        if(splashBitmap != NULL)
-        	(*progArgv)[ dst++ ] = splashBitmap;
     }
 
 	/* Append the launcher command */
@@ -1306,86 +1253,6 @@ _TCHAR* getProgramDir( )
     return NULL;
 }
 
-static _TCHAR* findSplash(_TCHAR* splashArg) {
-	struct _stat stats;
-	_TCHAR *ch, *prefix;
-	_TCHAR *path, *dir, *name;
-	size_t length;
-
-	if (splashArg == NULL)
-		return NULL;
-
-	splashArg = _tcsdup(splashArg);
-	length = _tcslen(splashArg);
-	/* _tstat doesn't seem to like dirSeparators on the end */
-	while (length && IS_DIR_SEPARATOR(splashArg[length - 1])) {
-		splashArg[--length] = 0;
-	}
-
-	/* does splashArg exist */
-	if (_tstat(splashArg, &stats) == 0) {
-		/* pointing to a file */
-		if (stats.st_mode & S_IFREG) {
-			/* file, use it*/
-			return splashArg;
-		} else if (stats.st_mode & S_IFDIR) {
-			/*directory, look for splash.bmp*/
-			dir = splashArg;
-			splashArg = NULL;
-		} else {
-			free(splashArg);
-			return NULL;
-		}
-	} else {
-		/* doesn't exist, separate into path & prefix and look for a /path/prefix_<version> */
-		ch = lastDirSeparator( splashArg );
-		if (ch != NULL) {
-			if (IS_ABSOLUTE(splashArg)) {
-				/*absolute path*/
-				path = _tcsdup(splashArg);
-				path[ch - splashArg] = 0;
-			} else {
-				/* relative path, prepend with programDir */
-				path = malloc( (_tcslen(programDir) + ch - splashArg + 2) * sizeof(_TCHAR));
-				*ch = 0;
-				_stprintf(path, _T_ECLIPSE("%s%c%s"), programDir, dirSeparator, splashArg);
-				*ch = dirSeparator;
-			}
-			prefix = ch + 1;
-		} else {
-			/* No separator, treat splashArg as the prefix and look in the plugins dir */
-#ifdef MACOSX
-			path = malloc( (_tcslen(programDir) + 20) * sizeof(_TCHAR));
-			_stprintf(path, _T_ECLIPSE("%s%c%s%s"), programDir, dirSeparator, _T_ECLIPSE("../Eclipse/"), _T_ECLIPSE("plugins"));
-#else
-			path = malloc( (_tcslen(programDir) + 9) * sizeof(_TCHAR));
-			_stprintf(path, _T_ECLIPSE("%s%c%s"), programDir, dirSeparator, _T_ECLIPSE("plugins"));
-#endif
-			prefix = splashArg;
-		}
-		dir = findFile(path, prefix);
-		free(path);
-		free(splashArg);
-		path = prefix = splashArg = NULL;
-	}
-
-	/* directory, look for splash image */
-	if (dir != NULL) {
-		length = _tcslen(dir);
-		for (name = SPLASH_IMAGES; *name; name += _tcslen(name) + 1) {
-			ch = malloc((length + 1 + _tcslen(name) + 1) * sizeof(_TCHAR));
-			_stprintf(ch, _T_ECLIPSE("%s%c%s"), dir, dirSeparator, name);
-			if (_tstat(ch, &stats) == 0 && (stats.st_mode & S_IFREG)) {
-				free(dir);
-				return ch;
-			}
-			free(ch);
-		}
-		free(dir);
-	}
-	return NULL;
-}
-
 static _TCHAR* findStartupJar(){
 	_TCHAR * file, *ch;
 	_TCHAR * pluginsPath;
@@ -1518,12 +1385,7 @@ static _TCHAR ** getRelaunchCommand( _TCHAR **newLaucherArgs  )
 
 	// Step 4. Add new non-vmargs launch arguments which will get precedence over old arguments
 	for (int i = 0; newLaucherArgs[i] != NULL && i != (newVmargsStart - 1); i++){
-		if (_tcsicmp(newLaucherArgs[i], SHOWSPLASH) == 0) {
-			/* remove if the next argument is not the bitmap to show */
-			if(newLaucherArgs[i + 1] != NULL && newLaucherArgs[i + 1][0] == _T_ECLIPSE('-')) {
-				continue;
-			}
-		} else if(_tcsncmp(newLaucherArgs[i], CLASSPATH_PREFIX, _tcslen(CLASSPATH_PREFIX)) == 0) {
+		if(_tcsncmp(newLaucherArgs[i], CLASSPATH_PREFIX, _tcslen(CLASSPATH_PREFIX)) == 0) {
 			/* skip -Djava.class.path=... */
 			continue;
 		} else if(_tcscmp(newLaucherArgs[i], EXITDATA) == 0) {
@@ -1712,9 +1574,6 @@ static int determineVM(_TCHAR** msg) {
     		return vmEEProps(vmName, msg);
 
     	case VM_LIBRARY:
-#ifdef MACOSX
-    		skipJava9ParamRemoval = 1;
-#endif
     		ch = findCommand(vmName);
     		if(ch != NULL) {
     			jniLib = findVMLibrary(ch);

--- a/features/org.eclipse.equinox.executable.feature/library/eclipseCommon.h
+++ b/features/org.eclipse.equinox.executable.feature/library/eclipseCommon.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2025 IBM Corporation and others.
+ * Copyright (c) 2006, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -72,6 +72,7 @@
 #define MAX_PATH_LENGTH   2000
 
 #ifdef UNICODE
+//TODO: this case seems unused?
 #define run runW
 #define setInitialArgs setInitialArgsW
 #define RUN_METHOD		 _T_ECLIPSE("runW")

--- a/features/org.eclipse.equinox.executable.feature/library/eclipseJNI.c
+++ b/features/org.eclipse.equinox.executable.feature/library/eclipseJNI.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2009 IBM Corporation and others.
+ * Copyright (c) 2006, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -28,12 +28,9 @@ static _TCHAR* failedCreateVM = _T_ECLIPSE("Failed to create the Java Virtual Ma
 static _TCHAR* internalExpectedVMArgs = _T_ECLIPSE("Internal Error, the JVM argument list is empty.\n");
 static _TCHAR* mainClassNotFound = _T_ECLIPSE("Failed to find a Main Class in \"%s\".\n");
 
-static JNINativeMethod natives[] = {{"_update_splash", "()V", (void *)&update_splash},
-									{"_get_splash_handle", "()J", (void *)&get_splash_handle},
+static JNINativeMethod natives[] = {
 									{"_set_exit_data", "(Ljava/lang/String;Ljava/lang/String;)V", (void *)&set_exit_data},
 									{"_set_launcher_info", "(Ljava/lang/String;Ljava/lang/String;)V", (void *)&set_launcher_info},
-									{"_show_splash", "(Ljava/lang/String;)V", (void *)&show_splash},
-									{"_takedown_splash", "()V", (void *)&takedown_splash},
 									{"_get_os_recommended_folder", "()Ljava/lang/String;", (void *)&get_os_recommended_folder}};
 
 /* local methods */
@@ -43,7 +40,6 @@ static int shouldShutdown(JNIEnv *env);
 static void JNI_ReleaseStringChars(JNIEnv *env, jstring s, const _TCHAR* data);
 static const _TCHAR* JNI_GetStringChars(JNIEnv *env, jstring str);
 static char * getMainClass(JNIEnv *env, _TCHAR * jarFile);
-static void setLibraryLocation(JNIEnv *env, jobject obj);
 
 static JavaVM * jvm = 0;
 static JNIEnv *env = 0;
@@ -108,66 +104,12 @@ JNIEXPORT void JNICALL set_launcher_info(JNIEnv * env, jobject obj, jstring laun
 	}
 }
 
-
-JNIEXPORT void JNICALL update_splash(JNIEnv * env, jobject obj){
-	dispatchMessages();
-}
-
-JNIEXPORT jlong JNICALL get_splash_handle(JNIEnv * env, jobject obj){
-	return getSplashHandle();
-}
-
-JNIEXPORT void JNICALL show_splash(JNIEnv * env, jobject obj, jstring s){
-	const _TCHAR* data = NULL;
-	
-	setLibraryLocation(env, obj);
-	
-	if(s != NULL) {
-		data = JNI_GetStringChars(env, s);
-		if(data != NULL) {
-			showSplash(data);
-			JNI_ReleaseStringChars(env, s, data);
-		} else {
-			(*env)->ExceptionDescribe(env);
-			(*env)->ExceptionClear(env);
-		}
-	}
-}
-
-JNIEXPORT void JNICALL takedown_splash(JNIEnv * env, jobject obj){
-	takeDownSplash();
-}
-
 JNIEXPORT jstring JNICALL get_os_recommended_folder(JNIEnv * env, jobject obj){
 #ifdef MACOSX
 	return newJavaString(env, getFolderForApplicationData());
 #else
 	return NULL;
 #endif
-}
-
-/*
- * On AIX we need the location of the eclipse shared library so that we
- * can find the libeclipse-motif.so library.  Reach into the JNIBridge
- * object to get the "library" field.
- */
-static void setLibraryLocation(JNIEnv * env, jobject obj) {
-	jclass bridge = (*env)->FindClass(env, "org/eclipse/equinox/launcher/JNIBridge");
-	if (bridge != NULL) {
-		jfieldID libraryField = (*env)->GetFieldID(env, bridge, "library", "Ljava/lang/String;");
-		if (libraryField != NULL) {
-			jstring stringObject = (jstring) (*env)->GetObjectField(env, obj, libraryField);
-			if (stringObject != NULL) {
-				const _TCHAR * str = JNI_GetStringChars(env, stringObject);
-				eclipseLibrary = _tcsdup(str);
-				JNI_ReleaseStringChars(env, stringObject, str);
-			}
-		}
-	}
-	if( (*env)->ExceptionOccurred(env) != 0 ){
-		(*env)->ExceptionDescribe(env);
-		(*env)->ExceptionClear(env);
-	}
 }
 
 static void registerNatives(JNIEnv *env) {

--- a/features/org.eclipse.equinox.executable.feature/library/eclipseJNI.h
+++ b/features/org.eclipse.equinox.executable.feature/library/eclipseJNI.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2009 IBM Corporation and others.
+ * Copyright (c) 2006, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -29,10 +29,6 @@ typedef jint (JNICALL *JNI_createJavaVM)(JavaVM **pvm, JNIEnv **env, void *args)
 /* Use name mangling since we may be linking these from java with System.LoadLibrary */
 #define set_exit_data 		Java_org_eclipse_equinox_launcher_JNIBridge__1set_1exit_1data
 #define set_launcher_info	Java_org_eclipse_equinox_launcher_JNIBridge__1set_1launcher_1info
-#define update_splash 		Java_org_eclipse_equinox_launcher_JNIBridge__1update_1splash
-#define show_splash			Java_org_eclipse_equinox_launcher_JNIBridge__1show_1splash
-#define get_splash_handle 	Java_org_eclipse_equinox_launcher_JNIBridge__1get_1splash_1handle
-#define takedown_splash 	Java_org_eclipse_equinox_launcher_JNIBridge__1takedown_1splash
 #define get_os_recommended_folder 	    Java_org_eclipse_equinox_launcher_JNIBridge__1get_1os_1recommended_1folder
 
 #ifdef __cplusplus
@@ -49,30 +45,6 @@ JNIEXPORT void JNICALL set_exit_data(JNIEnv *, jobject, jstring, jstring);
  * Signature: (Ljava/lang/String;Ljava/lang/String;)V
  */
 JNIEXPORT void JNICALL set_launcher_info(JNIEnv *, jobject, jstring, jstring);
-
-/*
- * org_eclipse_equinox_launcher_JNIBridge#_update_splash
- * Signature: ()V
- */
-JNIEXPORT void JNICALL update_splash(JNIEnv *, jobject);
-
-/*
- * org_eclipse_equinox_launcher_JNIBridge#_get_splash_handle
- * Signature: ()J
- */
-JNIEXPORT jlong JNICALL get_splash_handle(JNIEnv *, jobject);
-
-/*
- * org_eclipse_equinox_launcher_JNIBridge#_show_splash
- * Signature: (Ljava/lang/String;)V
- */
-JNIEXPORT void JNICALL show_splash(JNIEnv *, jobject, jstring);
-
-/*
- * org_eclipse_equinox_launcher_JNIBridge#_takedown_splash
- * Signature: ()V
- */
-JNIEXPORT void JNICALL takedown_splash(JNIEnv *, jobject);
 
 /*
  * org_eclipse_equinox_launcher_JNIBridge#_get_os_recommended_folder

--- a/features/org.eclipse.equinox.executable.feature/library/eclipseOS.h
+++ b/features/org.eclipse.equinox.executable.feature/library/eclipseOS.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -62,27 +62,6 @@ extern void displayMessage( _TCHAR* title, _TCHAR* message );
 extern int initWindowSystem( int* argc, _TCHAR* argv[] );
 
 
-/** Show the Splash Window
- *
- * This method is called to display the actual splash window. It will only
- * be called by the splash window process and not the main launcher process.
- * The splash ID passed corresponds to the string returned from initWindowSystem().
- * If possible, this ID should be used to communicate some piece of data back
- * to the main launcher program for two reasons:
- * 1) to detect when the splash window process terminates
- * 2) to terminate the splash window process should the JVM terminate before it
- *    completes its initialization.
- *
- * Two parameters are passed: the install home directory and a specific bitmap image
- * file for a feature. The feature's image file is tried first and if it cannot be
- * displayed, the images from the install directory are used.
- *
- * Return (exit code):
- * 0        - success
- * non-zero - could not find a splash image to display
- */
-extern int showSplash( const _TCHAR* featureImage );
-
 /** Get List of Java VM Arguments
  *
  * A given Java VM might require a special set of arguments in order to
@@ -93,12 +72,6 @@ extern _TCHAR** getArgVM( _TCHAR *vm );
 
 /* Find the vm shared library associated with the given java executable */
 extern _TCHAR * findVMLibrary( _TCHAR * command );
-
-extern void dispatchMessages();
-
-extern jlong getSplashHandle();
-
-extern void takeDownSplash();
 
 extern void restartLauncher( _TCHAR* program, _TCHAR* args[] );
 

--- a/features/org.eclipse.equinox.executable.feature/library/eclipseUtil.c
+++ b/features/org.eclipse.equinox.executable.feature/library/eclipseUtil.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -32,38 +32,6 @@
 #endif
 
 #include "eclipse-memcpy.h"
-
-#define MAX_LINE_LENGTH 256
-
-/* Is the given VM J9 */
-int isJ9VM( _TCHAR* vm )
-{
-	_TCHAR * ch = NULL, *ch2 = NULL;
-	int res = 0;
-	
-	if (vm == NULL)
-		return 0;
-	
-	ch = lastDirSeparator( vm );
-	if (isVMLibrary(vm)) {
-		/* a library, call it j9 if the parent dir is j9vm */
-		if(ch == NULL)
-			return 0;
-		ch[0] = 0;
-		ch2 = lastDirSeparator(vm);
-		if(ch2 != NULL) {
-			res = (_tcsicmp(ch2 + 1, _T_ECLIPSE("j9vm")) == 0);
-		}
-		ch[0] = dirSeparator;
-		return res;
-	} else {
-		if (ch == NULL)
-		    ch = vm;
-		else
-		    ch++;
-		return (_tcsicmp( ch, _T_ECLIPSE("j9") ) == 0);
-	}
-}
 
 int checkProvidedVMType( _TCHAR* vm ) 
 {

--- a/features/org.eclipse.equinox.executable.feature/library/eclipseUtil.h
+++ b/features/org.eclipse.equinox.executable.feature/library/eclipseUtil.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -25,9 +25,6 @@
 #define VM_EE_PROPS		4		/* it is a vm .ee properties file */
 
 /* Eclipse Launcher Utility Methods */
-
-/* Is the given Java VM J9 */
-extern int isJ9VM( _TCHAR* vm );
 
 /* Is the given file a shared library? */
 extern int isVMLibrary( _TCHAR* vm );

--- a/features/org.eclipse.equinox.executable.feature/library/gtk/eclipseGtk.c
+++ b/features/org.eclipse.equinox.executable.feature/library/gtk/eclipseGtk.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -45,7 +45,6 @@ static char*  argVM_JAVA[]        = { NULL };
 
 
 /* Define local variables . */
-static GtkWidget*	splashHandle = 0;
 static GtkWidget*   shellHandle = 0;
 
 static _TCHAR** openFilePath = NULL; /* the files we want to open */
@@ -247,101 +246,14 @@ float scaleFactor () {
 	return scaleFactor;
 }
 
-/* Create and Display the Splash Window */
-int showSplash( const char* featureImage ) {
-	GtkWidget *image;
-	GdkPixbuf *pixbuf, *scaledPixbuf;
-	int width, height;
-	float scalingFactor;
-
-	if (splashHandle != 0)
-		return 0; /* already showing splash */
-	if (featureImage == NULL)
-		return -1;
-	
-	if (initialArgv == NULL)
-		initialArgc = 0;
-	
-	if( initWindowSystem(&initialArgc, initialArgv) != 0)
-		return -1;
-	if (!isGtk4()) {
-		shellHandle = gtk.gtk_window_new(GTK_WINDOW_TOPLEVEL);
-		gtk.gtk_window_set_type_hint((GtkWindow*)(shellHandle), 4 /*GDK_WINDOW_TYPE_HINT_SPLASHSCREEN*/);
-		gtk.gtk_window_set_position((GtkWindow*)(shellHandle), GTK_WIN_POS_CENTER);
-		gtk.g_signal_connect_data((gpointer)shellHandle, "destroy", (GCallback)(gtk.gtk_widget_destroyed), &shellHandle, NULL, 0);
-	} else {
-		void *gtkLib = dlopen(GTK4_LIB, RTLD_LAZY);
-		GtkWidget * (*func)();
-		*(void**) (&func) = dlsym(gtkLib, "gtk_window_new");
-		if (dlerror() == NULL && func) {
-			shellHandle = (*func)();
-		} else {
-			printf(dlerror());
-		}
-	}
-	gtk.gtk_window_set_decorated((GtkWindow*)(shellHandle), FALSE);
-		
-	pixbuf = gtk.gdk_pixbuf_new_from_file(featureImage, NULL);
-	width = gtk.gdk_pixbuf_get_width(pixbuf);
-	height = gtk.gdk_pixbuf_get_height(pixbuf);
-	scalingFactor = scaleFactor();
-
-	if (scalingFactor > 1) {
-		scaledPixbuf = gtk.gdk_pixbuf_scale_simple(pixbuf, width * scalingFactor, height * scalingFactor, GDK_INTERP_BILINEAR);
-	} else {
-		scaledPixbuf = pixbuf;
-	}
-	if (!isGtk4()) {
-		image = gtk.gtk_image_new_from_pixbuf(scaledPixbuf);
-	} else {
-		image = gtk.gtk_picture_new_for_pixbuf(scaledPixbuf);
-	}
-	if (pixbuf) 	{
-		gtk.g_object_unref(pixbuf);
-	}
-	if (getOfficialName() != NULL)
-		gtk.gtk_window_set_title((GtkWindow*) shellHandle, getOfficialName());
-
-	if (!isGtk4()) {
-		gtk.gtk_container_add((GtkContainer*) shellHandle, image);
-		gtk.gtk_window_resize((GtkWindow*) shellHandle, gtk.gdk_pixbuf_get_width(scaledPixbuf), gtk.gdk_pixbuf_get_height(scaledPixbuf));
-		gtk.gtk_widget_show_all((GtkWidget*) shellHandle);
-	} else {
-		gtk.gtk_window_set_child((GtkWindow*) shellHandle, image);
-		gtk.gtk_window_present((GtkWindow*) shellHandle);
-	}
-	splashHandle = shellHandle;
-	dispatchMessages();
-	return 0;
-}
-
 void dispatchMessages() {
 	if (gtk.g_main_context_iteration != 0)
 		while(gtk.g_main_context_iteration(0,0) != 0) {}
 }
 
-jlong getSplashHandle() {
-	return (jlong) splashHandle;
-}
-
-void takeDownSplash() {
-	if(shellHandle != 0) {
-		if (!isGtk4()) {
-			gtk.gtk_widget_destroy(shellHandle);
-		}
-		dispatchMessages();
-		splashHandle = 0;
-		shellHandle = NULL;
-	}
-}
-
 /* Get the window system specific VM arguments */
 char** getArgVM( char* vm ) {
     char** result;
-
-/*    if (isJ9VM( vm )) 
-        return argVM_J9;*/
-    
     /* Use the default arguments for a standard Java VM */
     result = argVM_JAVA;
     return result;

--- a/features/org.eclipse.equinox.executable.feature/library/win32/eclipseWin.c
+++ b/features/org.eclipse.equinox.executable.feature/library/win32/eclipseWin.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -52,17 +52,6 @@ static _TCHAR**	openFilePath;
 
 /* Define the window system arguments for the Java VM. */
 static _TCHAR*  argVM[] = { NULL };
-
-/* Define the SWT auto-scale setting for the splash screen. */
-enum {
-	AUTOSCALE_DEFAULT = -1,
-	AUTOSCALE_FALSE = -2,
-	AUTOSCALE_QUARTER = -3,
-	AUTOSCALE_EXACT = -4,
-	AUTOSCALE_INTEGER = -5
-	/* positive values indicate a literal percentage */
-};
-static int autoScaleValue = AUTOSCALE_DEFAULT;
 
 /* Define local variables for running the JVM and detecting its exit. */
 static HANDLE  jvmProcess     = 0;
@@ -204,198 +193,6 @@ int reuseWorkbench(_TCHAR** filePath, int timeout) {
 		SetTimer( topWindow, findWindowTimerId, findWindowTimeout, findWindowProc );
 	
 	return 0;
-}
-
-HBITMAP loadImage(LPCWSTR pszFilename, int targetDpi) {
-	HRESULT hr = S_OK;
-	HBITMAP hBitmap = NULL;
-	IWICImagingFactory *pFactory = NULL;
-	IWICBitmapDecoder *pDecoder = NULL;
-	IWICBitmapFrameDecode *pFrame = NULL;
-	IWICFormatConverter *pConverter = NULL;
-	IWICBitmapScaler *pScaler = NULL;
-	IWICBitmapSource *pSource = NULL; /* borrowed, don't deref */
-
-	hr = CoInitializeEx(NULL, COINIT_APARTMENTTHREADED);
-	if (FAILED(hr)) return NULL;
-	hr = CoCreateInstance(&CLSID_WICImagingFactory, NULL, CLSCTX_INPROC_SERVER, &IID_IWICImagingFactory, &pFactory);
-	if (FAILED(hr)) goto done;
-
-	hr = IWICImagingFactory_CreateDecoderFromFilename(pFactory, pszFilename, NULL, GENERIC_READ, WICDecodeMetadataCacheOnDemand, &pDecoder);
-	if (FAILED(hr)) goto done;
-	hr = IWICBitmapDecoder_GetFrame(pDecoder, 0, &pFrame);
-	if (FAILED(hr)) goto done;
-	pSource = (IWICBitmapSource *)pFrame;
-
-	/* Scale the image to the targetDpi, assuming that the source is always 96 dpi. */
-	UINT uiWidth = 0, uiHeight = 0;
-	hr = IWICBitmapSource_GetSize(pFrame, &uiWidth, &uiHeight);
-	if (FAILED(hr)) goto done;
-	if (targetDpi != 96) {
-		uiWidth = uiWidth * targetDpi / 96;
-		uiHeight = uiHeight * targetDpi / 96;
-		hr = IWICImagingFactory_CreateBitmapScaler(pFactory, &pScaler);
-		if (FAILED(hr)) goto done;
-		hr = IWICBitmapScaler_Initialize(pScaler, pSource, uiWidth, uiHeight, WICBitmapInterpolationModeCubic);
-		if (FAILED(hr)) goto done;
-		pSource = (IWICBitmapSource *)pScaler;
-	}
-
-	/* Convert the image to the 24-bit BGR format. */
-	WICPixelFormatGUID format;
-	hr = IWICBitmapSource_GetPixelFormat(pSource, &format);
-	if (FAILED(hr)) goto done;
-	if (!IsEqualGUID(&format, &GUID_WICPixelFormat24bppBGR)) {
-		hr = IWICImagingFactory_CreateFormatConverter(pFactory, &pConverter);
-		if (FAILED(hr)) goto done;
-		hr = IWICFormatConverter_Initialize(pConverter, pSource, &GUID_WICPixelFormat24bppBGR, WICBitmapDitherTypeNone, NULL, 0., WICBitmapPaletteTypeCustom);
-		if (FAILED(hr)) goto done;
-		pSource = (IWICBitmapSource *)pConverter;
-	}
-
-	/* Create a DIB and initialize it from the WIC source. */
-	BITMAPINFO bmi = {{
-		.biSize = sizeof(BITMAPINFOHEADER),
-		.biWidth = (LONG)uiWidth,
-		.biHeight = -(LONG)uiHeight,
-		.biPlanes = 1,
-		.biBitCount = 24,
-		.biCompression = BI_RGB,
-	}};
-	UINT uiStride = (uiWidth * 3 + 3) & ~3; /* rounded up to a multiple of 4 */
-	PVOID pvBits = NULL;
-	hBitmap = CreateDIBSection(NULL, &bmi, DIB_RGB_COLORS, &pvBits, NULL, 0);
-	if (!hBitmap) goto done;
-	hr = IWICBitmapSource_CopyPixels(pSource, NULL, uiStride, uiStride * uiHeight, pvBits);
-	if (FAILED(hr)) {
-		DeleteObject(hBitmap);
-		hBitmap = NULL;
-	}
-
-done:
-	if (pScaler) IUnknown_Release(pScaler);
-	if (pConverter) IUnknown_Release(pConverter);
-	if (pFrame) IUnknown_Release(pFrame);
-	if (pDecoder) IUnknown_Release(pDecoder);
-	if (pFactory) IUnknown_Release(pFactory);
-	CoUninitialize();
-	return hBitmap;
-}
-
-/* Show the Splash Window
- *
- * Open the bitmap, insert into the splash window and display it.
- *
- */
-int showSplash( const _TCHAR* featureImage )
-{
-	static int splashing = 0;
-    HBITMAP hBitmap = 0;
-    BITMAP  bmp;
-    HDC     hDC;
-    int     x, y;
-    int     width, height;
-    int     dpiX;
-
-	if(splashing) {
-		/*splash screen is already showing, do nothing */
-		return 0;
-	}
-	if (featureImage == NULL)
-		return -1;
-	
-	/* if Java was started first and is calling back to show the splash, we might not
-	 * have initialized the window system yet
-	 */
-	initWindowSystem(0, NULL);
-	
-    /* fetch screen DPI and round it according to the swt.autoScale setting, 
-    this implementation needs to be kept in sync with org.eclipse.swt.internal.DPIUtil#setDeviceZoom(int) */
-    hDC = GetDC( NULL);
-	dpiX = GetDeviceCaps ( hDC, LOGPIXELSX );
-	ReleaseDC(NULL, hDC);
-	switch (autoScaleValue) {
-		case AUTOSCALE_FALSE:
-			dpiX = 96;
-			break;
-		case AUTOSCALE_DEFAULT:
-		case AUTOSCALE_QUARTER:
-			dpiX = ((dpiX + 12) / 24) * 24;
-			break;
-		case AUTOSCALE_EXACT:
-			break;
-		case AUTOSCALE_INTEGER:
-			dpiX = ((int)((dpiX + 24) / 96 )) * 96;
-			break;
-		default:
-			dpiX = (96 * autoScaleValue + 50) / 100;
-			break;
-	}
-
-	/* Load the bitmap for the feature. */
-	if (featureImage != NULL)
-		hBitmap = loadImage(featureImage, dpiX);
-
-    /* If the bitmap could not be found, return an error. */
-    if (hBitmap == 0)
-    	return ERROR_FILE_NOT_FOUND;
-    
-	GetObject(hBitmap, sizeof(BITMAP), &bmp);
-
-    /* figure out position */
-    width = GetSystemMetrics (SM_CXSCREEN);
-    height = GetSystemMetrics (SM_CYSCREEN);
-    x = (width - bmp.bmWidth) / 2;
-    y = (height - bmp.bmHeight) / 2;
-
-	/* Centre the splash window and display it. */
-    SetWindowPos (topWindow, 0, x, y, bmp.bmWidth, bmp.bmHeight, SWP_NOZORDER | SWP_NOSIZE | SWP_NOACTIVATE);
-    SendMessage( topWindow, STM_SETIMAGE, IMAGE_BITMAP, (LPARAM) hBitmap );
-    ShowWindow( topWindow, SW_SHOW );
-    BringWindowToTop( topWindow );
-	splashing = 1;
-	
-    /* Process messages */
-	dispatchMessages();
-	return 0;
-}
-
-void dispatchMessages() {
-	MSG     msg;
-	
-	if(topWindow == 0)
-		return;
-	while (PeekMessage( &msg, NULL, 0, 0, PM_REMOVE))
-   	{
-		TranslateMessage( &msg );
-		DispatchMessage( &msg );
-	}
-}
-
-jlong getSplashHandle() {
-	return (jlong)topWindow;
-}
-
-void takeDownSplash() {
-	HWND window = NULL;
-	if(topWindow != NULL) {
-		if (mutex != NULL) {
-			KillTimer(topWindow, findWindowTimerId);
-
-			window = findSWTMessageWindow();
-			if (window != NULL) {
-				sendOpenFileMessage(window);
-			}
-
-			ReleaseMutex(mutex);
-			CloseHandle(mutex);
-			mutex = 0;
-		}
-
-		DestroyWindow(topWindow);
-		dispatchMessages();
-		topWindow = 0;
-	}
 }
 
 /* Get the window system specific VM args */
@@ -697,44 +494,7 @@ static void CALLBACK detectJvmExit( HWND hwnd, UINT uMsg, UINT id, DWORD dwTime 
 }
 
 void processVMArgs(_TCHAR **vmargs[] ) {
-	_TCHAR** arg;
-	for (arg = *vmargs; *arg != NULL; arg++) {
-		// see org.eclipse.swt.internal.DPIUtil.getZoomForAutoscaleProperty()
-		if (_tcsncmp(*arg, _T("-Dswt.autoScale.updateOnRuntime="), 32) == 0) {
-			_TCHAR* value = *arg + 32;
-			if (_tcsicmp(value, _T("false")) == 0) {
-				/* when monitor-specific scaling is disabled, default is "integer" */
-				autoScaleValue = AUTOSCALE_INTEGER;
-			}
-		}
-		if (_tcsncmp(*arg, _T("-Dswt.autoScale="), 16) == 0) {
-			_TCHAR* value = *arg + 16;
-			if (_tcsicmp(value, _T("false")) == 0) {
-				autoScaleValue = AUTOSCALE_FALSE;
-			}
-			else if (_tcsicmp(value, _T("quarter")) == 0) {
-				autoScaleValue = AUTOSCALE_QUARTER;
-			}
-			else if (_tcsicmp(value, _T("exact")) == 0) {
-				autoScaleValue = AUTOSCALE_EXACT;
-			}
-			else if (_tcsicmp(value, _T("integer")) == 0) {
-				autoScaleValue = AUTOSCALE_INTEGER;
-			}
-			else {
-				_TCHAR* end = NULL;
-				autoScaleValue = (int)_tcstol(value, &end, 10);
-				if (end == NULL || *end != _T('\0')) {
-					/* conversion error, reset to default */
-					autoScaleValue = AUTOSCALE_DEFAULT;
-				}
-				else {
-					if (autoScaleValue < 25) autoScaleValue = 25;
-					else if (autoScaleValue > 1600) autoScaleValue = 1600;
-				}
-			}
-		}
-	}
+	/* nothing yet */
 }
 
 JavaResults* startJavaVM( _TCHAR* libPath, _TCHAR* vmArgs[], _TCHAR* progArgs[], _TCHAR* jarFile )

--- a/features/org.eclipse.equinox.executable.feature/library/win32/eclipseWinCommon.c
+++ b/features/org.eclipse.equinox.executable.feature/library/win32/eclipseWinCommon.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2025 IBM Corporation and others.
+ * Copyright (c) 2006, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -44,8 +44,6 @@ void displayMessage( _TCHAR* title, _TCHAR* message )
 /* Initialize Window System
  *
  * Create a pop window to display the bitmap image.
- *
- * Return the window handle as the data for the splash command.
  *
  */
 int initWindowSystem( int* pArgc, _TCHAR* argv[] )


### PR DESCRIPTION
Create the splash-screen immediately at application start-up using standalone SWT within the Equinox launcher, which is effectively a plain Java application with flat classpath.
The SWT jars are obtained from the to be launched OSGi runtime but are loaded in this preliminary phase using a flat-classpath.

Fixes
- https://github.com/eclipse-equinox/equinox/issues/1278

This is currently a draft because, although showing the splash-screen works as desired, the launched application has a severely broken UI, at least under Windows. But at least it launches...
It's probably an interference of the `Display` created within the launcher and the display created within the OSGi runtime. E.g. disposing the launchers display, crashes the entire application and just creating the display without using it further causes the UI break. But I have high hopes that this can be fixed eventually.

It would be interesting for me how the situation is under Linux and macOS.
If anybody who has these OS at hand could check this out and just launch an Eclipse application containing e.g. the `o.e.sdk` it would be interesting if the application starts at all and what the state of the UI is.