### PR TITLE
Remove unnecessary single quotes for links

### DIFF
--- a/bundles/org.eclipse.equinox.security.ui/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.security.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.security.ui;singleton:=true
-Bundle-Version: 1.4.700.qualifier
+Bundle-Version: 1.4.800.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Import-Package: javax.crypto.spec,

--- a/bundles/org.eclipse.equinox.security.ui/src/org/eclipse/equinox/internal/security/ui/SecurityUIMsg.properties
+++ b/bundles/org.eclipse.equinox.security.ui/src/org/eclipse/equinox/internal/security/ui/SecurityUIMsg.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2007, 2008 IBM Corporation and others.
+# Copyright (c) 2007, 2026 IBM Corporation and others.
 #
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
@@ -47,10 +47,10 @@ WIZARD_ERROR_NO_WRITE_ENGINE = There is no a writable trust engine!
 STR_CERT_VIEWER_FIELD=Field
 STR_CERT_VIEWER_VALUE=Value
 
-CATPAGE_LABEL_STORAGE = See <a>''{0}''</a> for settings related to the encrypted storage system.
-CATPAGE_LABEL_POLICY = See <a>''{0}''</a> to manage policy settings applied to plug-ins.
-CATPAGE_LABEL_CERTIFICATES = See <a>''{0}''</a> to manage security certificates.
-CATPAGE_LABEL_ADVANCED = See <a>''{0}''</a> to view advanced security configuration.
+CATPAGE_LABEL_STORAGE = See <a>{0}</a> for settings related to the encrypted storage system.
+CATPAGE_LABEL_POLICY = See <a>{0}</a> to manage policy settings applied to plug-ins.
+CATPAGE_LABEL_CERTIFICATES = See <a>{0}</a> to manage security certificates.
+CATPAGE_LABEL_ADVANCED = See <a>{0}</a> to view advanced security configuration.
 
 POLPAGE_LABEL_DESC = Allow plug-in code to load when
 POLPAGE_BUTTON_ALLOW_ANY = Signed or unsigned


### PR DESCRIPTION
This change removes the unnecessary quotes around `Secure Storage` in the properties strings.

The single quotes around the placeholder text in the preference page were likely added following older UI conventions. Quotes often differentiate literal text or placeholders from the rest of the message. Since the text already appears as a blue clickable link, the additional quotes are unnecessary. Removing them keeps the link still clickable while making the message cleaner and consistent with other preference links across the UI, where such quotes are not used.
The PR changes the link like other links provided in other areas in Preference page like `File Associations`.
As an example -> 
<img width="925" height="491" alt="image" src="https://github.com/user-attachments/assets/e1d57346-b3d6-40b3-85bd-5dde65fea48f" />


Before pr
<img width="842" height="608" alt="image" src="https://github.com/user-attachments/assets/7d6d0fcf-ddfa-49d3-8840-edd7ac8a9e63" />

After pr
<img width="750" height="555" alt="image" src="https://github.com/user-attachments/assets/9a24c572-fc54-4b9b-9eee-8dc66227fd05" />
