### PR TITLE
disable external DTD loading in DOM parser factory

### DIFF
--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/framework/XMLParsingServiceFactory.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/framework/XMLParsingServiceFactory.java
@@ -78,9 +78,10 @@ class XMLParsingServiceFactory implements ServiceFactory<Object> {
 		}
 		DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
 		try {
-			// completely disable external entities declarations:
+			// completely disable external entity declarations and external DTD loading:
 			factory.setFeature("http://xml.org/sax/features/external-general-entities", false); //$NON-NLS-1$
 			factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false); //$NON-NLS-1$
+			factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false); //$NON-NLS-1$
 		} catch (ParserConfigurationException e) {
 			throw new IllegalStateException(e.getMessage(), e);
 		}

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/framework/XMLParsingServiceFactory.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/framework/XMLParsingServiceFactory.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.osgi.internal.framework;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParserFactory;
@@ -71,6 +72,8 @@ class XMLParsingServiceFactory implements ServiceFactory<Object> {
 				factory.setFeature("http://xml.org/sax/features/external-general-entities", false); //$NON-NLS-1$
 				factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false); //$NON-NLS-1$
 				factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false); //$NON-NLS-1$
+				// enable secure processing:
+				factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
 			} catch (Exception e) {
 				throw new IllegalStateException(e);
 			}
@@ -82,6 +85,8 @@ class XMLParsingServiceFactory implements ServiceFactory<Object> {
 			factory.setFeature("http://xml.org/sax/features/external-general-entities", false); //$NON-NLS-1$
 			factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false); //$NON-NLS-1$
 			factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false); //$NON-NLS-1$
+			// enable secure processing:
+			factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
 		} catch (ParserConfigurationException e) {
 			throw new IllegalStateException(e.getMessage(), e);
 		}


### PR DESCRIPTION
The SAX branch in `XMLParsingServiceFactory.createService()` disables three
features but the DOM branch only disables two: `load-external-dtd` is missing.
Even with `external-general-entities`/`external-parameter-entities` off, a
`<!DOCTYPE root SYSTEM "http://attacker/x.dtd">` on input still causes the
DocumentBuilder returned from the system-published `DocumentBuilderFactory`
service to fetch that URL (SSRF / DTD-fetch via Xerces). Verified locally:
without the flag the parse throws `ConnectException` to the attacker host;
with it added the parse completes without any network attempt. Patch just
makes the DOM branch symmetric with the SAX branch right above it.