### PR TITLE
reject inverted byte range in ResourceServlet Range.isValid

### DIFF
--- a/bundles/org.eclipse.equinox.http.servlet.tests/src/org/eclipse/equinox/http/servlet/tests/ServletTest.java
+++ b/bundles/org.eclipse.equinox.http.servlet.tests/src/org/eclipse/equinox/http/servlet/tests/ServletTest.java
@@ -2005,6 +2005,34 @@ public class ServletTest extends BaseTest {
 	}
 
 	@Test
+	public void test_ResourceRangeRequest_InvalidRange() throws Exception {
+		Bundle bundle = installBundle(TEST_BUNDLE_2);
+		ServletContextHelper customSCH = new ServletContextHelper(bundle) {
+			@Override
+			public String getMimeType(String filename) {
+				if (filename.endsWith(".mp4")) { //$NON-NLS-1$
+					return "video/mp4"; //$NON-NLS-1$
+				}
+				return null;
+			}
+		};
+		Dictionary<String, Object> contextProps = new Hashtable<>();
+		contextProps.put(HttpWhiteboardConstants.HTTP_WHITEBOARD_CONTEXT_NAME, "foo");
+		contextProps.put(HttpWhiteboardConstants.HTTP_WHITEBOARD_CONTEXT_PATH, "/foo");
+		registrations.add(getBundleContext().registerService(ServletContextHelper.class, customSCH, contextProps));
+		Map<String, List<String>> actual;
+		Map<String, List<String>> requestHeader = new HashMap<>();
+		requestHeader.put("Range", Collections.singletonList("bytes=9999-1000"));
+		try {
+			bundle.start();
+			actual = requestAdvisor.request("foo/TestResource1/rangerequest.mp4", requestHeader);
+		} finally {
+			uninstallBundle(bundle);
+		}
+		assertEquals("Response Code", Collections.singletonList("416"), actual.get("responseCode"));
+	}
+
+	@Test
 	public void test_ResourceRangeRequest_WithRange() throws Exception {
 		Map<String, List<String>> actual;
 		Bundle bundle = installBundle(TEST_BUNDLE_2);

--- a/bundles/org.eclipse.equinox.http.servlet.tests/src/org/eclipse/equinox/http/servlet/tests/util/ServletRequestAdvisor.java
+++ b/bundles/org.eclipse.equinox.http.servlet.tests/src/org/eclipse/equinox/http/servlet/tests/util/ServletRequestAdvisor.java
@@ -228,6 +228,13 @@ public class ServletRequestAdvisor extends Object {
 			stream = connection.getInputStream();
 		}
 
+		// getErrorStream() is null when an error response carries no body, e.g. a
+		// bodyless 416, so guard against it before draining and closing.
+		if (stream == null) {
+			map.put("responseBody", Arrays.asList(""));
+			return map;
+		}
+
 		try {
 			String drainedStream = drain(stream);
 			map.put("responseBody", Arrays.asList(drainedStream));

--- a/bundles/org.eclipse.equinox.http.servlet/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.http.servlet/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.equinox.http.servlet
-Bundle-Version: 1.8.600.qualifier
+Bundle-Version: 1.8.700.qualifier
 Bundle-Activator: org.eclipse.equinox.http.servlet.internal.Activator
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/servlet/ResourceServlet.java
+++ b/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/servlet/ResourceServlet.java
@@ -315,6 +315,10 @@ public class ResourceServlet extends HttpServlet {
 				return false;
 			}
 
+			if (firstBytePos > lastBytePos) {
+				return false;
+			}
+
 			return true;
 		}
 


### PR DESCRIPTION
Fuzzing the Range header against the resource servlet turned up `bytes=9999-1000`: Range.isValid() only checks each position against the resource length, never that first-byte-pos <= last-byte-pos. An inverted range is accepted, so contentLength() goes negative and the reply is a 206 with a malformed `Content-Range: bytes 9999-1000/<len>` instead of a 416. RFC 7233 treats such a range as unsatisfiable, so reject it.