### PR TITLE
reserve room for nul terminator in checkPathList result buffer

### DIFF
--- a/features/org.eclipse.equinox.executable.feature/library/eclipseUtil.c
+++ b/features/org.eclipse.equinox.executable.feature/library/eclipseUtil.c
@@ -73,7 +73,7 @@ _TCHAR * checkPathList( _TCHAR* pathList, _TCHAR* programDir, int reverseOrder) 
 	_TCHAR * c1, *c2;
 	_TCHAR * checked, *result;
 	size_t checkedLength = 0, resultLength = 0;
-	size_t bufferLength = _tcslen(pathList);
+	size_t bufferLength = _tcslen(pathList) + 1;
 	
 	result = malloc(bufferLength * sizeof(_TCHAR));
 	c1 = pathList;

--- a/features/org.eclipse.equinox.executable.feature/library/eclipseUtil.c
+++ b/features/org.eclipse.equinox.executable.feature/library/eclipseUtil.c
@@ -105,7 +105,7 @@ _TCHAR * checkPathList( _TCHAR* pathList, _TCHAR* programDir, int reverseOrder) 
 	_TCHAR * c1, *c2;
 	_TCHAR * checked, *result;
 	size_t checkedLength = 0, resultLength = 0;
-	size_t bufferLength = _tcslen(pathList);
+	size_t bufferLength = _tcslen(pathList) + 1;
 	
 	result = malloc(bufferLength * sizeof(_TCHAR));
 	c1 = pathList;


### PR DESCRIPTION
Found this with ASan while exercising the launcher's .ee path-list handling. checkPathList sizes result as malloc(strlen(pathList)) but the recombined string also needs the trailing nul (plus the separators it reinserts), so a value like /a:/b writes one _TCHAR past the allocation. concatPaths just below already does length + 1; the same applies here.