### PR TITLE
reject path traversal in MultipartSupportPart.write

### DIFF
--- a/bundles/org.eclipse.equinox.http.servlet.tests/src/org/eclipse/equinox/http/servlet/tests/ServletTest.java
+++ b/bundles/org.eclipse.equinox.http.servlet.tests/src/org/eclipse/equinox/http/servlet/tests/ServletTest.java
@@ -2515,6 +2515,53 @@ public class ServletTest extends BaseTest {
 	}
 
 	@Test
+	public void test_Servlet16_fileupload_rejectPathTraversal() throws Exception {
+		Servlet servlet = new HttpServlet() {
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			protected void doPost(HttpServletRequest req, HttpServletResponse resp)
+					throws IOException, ServletException {
+
+				Part part = req.getPart("file");
+				Assert.assertNotNull(part);
+
+				File tempDir = (File) getServletContext().getAttribute(ServletContext.TEMPDIR);
+				// a name that climbs out of the configured multipart location
+				File escapee = new File(tempDir, "escaped-upload.txt");
+				escapee.delete();
+
+				PrintWriter writer = resp.getWriter();
+				try {
+					part.write("../../escaped-upload.txt");
+					writer.write("written");
+				} catch (IOException e) {
+					writer.write("rejected");
+				}
+				writer.write("|" + escapee.exists());
+			}
+		};
+
+		Dictionary<String, Object> props = new Hashtable<>();
+		props.put(HttpWhiteboardConstants.HTTP_WHITEBOARD_SERVLET_NAME, "S16");
+		props.put(HttpWhiteboardConstants.HTTP_WHITEBOARD_SERVLET_PATTERN, "/Servlet16/*");
+		props.put("equinox.http.multipartSupported", Boolean.TRUE);
+		props.put("equinox.http.whiteboard.servlet.multipart.location", "file-upload-test");
+		// force the item onto disk so a store location (and the containment check) exists
+		props.put("equinox.http.whiteboard.servlet.multipart.fileSizeThreshold", 10);
+		registrations.add(getBundleContext().registerService(Servlet.class, servlet, props));
+
+		Map<String, List<Object>> map = new HashMap<>();
+
+		map.put("file", Arrays.<Object>asList(getClass().getResource("resource1.txt")));
+
+		Map<String, List<String>> result = requestAdvisor.upload("Servlet16/do", map);
+
+		assertEquals("200", result.get("responseCode").get(0));
+		assertEquals("rejected|false", result.get("responseBody").get(0));
+	}
+
+	@Test
 	public void test_Servlet16_fileuploadWithLocationMaxFileSize() throws Exception {
 		Servlet servlet = new HttpServlet() {
 			private static final long serialVersionUID = 1L;

--- a/bundles/org.eclipse.equinox.http.servlet/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.http.servlet/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.equinox.http.servlet
-Bundle-Version: 1.8.600.qualifier
+Bundle-Version: 1.8.700.qualifier
 Bundle-Activator: org.eclipse.equinox.http.servlet.internal.Activator
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/multipart/MultipartSupportPart.java
+++ b/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/multipart/MultipartSupportPart.java
@@ -53,8 +53,22 @@ public class MultipartSupportPart implements Part {
 
 	@Override
 	public void write(String fileName) throws IOException {
+		File storeLocation = item.getStoreLocation();
+		File target = new File(storeLocation, fileName);
+		if (storeLocation != null) {
+			// keep the write inside the configured multipart storage area; a
+			// submitted file name may contain ".." segments
+			File root = storeLocation.getCanonicalFile().getParentFile();
+			String rootPath = (root == null) ? null : root.getCanonicalPath();
+			String targetPath = target.getCanonicalPath();
+			// require the target to be strictly under the storage area; the
+			// directory itself (e.g. a ".." name) is not a valid file target
+			if (rootPath == null || !targetPath.startsWith(rootPath + File.separator)) {
+				throw new IOException("Invalid file name: " + fileName); //$NON-NLS-1$
+			}
+		}
 		try {
-			item.write(new File(item.getStoreLocation(), fileName));
+			item.write(target);
 		} catch (Exception e) {
 			throw new IOException(e);
 		}

--- a/features/org.eclipse.equinox.server.jetty/feature.xml
+++ b/features/org.eclipse.equinox.server.jetty/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.equinox.server.jetty"
       label="%featureName"
-      version="1.11.1100.qualifier"
+      version="1.11.1200.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">


### PR DESCRIPTION
Found while fuzzing a servlet that does part.write(part.getSubmittedFileName()). The submitted file name is fully attacker controlled, and write() joined it onto the item store location with no containment check, so a name like ../../somedir/evil resolves outside the configured multipart storage area and lands wherever the process can write. Resolve the target and verify it stays under the store directory before writing.