### PR TITLE
escape message in built-in error page

### DIFF
--- a/bundles/org.eclipse.equinox.http.servlet/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.http.servlet/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.equinox.http.servlet
-Bundle-Version: 1.8.600.qualifier
+Bundle-Version: 1.8.700.qualifier
 Bundle-Activator: org.eclipse.equinox.http.servlet.internal.Activator
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/servlet/ResponseStateHandler.java
+++ b/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/servlet/ResponseStateHandler.java
@@ -128,7 +128,7 @@ public class ResponseStateHandler {
 				writer.print(httpStatus.description());
 				writer.println("</small></h1>"); //$NON-NLS-1$
 				writer.print("<p>"); //$NON-NLS-1$
-				writer.print(message);
+				writer.print(escapeHTML(message));
 				writer.println("</p></div></body></html>"); //$NON-NLS-1$
 			}
 
@@ -167,6 +167,14 @@ public class ResponseStateHandler {
 
 	public void setException(Exception exception) {
 		this.exception = exception;
+	}
+
+	private static String escapeHTML(String value) {
+		if (value == null) {
+			return null;
+		}
+		return value.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;") //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$
+				.replace("\"", "&quot;").replace("'", "&#x27;"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 	}
 
 	private List<ServletRequestListener> getServletRequestListener() {

--- a/features/org.eclipse.equinox.server.jetty/feature.xml
+++ b/features/org.eclipse.equinox.server.jetty/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.equinox.server.jetty"
       label="%featureName"
-      version="1.11.1100.qualifier"
+      version="1.11.1200.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">


### PR DESCRIPTION
The fallback error page in ResponseStateHandler writes the error message into the HTML body at ResponseStateHandler.java:131 without escaping, and that message carries the request URI (ResourceServlet/ProxyServlet pass "ProxyServlet: " + req.getRequestURI() to sendError). A request URI with markup is reflected unescaped, so escape it before writing.