### PR TITLE
size shared-memory id buffer for 64-bit handle on win64

### DIFF
--- a/features/org.eclipse.equinox.executable.feature/library/eclipseShm.c
+++ b/features/org.eclipse.equinox.executable.feature/library/eclipseShm.c
@@ -30,10 +30,12 @@ int createSharedData(_TCHAR** id, int size) {
 	HANDLE mapHandle = CreateFileMapping(INVALID_HANDLE_VALUE, NULL, PAGE_READWRITE, 0, size, NULL);
 	if (mapHandle == 0) return -1;
 	if (id != NULL) {
-		*id = malloc(18 * sizeof(_TCHAR));
 #ifdef WIN64
+		/* "%lx_%I64x" is up to 8 + 1 + 16 _TCHARs plus the terminating nul */
+		*id = malloc(26 * sizeof(_TCHAR));
 		_stprintf(*id, _T_ECLIPSE("%lx_%I64x"), GetCurrentProcessId(), (DWORDLONG) mapHandle);
 #else
+		*id = malloc(18 * sizeof(_TCHAR));
 		_stprintf(*id, _T_ECLIPSE("%lx_%lx"), GetCurrentProcessId(), (DWORD) mapHandle);
 #endif
 	}


### PR DESCRIPTION
On win64 createSharedData formats the shared-memory id with "%lx_%I64x" from the process id and the file-mapping HANDLE cast to DWORDLONG, which can reach 25 characters, but it only allocates 18 _TCHARs. A HANDLE value beyond ~0xFFFFFFFFFF makes _stprintf write past the buffer. Size the win64 allocation to 26 so the 64-bit handle form fits; the 32-bit "%lx_%lx" branch already fits in 18.