### PR TITLE
Add --launcher.GTK_version 4 support

### DIFF
--- a/bundles/org.eclipse.equinox.launcher.cocoa.macosx.aarch64/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.launcher.cocoa.macosx.aarch64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.equinox.launcher.cocoa.macosx.aarch64;singleton:=true
-Bundle-Version: 1.2.1500.qualifier
+Bundle-Version: 1.2.1600.qualifier
 Fragment-Host: org.eclipse.equinox.launcher;bundle-version="[1.7.0,1.8.0)"
 Eclipse-PlatformFilter: (& (osgi.ws=cocoa) (osgi.os=macosx) (osgi.arch=aarch64) )
 Bundle-Localization: launcher.cocoa.macosx.aarch64

--- a/bundles/org.eclipse.equinox.launcher.cocoa.macosx.x86_64/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.launcher.cocoa.macosx.x86_64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.equinox.launcher.cocoa.macosx.x86_64;singleton:=true
-Bundle-Version: 1.2.1500.qualifier
+Bundle-Version: 1.2.1600.qualifier
 Fragment-Host: org.eclipse.equinox.launcher;bundle-version="[1.7.0,1.8.0)"
 Eclipse-PlatformFilter: (& (osgi.ws=cocoa) (osgi.os=macosx) (osgi.arch=x86_64) )
 Bundle-Localization: launcher.cocoa.macosx.x86_64

--- a/bundles/org.eclipse.equinox.launcher.gtk.linux.aarch64/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.launcher.gtk.linux.aarch64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.equinox.launcher.gtk.linux.aarch64;singleton:=true
-Bundle-Version: 1.2.1500.qualifier
+Bundle-Version: 1.2.1600.qualifier
 Fragment-Host: org.eclipse.equinox.launcher;bundle-version="[1.7.0,1.8.0)"
 Eclipse-PlatformFilter: (& (osgi.ws=gtk) (osgi.os=linux) (osgi.arch=aarch64))
 Bundle-Localization: launcher.gtk.linux.aarch64

--- a/bundles/org.eclipse.equinox.launcher.gtk.linux.ppc64le/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.launcher.gtk.linux.ppc64le/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.equinox.launcher.gtk.linux.ppc64le;singleton:=true
-Bundle-Version: 1.2.1500.qualifier
+Bundle-Version: 1.2.1600.qualifier
 Fragment-Host: org.eclipse.equinox.launcher;bundle-version="[1.7.0,1.8.0)"
 Eclipse-PlatformFilter: (& (osgi.ws=gtk) (osgi.os=linux) (osgi.arch=ppc64le))
 Bundle-Localization: launcher.gtk.linux.ppc64le

--- a/bundles/org.eclipse.equinox.launcher.gtk.linux.riscv64/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.launcher.gtk.linux.riscv64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.equinox.launcher.gtk.linux.riscv64;singleton:=true
-Bundle-Version: 1.2.1500.qualifier
+Bundle-Version: 1.2.1600.qualifier
 Fragment-Host: org.eclipse.equinox.launcher;bundle-version="[1.7.0,1.8.0)"
 Eclipse-PlatformFilter: (& (osgi.ws=gtk) (osgi.os=linux) (osgi.arch=riscv64))
 Bundle-Localization: launcher.gtk.linux.riscv64

--- a/bundles/org.eclipse.equinox.launcher.gtk.linux.x86_64/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.launcher.gtk.linux.x86_64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.equinox.launcher.gtk.linux.x86_64;singleton:=true
-Bundle-Version: 1.2.1500.qualifier
+Bundle-Version: 1.2.1600.qualifier
 Fragment-Host: org.eclipse.equinox.launcher;bundle-version="[1.7.0,1.8.0)"
 Eclipse-PlatformFilter: (& (osgi.ws=gtk) (osgi.os=linux) (osgi.arch=x86_64))
 Bundle-Localization: launcher.gtk.linux.x86_64

--- a/bundles/org.eclipse.equinox.launcher.win32.win32.aarch64/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.launcher.win32.win32.aarch64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.equinox.launcher.win32.win32.aarch64;singleton:=true
-Bundle-Version: 1.3.0.qualifier
+Bundle-Version: 1.3.100.qualifier
 Fragment-Host: org.eclipse.equinox.launcher;bundle-version="[1.7.0,1.8.0)"
 Eclipse-PlatformFilter: (& (osgi.ws=win32) (osgi.os=win32) (osgi.arch=aarch64))
 Bundle-Localization: launcher.win32.win32.aarch64

--- a/bundles/org.eclipse.equinox.launcher.win32.win32.x86_64/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.launcher.win32.win32.x86_64/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.equinox.launcher.win32.win32.x86_64;singleton:=true
-Bundle-Version: 1.3.0.qualifier
+Bundle-Version: 1.3.100.qualifier
 Fragment-Host: org.eclipse.equinox.launcher;bundle-version="[1.7.0,1.8.0)"
 Eclipse-PlatformFilter: (& (osgi.ws=win32) (osgi.os=win32) (osgi.arch=x86_64))
 Bundle-Localization: launcher.win32.win32.x86_64

--- a/docs/_launcher/equinox_launcher.md
+++ b/docs/_launcher/equinox_launcher.md
@@ -63,6 +63,7 @@ The launcher accepts various command-line arguments to control its behavior:
 
 - `-nosplash`: Disables the splash screen
 - `-showlocation`: Shows the workspace location in the window title
+- `--launcher.GTK_version <version>`: Selects the GTK version on Linux. Supported values are `3` (default) and `4`; passing `4` starts Eclipse with GTK 4. Falls back to GTK 3 if the requested Gtk version is unavailable.
 
 ## Configuration Files
 

--- a/docs/_launcher/starting_eclipse_commandline.md
+++ b/docs/_launcher/starting_eclipse_commandline.md
@@ -69,6 +69,7 @@ Control the launcher behavior:
 | `-showlocation` | Show workspace in title | `-showlocation` |
 | `--launcher.defaultAction` | Default file action | `--launcher.defaultAction openFile` |
 | `--launcher.library` | Launcher library path | `--launcher.library plugins/...` |
+| `--launcher.GTK_version` | GTK version to use (Linux only): `3` or `4` | `--launcher.GTK_version 4` |
 
 ### VM Arguments
 
@@ -429,7 +430,10 @@ eclipse.exe > output.txt 2>&1
 ./eclipse -data ~/workspace -clean
 
 # Specify Java
-./eclipse -vm /usr/lib/jvm/java-17/bin/java
+./eclipse -vm /usr/lib/jvm/java-21/bin/java
+
+# Start with GTK 4 (defaults to GTK 3 when omitted)
+./eclipse --launcher.GTK_version 4
 
 # Background execution
 ./eclipse &
@@ -472,7 +476,7 @@ Or:
 Specify Java explicitly:
 
 ```bash
-eclipse -vm /path/to/java17/bin/java
+eclipse -vm /path/to/java21/bin/java
 ```
 
 ### Workspace Locked

--- a/features/org.eclipse.equinox.executable.feature/library/eclipse.c
+++ b/features/org.eclipse.equinox.executable.feature/library/eclipse.c
@@ -490,6 +490,14 @@ static int _run(int argc, _TCHAR* argv[], _TCHAR* vmArgs[])
 			errorMsg = malloc( (_tcslen(gtk2Msg) + _tcslen(officialName) + 10) * sizeof(_TCHAR) );
 			_stprintf( errorMsg, gtk2Msg, officialName );
 			_ftprintf(stderr, _T_ECLIPSE("%s:\n%s\n"), officialName, errorMsg);
+			free( errorMsg );
+			errorMsg = NULL;
+			/* GTK+ 2.x is no longer supported, continue using GTK+ 3.x. */
+			setenv("SWT_GTK4", "0", 1);
+		} else if (gtkVersion == 3) {
+			setenv("SWT_GTK4", "0", 1);
+		} else if (gtkVersion == 4) {
+			setenv("SWT_GTK4", "1", 1);
 		}
 	}
 


### PR DESCRIPTION
Gtk 4 port is in shape for broader testing, extending the GTK_version to support switching to 4.