### PR TITLE
Turn warnings into errors in native launcher code for Linux

### DIFF
--- a/features/org.eclipse.equinox.executable.feature/library/gtk/eclipseGtk.c
+++ b/features/org.eclipse.equinox.executable.feature/library/gtk/eclipseGtk.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -276,7 +276,7 @@ int showSplash( const char* featureImage ) {
 		if (dlerror() == NULL && func) {
 			shellHandle = (*func)();
 		} else {
-			printf(dlerror());
+			printf("%s\n", dlerror());
 		}
 	}
 	gtk.gtk_window_set_decorated((GtkWindow*)(shellHandle), FALSE);

--- a/features/org.eclipse.equinox.executable.feature/library/gtk/make_linux.mak
+++ b/features/org.eclipse.equinox.executable.feature/library/gtk/make_linux.mak
@@ -81,7 +81,8 @@ GTK_LIBS = \
  -DGIO_LIB="\"libgio-2.0.so.0\"" -DGLIB_LIB="\"libglib-2.0.so.0\""
 LFLAGS = ${M_ARCH} -shared -fpic -Wl,--export-dynamic 
 GTK_CFLAGS := $(shell pkg-config --cflags gtk+-3.0)
-CFLAGS = ${M_CFLAGS} ${M_ARCH} -g -s -Wall\
+CFLAGS = ${M_CFLAGS} ${M_ARCH} -g -s \
+	-Wall -Werror \
 	-fpic \
 	-DLINUX \
 	-DDEFAULT_OS="\"$(DEFAULT_OS)\"" \


### PR DESCRIPTION
And fix the only warning occurring only under Linux on RISCV because it has -Wformat-security enabled automatically.

Thanks to Alex for providing the fix for the warning.