### PR TITLE
[Win32] Add format for VS 2026 path to binaries build script

### DIFF
--- a/features/org.eclipse.equinox.executable.feature/library/win32/build.bat
+++ b/features/org.eclipse.equinox.executable.feature/library/win32/build.bat
@@ -121,7 +121,9 @@ rem Search for Microsoft Visual Studio and set up its C compiler.
 rem --------------------------
 rem Specify VisualStudio Edition: 'Community', 'Enterprise', 'Professional' etc.
 if "%MSVC_EDITION%"=="" set "MSVC_EDITION=auto"
-rem Specify VisualStudio Version: '2022', '2019' etc.
+@rem Specify VisualStudio Version:
+@rem Up to VisualStudio 2022 the version year is relevant for the installation path ('2022', '2019', '2017' etc.)
+@rem Starting with VisualStudio 2026, the internal version number is relevant ('18' for VS2026)
 if "%MSVC_VERSION%"=="" set "MSVC_VERSION=auto"
 
 rem Search for a usable Visual Studio
@@ -176,6 +178,7 @@ GOTO :EOF
 @rem %1 = path template with '$MSVC_VERSION$' and '$MSVC_EDITION$' tokens
 :FindVisualStudio
 	IF "%MSVC_VERSION%"=="auto" (
+		CALL :FindVisualStudio2 "%~1" "18"
 		CALL :FindVisualStudio2 "%~1" "2022"
 		CALL :FindVisualStudio2 "%~1" "2019"
 	) ELSE (


### PR DESCRIPTION
Visual Studio 2026 uses a new default path pattern containing the internal version number instead of the external version year. This change adapts the logic for searching the visual studio installation in the build script to match this Visual Studio 2026 path.

This prepares for the GHA runner update to using a new Windows Server image that contains Visual Studio 2026 by default, which already produced build failures for SWT:
- https://github.com/eclipse-platform/eclipse.platform.swt/pull/3380
