### PR TITLE
Remove temporarily preserved EquinoxBundle#getModuleClassLoader(boolean)

### DIFF
--- a/bundles/org.eclipse.osgi/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.osgi/META-INF/MANIFEST.MF
@@ -107,7 +107,7 @@ Bundle-Activator: org.eclipse.osgi.internal.framework.SystemBundleActivator
 Bundle-Description: %systemBundle
 Bundle-Copyright: %copyright
 Bundle-Vendor: %eclipse.org
-Bundle-Version: 3.24.200.qualifier
+Bundle-Version: 3.24.300.qualifier
 Bundle-Localization: systembundle
 Bundle-DocUrl: http://www.eclipse.org
 Eclipse-ExtensibleAPI: true

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/framework/EquinoxBundle.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/framework/EquinoxBundle.java
@@ -695,17 +695,6 @@ public class EquinoxBundle implements Bundle, BundleReference {
 		return new ResolvedModuleClassLoader(cl, report);
 	}
 
-	// This method is only preserved as a temporary workaround for consumers that
-	// reflectively access it until they are adapted, such as Jetty OSGi's
-	// DefaultBundleClassLoaderHelper
-	// (see https://github.com/jetty/jetty.project/pull/14086)
-	@Deprecated
-	protected ModuleClassLoader getModuleClassLoader(boolean unused) {
-		System.err.println(
-				"WARNING: Reflective call to EquinoxBundle#getModuleClassLoader(boolean) detected. This method will be removed soon."); //$NON-NLS-1$
-		return getModuleClassLoader().moduleClassLoader;
-	}
-
 	@Override
 	public Enumeration<URL> getResources(String name) throws IOException {
 		try {

--- a/bundles/org.eclipse.osgi/pom.xml
+++ b/bundles/org.eclipse.osgi/pom.xml
@@ -19,7 +19,7 @@
 </parent>
   <groupId>org.eclipse.platform</groupId>
   <artifactId>org.eclipse.osgi</artifactId>
-  <version>3.24.200-SNAPSHOT</version>
+  <version>3.24.300-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   <properties>
 	  <!-- The actual TCKs are executed in the org.eclipse.osgi.tck module because of reference to other service implementations -->


### PR DESCRIPTION
The private method `EquinoxBundle#getModuleClassLoader(boolean)` was replaced by a method with a different signature for the 2025-12 release. Some relevant consumers (at least Jetty OSGi's `DefaultBundleClassLoaderHelper`) reflectively accessed the replaced method. To avoid that compatibility of such consumers breaks, the replaced method was temporarily preserved for the 2025-12 release:
- https://github.com/eclipse-equinox/equinox/pull/1211

Jetty, as the known consumer of that method, was updated immediately after that:
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3546

The idea was to keep the temporary revert for some releases and then remove it again (https://github.com/eclipse-equinox/equinox/pull/1211#issuecomment-3617372252). Three releases seem to be sufficient time, so that I propose to remove the temporary revert for the 2026-09 release.

This change finally removes the replaced method by reverting commit 74e38821ef7ea257da027a00117c8484603702fb.