### PR TITLE
Remove unused values for unsupported OS and WS from launcher Constants

### DIFF
--- a/bundles/org.eclipse.equinox.launcher/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.launcher/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.launcher;singleton:=true
-Bundle-Version: 1.7.100.qualifier
+Bundle-Version: 1.7.200.qualifier
 Main-Class: org.eclipse.equinox.launcher.Main
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/bundles/org.eclipse.equinox.launcher/src/org/eclipse/equinox/launcher/Constants.java
+++ b/bundles/org.eclipse.equinox.launcher/src/org/eclipse/equinox/launcher/Constants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2024 IBM Corporation and others.
+ * Copyright (c) 2006, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -36,73 +36,10 @@ class Constants {
 	public static final String OS_LINUX = "linux";//$NON-NLS-1$
 
 	/**
-	 * Constant string (value "aix") indicating the platform is running on an
-	 * AIX-based operating system.
-	 *
-	 * @deprecated AIX support has been removed
-	 */
-	@Deprecated(forRemoval = true, since = "2025-12")
-	public static final String OS_AIX = "aix";//$NON-NLS-1$
-
-	/**
-	 * Constant string (value "solaris") indicating the platform is running on a
-	 * Solaris-based operating system.
-	 *
-	 * @deprecated Solaris support has been removed
-	 */
-	@Deprecated(forRemoval = true, since = "2025-12")
-	public static final String OS_SOLARIS = "solaris";//$NON-NLS-1$
-
-	/**
-	 * Constant string (value "hpux") indicating the platform is running on an
-	 * HP/UX-based operating system.
-	 *
-	 * @deprecated HP/UX support has been removed
-	 */
-	@Deprecated(forRemoval = true, since = "2025-12")
-	public static final String OS_HPUX = "hpux";//$NON-NLS-1$
-
-	/**
-	 * Constant string (value "qnx") indicating the platform is running on a
-	 * QNX-based operating system.
-	 *
-	 * @deprecated QNX support has been removed
-	 */
-	@Deprecated(forRemoval = true, since = "2025-12")
-	public static final String OS_QNX = "qnx";//$NON-NLS-1$
-
-	/**
 	 * Constant string (value "macosx") indicating the platform is running on a
 	 * Mac OS X operating system.
 	 */
 	public static final String OS_MACOSX = "macosx";//$NON-NLS-1$
-
-	/**
-	 * Constant string (value "os/400") indicating the platform is running on a
-	 * OS/400 operating system.
-	 *
-	 * @deprecated OS/400 support has been removed
-	 */
-	@Deprecated(forRemoval = true, since = "2025-12")
-	public static final String OS_OS400 = "os/400"; //$NON-NLS-1$
-
-	/**
-	 * Constant string (value "os/390") indicating the platform is running on a
-	 * OS/390 operating system.
-	 *
-	 * @deprecated OS/390 support has been removed
-	 */
-	@Deprecated(forRemoval = true, since = "2025-12")
-	public static final String OS_OS390 = "os/390"; //$NON-NLS-1$
-
-	/**
-	 * Constant string (value "z/os") indicating the platform is running on a
-	 * z/OS operating system.
-	 *
-	 * @deprecated z/OS support has been removed
-	 */
-	@Deprecated(forRemoval = true, since = "2025-12")
-	public static final String OS_ZOS = "z/os"; //$NON-NLS-1$
 
 	/**
 	 * Constant string (value "unknown") indicating the platform is running on a
@@ -121,15 +58,6 @@ class Constants {
 	 * machine using the GTK windowing system.
 	 */
 	public static final String WS_GTK = "gtk";//$NON-NLS-1$
-
-	/**
-	 * Constant string (value "photon") indicating the platform is running on a
-	 * machine using the Photon windowing system.
-	 *
-	 * @deprecated Photon windowing system support has been removed
-	 */
-	@Deprecated(forRemoval = true, since = "2025-12")
-	public static final String WS_PHOTON = "photon";//$NON-NLS-1$
 
 	/**
 	 * Constant string (value "cocoa") indicating the platform is running on a


### PR DESCRIPTION
All references to these constants were removed in
- https://github.com/eclipse-equinox/equinox/pull/1151

and they cannot be referenced outside the package.

@tjwatson I consider your thump-up on https://github.com/eclipse-equinox/equinox/pull/1151#issuecomment-4624920598, as agreement. 