### PR TITLE
Replace ant-contrib with ifunless standard ANT attributes

### DIFF
--- a/launcher-binary-parent/pom.xml
+++ b/launcher-binary-parent/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2012, 2024 Eclipse Foundation and others.
+  Copyright (c) 2012, 2026 Eclipse Foundation and others.
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
@@ -83,25 +83,23 @@
                   <goal>run</goal>
                 </goals>
                 <configuration>
-                  <target>
-                    <!-- See https://stackoverflow.com/a/53227117 and http://ant-contrib.sourceforge.net/tasks/tasks/index.html -->
-                    <taskdef resource="net/sf/antcontrib/antlib.xml"/>
-                    <if><equals arg1="${native}" arg2="${ws}.${os}.${arch}"/>
-                      <then>
-                        <property name="JAVA_HOME" value="${java.home}"/><!-- Not overwritten if already set, e.g. as CLI argument -->
-                        <if><equals arg1="${ws}" arg2="win32" />
-                          <then>
-                            <exec dir="${natives.source.dir}" executable="cmd" failonerror="true">
-                              <arg line="/c build.bat install -ws ${ws} -os ${os} -arch ${arch}"/>
-                            </exec>
-                          </then><else>
-                            <exec dir="${natives.source.dir}" executable="sh" failonerror="true">
-                              <arg line="build.sh install -ws ${ws} -os ${os} -arch ${arch}"/>
-                            </exec>
-                          </else>
-                        </if>
-                      </then>
-                    </if>
+                  <target xmlns:if="ant:if" xmlns:unless="ant:unless">
+                    <condition property="swt.build.natives">
+                      <equals arg1="${native}" arg2="${ws}.${os}.${arch}"/>
+                    </condition>
+                    <condition property="swt.build.natives.win32">
+                      <and>
+                        <isset property="swt.build.natives"/>
+                        <equals arg1="${ws}" arg2="win32"/>
+                      </and>
+                    </condition>
+                    <property name="JAVA_HOME" value="${java.home}"/><!-- Not overwritten if already set, e.g. as CLI argument -->
+                    <exec if:true="${swt.build.natives.win32}" dir="${natives.source.dir}" executable="cmd" failonerror="true">
+                      <arg line="/c build.bat install -ws ${ws} -os ${os} -arch ${arch}"/>
+                    </exec>
+                    <exec if:true="${swt.build.natives}" unless:true="${swt.build.natives.win32}" dir="${natives.source.dir}" executable="sh" failonerror="true">
+                      <arg line="build.sh install -ws ${ws} -os ${os} -arch ${arch}"/>
+                    </exec>
                   </target>
                 </configuration>
               </execution>
@@ -112,46 +110,26 @@
                   <goal>run</goal>
                 </goals>
                 <configuration>
-                  <target>
-                    <!-- See https://stackoverflow.com/a/53227117 and http://ant-contrib.sourceforge.net/tasks/tasks/index.html -->
-                    <taskdef resource="net/sf/antcontrib/antlib.xml"/>
-                    <if><equals arg1="${native}" arg2="${ws}.${os}.${arch}"/>
-                      <then>
-                        <if><equals arg1="${ws}" arg2="win32" />
-                          <then>
-                            <exec dir="${natives.source.dir}" executable="cmd">
-                              <arg line="/c build.bat clean"/>
-                            </exec>
-                          </then><else>
-                            <exec dir="${natives.source.dir}" executable="sh">
-                              <arg line="build.sh clean"/>
-                            </exec>
-                          </else>
-                        </if>
-                      </then>
-                    </if>
+                  <target xmlns:if="ant:if" xmlns:unless="ant:unless">
+                    <condition property="swt.build.natives">
+                      <equals arg1="${native}" arg2="${ws}.${os}.${arch}"/>
+                    </condition>
+                    <condition property="swt.build.natives.win32">
+                      <and>
+                        <isset property="swt.build.natives"/>
+                        <equals arg1="${ws}" arg2="win32"/>
+                      </and>
+                    </condition>
+                    <exec if:true="${swt.build.natives.win32}" dir="${natives.source.dir}" executable="cmd">
+                      <arg line="/c build.bat clean"/>
+                    </exec>
+                    <exec if:true="${swt.build.natives}" unless:true="${swt.build.natives.win32}" dir="${natives.source.dir}" executable="sh">
+                      <arg line="build.sh clean"/>
+                    </exec>
                   </target>
                 </configuration>
               </execution>
             </executions>
-            <dependencies>
-              <dependency>
-                <groupId>org.apache.ant</groupId>
-                <artifactId>ant</artifactId>
-                <version>1.10.15</version>
-              </dependency>
-              <dependency>
-                <groupId>ant-contrib</groupId>
-                <artifactId>ant-contrib</artifactId>
-                <version>1.0b3</version>
-                <exclusions>
-                  <exclusion>
-                    <groupId>ant</groupId>
-                    <artifactId>ant</artifactId>
-                  </exclusion>
-                </exclusions>
-              </dependency>
-            </dependencies>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
Ant 1.9.1 added https://ant.apache.org/manual/ifunless.html, which allows to replace all uses of `ant-contrib`.

Similar to
- https://github.com/eclipse-platform/eclipse.platform.swt/pull/3395