### PR TITLE
[Build] Fix executions of OSGi TCK test cases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,8 +114,8 @@ jobs:
         -Pbree-libs
         -Ptck
         -Dskip-default-modules=true
-        -Dtycho.resolver.classic=false
-        -fn
+        -Dmaven.test.failure.ignore
+        -fae
         clean verify
     - name: Upload TCK Results
       uses: actions/upload-artifact@v7

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -41,7 +41,7 @@ jobs:
           event_name:  ${{ github.event.workflow_run.event }}
           event_file:  artifacts/Event File/event.json
   tck-results:
-    name: TCK Test Results for ${{ matrix.tck.name }}
+    name: TCK Test Results for ${{ matrix.tck.label }}
     runs-on: ubuntu-latest
     if: github.event.workflow_run.conclusion != 'skipped'
     permissions:
@@ -80,7 +80,7 @@ jobs:
              unzip -d "$name" "$name.zip"
            done
 
-      - name: Parse TCK Results of ${{ matrix.tck.name }}
+      - name: Parse TCK Results of ${{ matrix.tck.label }}
         uses: EnricoMi/publish-unit-test-result-action@v2
         id: test-results
         if: always()
@@ -91,7 +91,7 @@ jobs:
           check_name:   ${{ matrix.tck.label }} TCK
           event_name:   ${{ github.event.workflow_run.event }}
           event_file:   artifacts/Event File/event.json
-      - name: Set badge color of ${{ matrix.tck.name }}
+      - name: Set badge color of ${{ matrix.tck.label }}
         shell: bash
         run: |
            case ${{ fromJSON( steps.test-results.outputs.json ).conclusion }} in
@@ -105,7 +105,7 @@ jobs:
            echo "BADGE_COLOR=696969" >> $GITHUB_ENV
            ;;
            esac
-      - name: Create badge of ${{ matrix.tck.name }}
+      - name: Create badge of ${{ matrix.tck.label }}
         uses: emibcn/badge-action@f9150fde070fcca0c4e832437611b44838fcd325
         with:
           # label: ${{ matrix.tck.chapter }} - ${{ matrix.tck.label }} ${{ matrix.tck.suffix }}
@@ -113,11 +113,10 @@ jobs:
           status: '${{ fromJSON( steps.test-results.outputs.json ).formatted.stats.tests_succ }} passed, ${{ fromJSON( steps.test-results.outputs.json ).formatted.stats.tests_fail }} failed'
           color: ${{ env.BADGE_COLOR }}
           path: tck-badge-${{ matrix.tck.name }}.svg
-      - name: Upload badge of ${{ matrix.tck.name }} to Gist
-        if: github.ref == 'refs/heads/master'
-        uses: andymckay/append-gist-action@ab30bf28df67017c7ad696500b218558c7c04db3
-        with:
-          token: ${{ secrets.GIST_TOKEN }}
-          gistURL: https://gist.github.com/eclipse-equinox-bot/d941fe2a4992a018d88e778b48ee3135
-          file: tck-badge-${{ matrix.tck.name }}.svg
-          
+      - name: Upload badge of ${{ matrix.tck.label }} to gist
+        if: github.event.workflow_run.head_branch == 'master'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GIST_TOKEN }}
+          GIST_ID: 'd941fe2a4992a018d88e778b48ee3135'
+        run: |
+          gh gist edit "${GIST_ID}" --add 'tck-badge-${{ matrix.tck.name }}.svg'

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,3 +1,2 @@
 -Pbuild-individual-bundles
 -Dtycho.localArtifacts=ignore
--Dcompare-version-with-baselines.skip=false

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -323,6 +323,7 @@ pipeline {
 					sh '''
 						mvn clean verify --batch-mode --fail-at-end -Dmaven.repo.local=$WORKSPACE/.m2/repository \
 							-Pbree-libs -Papi-check -Pjavadoc\
+							-Dcompare-version-with-baselines.skip=false \
 							-Dequinox.binaries.loc=$WORKSPACE/equinox.binaries
 					'''
 				}

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,6 @@
 		<id>tck</id>
 		<properties>
 			<!-- Might be overidden in build.properties -->
-			<tck.engine>org.junit.vintage.engine,junit-jupiter-engine</tck.engine>
 			<tck.tester>biz.aQute.tester.junit-platform</tck.tester>
 			<tck.security>false</tck.security>
 			<tck.skip>false</tck.skip>
@@ -84,7 +83,6 @@
 				<plugin>
 					<groupId>org.eclipse.tycho</groupId>
 					<artifactId>target-platform-configuration</artifactId>
-					<version>${tycho.version}</version>
 					<configuration>
 						<target>
 							<file>../../releng/tcks.target</file>
@@ -95,12 +93,49 @@
 							security feature for Java > 17
 						-->
 						<executionEnvironment>JavaSE-17</executionEnvironment>
+							<filters>
+								<filter>
+									<type>p2-installable-unit</type>
+									<id>junit-jupiter-api</id>
+									<versionRange>[6,7)</versionRange>
+									<removeAll />
+								</filter>
+								<filter>
+									<type>p2-installable-unit</type>
+									<id>junit-jupiter-engine</id>
+									<versionRange>[6,7)</versionRange>
+									<removeAll />
+								</filter>
+								<filter>
+									<type>p2-installable-unit</type>
+									<id>junit-platform-commons</id>
+									<versionRange>[6,7)</versionRange>
+									<removeAll />
+								</filter>
+								<filter>
+									<type>p2-installable-unit</type>
+									<id>junit-platform-engine</id>
+									<versionRange>[6,7)</versionRange>
+									<removeAll />
+								</filter>
+								<filter>
+									<type>p2-installable-unit</type>
+									<id>junit-platform-launcher</id>
+									<versionRange>[6,7)</versionRange>
+									<removeAll />
+								</filter>
+								<filter>
+									<type>p2-installable-unit</type>
+									<id>junit-vintage-engine</id>
+									<versionRange>[6,7)</versionRange>
+									<removeAll />
+								</filter>
+							</filters>
 					</configuration>
 				</plugin>
 				<plugin>
 					<groupId>org.eclipse.tycho</groupId>
 					<artifactId>tycho-surefire-plugin</artifactId>
-					<version>${tycho.version}</version>
 					<executions>
 						<execution>
 							<goals>
@@ -114,7 +149,6 @@
 								<useJDK>BREE</useJDK>
 								<skipTests>${tck.skip}</skipTests>
 								<tester>${tck.tester}</tester>
-								<engine>${tck.engine}</engine>
 								<trace>false</trace>
 								<testerTrace>false</testerTrace>
 								<printBundles>true</printBundles>
@@ -140,9 +174,6 @@
 							</configuration>
 						</execution>
 					</executions>
-					<configuration>
-						<tycho.test.packaging>disabled</tycho.test.packaging>
-					</configuration>
 				</plugin>
 			</plugins>
 		</build>


### PR DESCRIPTION
- Remove enabling the baseline comparison for all builds by default
It failed the build performed in preparation of the TCK execution because of missing version increments. For the TCK the repository is only cloned shallowly, which breaks the jgit timestamp provider and has the effect that the build-time is used as qualifier for all artifacts.
- Restrict test-runtime to include only JUnit-5 artifacts.
The biz.aQute.tester does not support JUnit-6 yet.
- Replace use of archived andymckay/append-gist-action for badge upload
It uses Node 20 which is deprecated
- Update badge gists only for TCK executions completed on the master
Previously the badges where also updated with PR results because due to
the setup, the uploading workflow has the master as direct context.
- Fail TCK build in case of errors, but ignore test-failures because they are handled by the specialized result collection.
- Remove some generally unused `tycho-surefire` parameters and apply general clean-ups
