### PR TITLE
Use local file URL in PlurlStreamHandlerFactoryTest

### DIFF
--- a/bundles/org.eclipse.osgi/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.osgi/META-INF/MANIFEST.MF
@@ -107,7 +107,7 @@ Bundle-Activator: org.eclipse.osgi.internal.framework.SystemBundleActivator
 Bundle-Description: %systemBundle
 Bundle-Copyright: %copyright
 Bundle-Vendor: %eclipse.org
-Bundle-Version: 3.24.300.qualifier
+Bundle-Version: 3.24.400.qualifier
 Bundle-Localization: systembundle
 Bundle-DocUrl: http://www.eclipse.org
 Eclipse-ExtensibleAPI: true

--- a/bundles/org.eclipse.osgi/container/src_test/org/eclipse/equinox/plurl/test/PlurlStreamHandlerFactoryTest.java
+++ b/bundles/org.eclipse.osgi/container/src_test/org/eclipse/equinox/plurl/test/PlurlStreamHandlerFactoryTest.java
@@ -273,9 +273,9 @@ public class PlurlStreamHandlerFactoryTest
 
 		PlurlTestHandlers.TestURLStreamHandlerFactory catchAll = new PlurlTestHandlers.CatchAllPlurlFactory("jar");
 		plurlTestHandlers.add(TestFactoryType.PLURL_FACTORY, catchAll);
-		checkURL("jar:file://path/to/some.jar!/some/file.txt", false);
+		checkURL("jar:file:/path/to/some.jar!/some/file.txt", false);
 		plurlTestHandlers.remove(TestFactoryType.PLURL_FACTORY, catchAll);
-		checkBuiltinProtocol("jar:file://path/to/some.jar!/some/file.txt");
+		checkBuiltinProtocol("jar:file:/path/to/some.jar!/some/file.txt");
 	}
 
 	private void checkBuiltinProtocol(String spec) throws IOException {

--- a/bundles/org.eclipse.osgi/pom.xml
+++ b/bundles/org.eclipse.osgi/pom.xml
@@ -19,7 +19,7 @@
 </parent>
   <groupId>org.eclipse.platform</groupId>
   <artifactId>org.eclipse.osgi</artifactId>
-  <version>3.24.300-SNAPSHOT</version>
+  <version>3.24.400-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   <properties>
 	  <!-- The actual TCKs are executed in the org.eclipse.osgi.tck module because of reference to other service implementations -->


### PR DESCRIPTION
`testBuiltinURLHandlers` opens `jar:file://path/to/some.jar!/some/file.txt`. The two slashes make `path` a host, so this is a non-local file URL. JDK 25.0.3 no longer falls back to FTP for those, and `openConnection()` fails with:

```
java.net.MalformedURLException: Unsupported non-local file URL
  at sun.net.www.protocol.file.FileURLConnection.requireFtpFallbackEnabled
```

Use a single slash, which is the local file URL the test intended and works on old and new JDKs.