### PR TITLE
Add State.getExportedPackages(String) to query exports by package name

### DIFF
--- a/bundles/org.eclipse.osgi.compatibility.state/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.osgi.compatibility.state/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.osgi.compatibility.state
-Bundle-Version: 1.3.0.qualifier
+Bundle-Version: 1.3.100.qualifier
 ExtensionBundle-Activator: org.eclipse.osgi.compatibility.state.Activator
 Fragment-Host: org.eclipse.osgi;bundle-version="3.12.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/bundles/org.eclipse.osgi.compatibility.state/src/org/eclipse/osgi/compatibility/state/ReadOnlyState.java
+++ b/bundles/org.eclipse.osgi.compatibility.state/src/org/eclipse/osgi/compatibility/state/ReadOnlyState.java
@@ -75,6 +75,11 @@ public final class ReadOnlyState implements State {
 	}
 
 	@Override
+	public ExportPackageDescription[] getExportedPackages(String packageName) {
+		return platformAdmin.getSystemState().getExportedPackages(packageName);
+	}
+
+	@Override
 	public StateObjectFactory getFactory() {
 		return platformAdmin.getSystemState().getFactory();
 	}

--- a/bundles/org.eclipse.osgi.compatibility.state/src/org/eclipse/osgi/internal/resolver/StateImpl.java
+++ b/bundles/org.eclipse.osgi.compatibility.state/src/org/eclipse/osgi/internal/resolver/StateImpl.java
@@ -837,6 +837,31 @@ public abstract class StateImpl implements State {
 		}
 	}
 
+	@Override
+	public ExportPackageDescription[] getExportedPackages(String packageName) {
+		fullyLoad();
+		synchronized (this.monitor) {
+			List<ExportPackageDescription> result = new ArrayList<>();
+			addSelectedExports(resolvedBundles.values(), packageName, result);
+			addSelectedExports(removalPendings, packageName, result);
+			return result.toArray(new ExportPackageDescription[result.size()]);
+		}
+	}
+
+	private static void addSelectedExports(Collection<BundleDescription> bundles, String packageName, List<ExportPackageDescription> result) {
+		for (BundleDescription bundle : bundles) {
+			ExportPackageDescription[] bundlePackages = bundle.getSelectedExports();
+			if (bundlePackages == null) {
+				continue;
+			}
+			for (ExportPackageDescription export : bundlePackages) {
+				if (export.getName().equals(packageName)) {
+					result.add(export);
+				}
+			}
+		}
+	}
+
 	private static final Comparator<BundleDescription> BY_BUNDLE_ID = Comparator.comparingLong(BundleDescription::getBundleId);
 
 	BundleDescription[] getFragments(final BundleDescription host) {

--- a/bundles/org.eclipse.osgi.tests/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.osgi.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Core OSGi Tests
 Bundle-SymbolicName: org.eclipse.osgi.tests;singleton:=true
-Bundle-Version: 3.22.600.qualifier
+Bundle-Version: 3.22.700.qualifier
 Bundle-Vendor: Eclipse.org
 Require-Bundle: 
  org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",

--- a/bundles/org.eclipse.osgi.tests/pom.xml
+++ b/bundles/org.eclipse.osgi.tests/pom.xml
@@ -19,7 +19,7 @@
   </parent>
   <groupId>org.eclipse.platform</groupId>
   <artifactId>org.eclipse.osgi.tests</artifactId>
-  <version>3.22.600-SNAPSHOT</version>
+  <version>3.22.700-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <properties>

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/services/resolver/StateResolverTest.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/services/resolver/StateResolverTest.java
@@ -132,6 +132,16 @@ public class StateResolverTest extends AbstractStateTest {
 	}
 
 	@Test
+	public void testGetExportedPackagesByName() throws BundleException {
+		State state = buildSimpleState();
+		state.resolve();
+		ExportPackageDescription[] p1 = state.getExportedPackages("org.eclipse.p1"); //$NON-NLS-1$
+		assertEquals("1.0", 1, p1.length); //$NON-NLS-1$
+		assertEquals("1.1", state.getBundle(1), p1[0].getExporter()); //$NON-NLS-1$
+		assertEquals("2.0", 0, state.getExportedPackages("org.eclipse.p3").length); //$NON-NLS-1$
+	}
+
+	@Test
 	public void testBasicResolution() throws BundleException {
 		State state = buildSimpleState();
 		StateDelta delta = state.resolve();

--- a/bundles/org.eclipse.osgi/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.osgi/META-INF/MANIFEST.MF
@@ -42,7 +42,7 @@ Export-Package: org.eclipse.core.runtime.adaptor;x-friends:="org.eclipse.core.ru
  org.eclipse.osgi.service.environment;version="1.4",
  org.eclipse.osgi.service.localization;version="1.1";uses:="org.osgi.framework",
  org.eclipse.osgi.service.pluginconversion;version="1.0",
- org.eclipse.osgi.service.resolver;version="1.7.0";uses:="org.osgi.framework,org.osgi.framework.hooks.resolver,org.osgi.framework.wiring",
+ org.eclipse.osgi.service.resolver;version="1.8.0";uses:="org.osgi.framework,org.osgi.framework.hooks.resolver,org.osgi.framework.wiring",
  org.eclipse.osgi.service.runnable;version="1.1",
  org.eclipse.osgi.service.security;version="1.0",
  org.eclipse.osgi.service.urlconversion;version="1.0",
@@ -107,7 +107,7 @@ Bundle-Activator: org.eclipse.osgi.internal.framework.SystemBundleActivator
 Bundle-Description: %systemBundle
 Bundle-Copyright: %copyright
 Bundle-Vendor: %eclipse.org
-Bundle-Version: 3.24.400.qualifier
+Bundle-Version: 3.25.0.qualifier
 Bundle-Localization: systembundle
 Bundle-DocUrl: http://www.eclipse.org
 Eclipse-ExtensibleAPI: true

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/service/resolver/State.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/service/resolver/State.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.osgi.service.resolver;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Dictionary;
 import java.util.List;
@@ -490,6 +491,24 @@ public interface State {
 	 * @see org.osgi.service.packageadmin.PackageAdmin#getExportedPackages(org.osgi.framework.Bundle)
 	 */
 	public ExportPackageDescription[] getExportedPackages();
+
+	/**
+	 * Returns the exported packages in this state with the given package name,
+	 * according to the OSGi rules for resolution.
+	 *
+	 * @param packageName name of the packages to query
+	 * @return the exported packages with the given name, never <code>null</code>
+	 * @since 3.25
+	 */
+	public default ExportPackageDescription[] getExportedPackages(String packageName) {
+		List<ExportPackageDescription> result = new ArrayList<>();
+		for (ExportPackageDescription export : getExportedPackages()) {
+			if (export.getName().equals(packageName)) {
+				result.add(export);
+			}
+		}
+		return result.toArray(new ExportPackageDescription[0]);
+	}
 
 	/**
 	 * Returns all bundle descriptions with the given bundle symbolic name.

--- a/bundles/org.eclipse.osgi/pom.xml
+++ b/bundles/org.eclipse.osgi/pom.xml
@@ -19,7 +19,7 @@
 </parent>
   <groupId>org.eclipse.platform</groupId>
   <artifactId>org.eclipse.osgi</artifactId>
-  <version>3.24.400-SNAPSHOT</version>
+  <version>3.25.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   <properties>
 	  <!-- The actual TCKs are executed in the org.eclipse.osgi.tck module because of reference to other service implementations -->


### PR DESCRIPTION
State.getExportedPackages() copies every selected export of every resolved bundle into a new array on each call. PDE's manifest editor calls it once per Import-Package row on the UI thread only to check whether a single package is exported, which on an SDK sized target with 731 bundles copies about 3200 exports per row (see eclipse-pde/eclipse.pde#2444).

This adds a name-filtered getExportedPackages(String packageName). It is a default method on State that filters the full array, so external implementors keep compiling. StateImpl overrides it to walk the resolved bundles and removal pendings once under the state monitor and collect only matching exports, and ReadOnlyState delegates to the system state. Package org.eclipse.osgi.service.resolver goes to 1.8.0 and org.eclipse.osgi to 3.25.0.