### PR TITLE
Use the StateObjectFactory.defaultFactory in platform admin

### DIFF
--- a/bundles/org.eclipse.osgi.compatibility.state/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.osgi.compatibility.state/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.osgi.compatibility.state
-Bundle-Version: 1.3.0.qualifier
+Bundle-Version: 1.3.100.qualifier
 ExtensionBundle-Activator: org.eclipse.osgi.compatibility.state.Activator
 Fragment-Host: org.eclipse.osgi;bundle-version="3.12.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/bundles/org.eclipse.osgi.compatibility.state/src/org/eclipse/osgi/compatibility/state/PlatformAdminImpl.java
+++ b/bundles/org.eclipse.osgi.compatibility.state/src/org/eclipse/osgi/compatibility/state/PlatformAdminImpl.java
@@ -25,7 +25,6 @@ import org.eclipse.osgi.internal.framework.BundleContextImpl;
 import org.eclipse.osgi.internal.framework.EquinoxContainer;
 import org.eclipse.osgi.internal.module.ResolverImpl;
 import org.eclipse.osgi.internal.resolver.StateHelperImpl;
-import org.eclipse.osgi.internal.resolver.StateObjectFactoryImpl;
 import org.eclipse.osgi.service.resolver.BundleDescription;
 import org.eclipse.osgi.service.resolver.DisabledInfo;
 import org.eclipse.osgi.service.resolver.PlatformAdmin;
@@ -37,7 +36,7 @@ import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceRegistration;
 
 public class PlatformAdminImpl implements PlatformAdmin {
-	private final StateObjectFactory factory = new StateObjectFactoryImpl();
+	private final StateObjectFactory factory = StateObjectFactory.defaultFactory;
 	private final Object monitor = new Object();
 	private EquinoxContainer equinoxContainer;
 	private BundleContext bc;


### PR DESCRIPTION
Currently it creates an own instance but the `StateObjectFactory` itself is state-less and matches what the default factory actually is. To avoid having lingering around different instances where one is accessible only through the `PlatformAdmin` (what is only available through the compatibility fragment) this now also uses the default.

See for example 
- https://github.com/eclipse-equinox/p2/pull/1124

that can avoid referencing `PlatformAdmin` all together then as it only wants to access a limited set of the (legacy) state API.