### PR TITLE
Disable jdk=BREE for org.eclipse.osgi

### DIFF
--- a/bundles/org.eclipse.osgi/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.osgi/META-INF/MANIFEST.MF
@@ -107,7 +107,7 @@ Bundle-Activator: org.eclipse.osgi.internal.framework.SystemBundleActivator
 Bundle-Description: %systemBundle
 Bundle-Copyright: %copyright
 Bundle-Vendor: %eclipse.org
-Bundle-Version: 3.24.400.qualifier
+Bundle-Version: 3.24.500.qualifier
 Bundle-Localization: systembundle
 Bundle-DocUrl: http://www.eclipse.org
 Eclipse-ExtensibleAPI: true

--- a/bundles/org.eclipse.osgi/pom.xml
+++ b/bundles/org.eclipse.osgi/pom.xml
@@ -19,12 +19,14 @@
 </parent>
   <groupId>org.eclipse.platform</groupId>
   <artifactId>org.eclipse.osgi</artifactId>
-  <version>3.24.400-SNAPSHOT</version>
+  <version>3.24.500-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   <properties>
 	  <!-- The actual TCKs are executed in the org.eclipse.osgi.tck module because of reference to other service implementations -->
 	  <tck.skip>true</tck.skip>
 	  <failOnJavadocErrors>false</failOnJavadocErrors>
+	  <!-- This ensures we use the -release 8 for compilation to ensure only java 8 API is used -->
+	  <tycho.useJDK>SYSTEM</tycho.useJDK>
   </properties>
   
   <build>


### PR DESCRIPTION
Currently `org.eclipse.osgi` has no (deprecated) EE header and therefore `jdk=BREE` has silently fall back to the target platform EE. Since this was recently changed to Java 25 this suddenly pulled in unwanted API due to https://github.com/eclipse-jdt/eclipse.jdt.core/issues/5389 and failed to start on JDKs < 21.

Due to a bug in Tycho https://github.com/eclipse-tycho/tycho/pull/6314 it was not discovered that effectively `jdk=BREE` was not effective at all for a long time. so this now explicitly uses `jdk=SYSTEM` to ensure the -release flag is used instead consistently.

Fix https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/4038